### PR TITLE
Add cythonize.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ data/en/strings
 _build/
 .env/
 tmp/
+cythonize.json
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
I noticed this had been generated for me after installing from the local repo with pip using `sudo pip3 install -e .` from within the spaCy folder. I figure it should be ignored.