### PR TITLE
Missing import statement for spacy.matcher.Matcher

### DIFF
--- a/website/docs/usage/rule-based-matching.jade
+++ b/website/docs/usage/rule-based-matching.jade
@@ -21,6 +21,7 @@ p
     |  callable, to receive a list of #[code (ent_id, start, end)] tuples:
 
 +code.
+    from spacy.matcher import Matcher
     matcher = Matcher(nlp.vocab)
     matcher.add_pattern("HelloWorld", [{LOWER: "hello"}, {IS_PUNCT: True}, {LOWER: "world"}])
 


### PR DESCRIPTION

## Description
I've added an import statement at the top of the `Matcher` example.

## Motivation and Context
First-time users and lazy people like me don't know how to import it. The `spacy.matcher` package is not listed in the autocomplete of PyCharm (not sure about other IDEs), so one either has to remember or look it up in the code or other examples.