### PR TITLE
Fixed train_ner examples when model_dir isn't None

### DIFF
--- a/examples/training/train_ner.py
+++ b/examples/training/train_ner.py
@@ -22,10 +22,10 @@ def train_ner(nlp, train_data, entity_types):
 
 def main(model_dir=None):
     if model_dir is not None:
-        model_dir = pathlb.Path(model_dir)
+        model_dir = pathlib.Path(model_dir)
         if not model_dir.exists():
             model_dir.mkdir()
-        assert model_dir.isdir()
+        assert model_dir.is_dir()
 
     nlp = spacy.load('en', parser=False, entity=False, vectors=False)
 
@@ -49,7 +49,7 @@ def main(model_dir=None):
         print(word.text, word.tag_, word.ent_type_, word.ent_iob)
 
     if model_dir is not None:
-        with (model_dir / 'config.json').open('wb') as file_:
+        with (model_dir / 'config.json').open('w') as file_:
             json.dump(ner.cfg, file_)
         ner.model.dump(str(model_dir / 'model'))
 


### PR DESCRIPTION
While trying out the save functionality of `train_ner.py` in the `examples` folder, it had some runtime errors. Just thought I'd fix those typos to aid anyone trying out the examples.

- [x] `pathlb` -> `pathlib`
- [x] `isdir()` -> `is_dir()`
- [x] `'wb'` (write binary) -> `'w'` (write) (Can't write JSON to binary file)