### PR TITLE
Added Gitter badge, alt text for all badges to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,15 +9,23 @@ the MIT license.
 
 .. image:: http://i.imgur.com/wFvLZyJ.png
     :target: https://travis-ci.org/explosion/spaCy
-
+    :alt: spaCy on Travis CI
+    
 .. image:: https://travis-ci.org/explosion/spaCy.svg?branch=master
     :target: https://travis-ci.org/explosion/spaCy
+    :alt: Build Status
     
 .. image:: https://img.shields.io/github/tag/explosion/spacy.svg
     :target: https://github.com/explosion/spaCy/releases   
-
+    :alt: Current Release Version
+    
 .. image:: https://img.shields.io/pypi/v/spacy.svg   
     :target: https://pypi.python.org/pypi/spacy
+    :alt: pypi Version
+
+.. image:: https://badges.gitter.im/spaCy-users.png
+    :target: https://gitter.im/spaCy-users/Lobby
+    :alt: spaCy on Gitter
 
 Where to ask questions
 ======================


### PR DESCRIPTION
Out of curiosity, I wonder if there's any sort of preferred grammar for alt text when it comes to accessibility.

Like, would someone using a screen reader prefer "Our Gitter chat room" or "Click here for our Gitter" over "spaCy on Gitter"?

Just a random thought.

Possibly fixes #487 (though may make sense to open a separate issue for connecting Gitter to Slack/IRC, if so)