### PR TITLE
updated training examples to v1.1.2

### DIFF
--- a/examples/training/train_ner.py
+++ b/examples/training/train_ner.py
@@ -27,7 +27,7 @@ def main(model_dir=None):
             model_dir.mkdir()
         assert model_dir.is_dir()
 
-    nlp = spacy.load('en', parser=False, entity=False, vectors=False)
+    nlp = spacy.load('en', parser=False, entity=False, add_vectors=False)
 
     train_data = [
         (

--- a/examples/training/train_parser.py
+++ b/examples/training/train_parser.py
@@ -32,7 +32,7 @@ def main(model_dir=None):
             model_dir.mkdir()
         assert model_dir.is_dir()
 
-    nlp = spacy.load('en', tagger=False, parser=False, entity=False, vectors=False)
+    nlp = spacy.load('en', tagger=False, parser=False, entity=False, add_vectors=False)
 
     train_data = [
         (


### PR DESCRIPTION
On spaCy v1.1.2 the `vector` parameter is changed to `add_vector`. I've updated the examples to reflect spaCy v1.1.2.

[x] - `vectors` -> `add_vectors`