### PR TITLE
Fixed bug: eg.guess is a tag id, rather than a tag

### DIFF
--- a/spacy/tagger.pyx
+++ b/spacy/tagger.pyx
@@ -250,7 +250,7 @@ cdef class Tagger:
                 eg.c.features, eg.c.nr_feat)
             self.model.updateC(&eg.c)
 
-            self.vocab.morphology.assign_tag(&tokens.c[i], eg.guess)
+            self.vocab.morphology.assign_tag_id(&tokens.c[i], eg.guess)
             
             correct += eg.cost == 0
             self.freqs[TAG][tokens.c[i].tag] += 1


### PR DESCRIPTION
I found this bug when I tried to run `examples/training/train_tagger.py`. I got exceptions like this:

```
Traceback (most recent call last):
  File "../train_tagger.py", line 78, in <module>
    plac.call(main)
  File "/usr/local/lib/python3.5/site-packages/plac_core.py", line 326, in call
    cmd, result = parser_from(obj).consume(arglist)
  File "/usr/local/lib/python3.5/site-packages/plac_core.py", line 209, in consume
    return cmd, self.func(*(args + varargs + extraopts), **kwargs)
  File "../train_tagger.py", line 64, in main
    tagger.update(doc, gold)
  File "spacy/tagger.pyx", line 255, in spacy.tagger.Tagger.update (spacy/tagger.cpp:6857)
    self.vocab.morphology.assign_tag(&tokens.c[i], eg.guess)
  File "spacy/morphology.pyx", line 42, in spacy.morphology.Morphology.assign_tag (spacy/morphology.cpp:3995)
    tag_id = self.reverse_index[tag]
KeyError: 0
```

It turned out that the parameter passed to `assign_tag` is a tag id, rather than a tag.