### PR TITLE
[DOCS] Typo

### DIFF
--- a/website/docs/usage/dependency-parse.jade
+++ b/website/docs/usage/dependency-parse.jade
@@ -155,7 +155,7 @@ p
 
 p
     |  If you need to load the parser, but need to disable it for specific
-    |  documents, you can control its use with the #[code parser] keyword
+    |  documents, you can control its use with the #[code parse] keyword
     |  argument:
 
 +code.


### PR DESCRIPTION
Small typo in dependency parser workflow guide