### PR TITLE
Fix PhraseMatcher to work with new Matcher

### DIFF
--- a/spacy/tests/test_matcher.py
+++ b/spacy/tests/test_matcher.py
@@ -87,6 +87,13 @@ def test_match_zero_plus(matcher):
     assert len(matcher(doc)) == 1
 
 
+def test_phrase_matcher():
+    vocab = Vocab(lex_attr_getters=English.Defaults.lex_attr_getters)
+    matcher = PhraseMatcher(vocab, [Doc(vocab, words='Google Now'.split())])
+    doc = Doc(vocab, words=['I', 'like', 'Google', 'Now', 'best'])
+    assert len(matcher(doc)) == 1
+
+
 #@pytest.mark.models
 #def test_match_preserved(EN):
 #    patterns = {


### PR DESCRIPTION
## Motivation and Context
https://github.com/explosion/spaCy/issues/613

## How Has This Been Tested?
PhraseMatcher wasn't tested at all, I've added a basic test for it.

## Types of changes
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality to spaCy)
- [ ] Breaking change (fix or feature causing change to spaCy's existing functionality)
- [ ] Documentation (Addition to documentation of spaCy)

## Checklist:
- [x] My code follows spaCy's code style. (it's [coming soon](https://github.com/explosion/spaCy/blob/master/CONTRIBUTING.md#conventions-for-cython) though)
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

P.S. Would be cool to have `test` script using makefile or something to easily run them. I had to look into travis scripts to learn how to do it.