### PR TITLE
Fix a bunch of missing spaces of the website

### DIFF
--- a/website/docs/api/doc.jade
+++ b/website/docs/api/doc.jade
@@ -164,8 +164,8 @@ p
         +cell #[code other]
         +cell -
         +cell
-            | The object to compare with. By default, accepts #[code Doc],
-            | #[code Span], #[code Token] and #[code Lexeme] objects.
+            |  The object to compare with. By default, accepts #[code Doc],
+            |  #[code Span], #[code Token] and #[code Lexeme] objects.
 
     +footrow
         +cell return

--- a/website/docs/api/span.jade
+++ b/website/docs/api/span.jade
@@ -156,8 +156,8 @@ p
         +cell #[code other]
         +cell -
         +cell
-            | The object to compare with. By default, accepts #[code Doc],
-            | #[code Span], #[code Token] and #[code Lexeme] objects.
+            |  The object to compare with. By default, accepts #[code Doc],
+            |  #[code Span], #[code Token] and #[code Lexeme] objects.
 
     +footrow
         +cell return

--- a/website/docs/api/vocab.jade
+++ b/website/docs/api/vocab.jade
@@ -70,8 +70,8 @@ p Create the vocabulary.
         +cell #[code lex_attr_getters]
         +cell dict
         +cell
-            | A dictionary mapping attribute IDs to functions to compute them.
-            | Defaults to #[code None].
+            |  A dictionary mapping attribute IDs to functions to compute them.
+            |  Defaults to #[code None].
 
     +row
         +cell #[code lemmatizer]

--- a/website/docs/usage/processing-text.jade
+++ b/website/docs/usage/processing-text.jade
@@ -73,7 +73,7 @@ p
     |  one-by-one. After a long and bitter struggle, the global interpreter
     |  lock was freed around spaCy's main parsing loop in v0.100.3. This means
     |  that the #[code .pipe()] method will be significantly faster in most
-    | practical situations, because it allows shared memory parallelism.
+    |  practical situations, because it allows shared memory parallelism.
 
 +code.
     for doc in nlp.pipe(texts, batch_size=10000, n_threads=3):


### PR DESCRIPTION
Having never touched Jade before, I ran into this annoying syntax trap while writing https://github.com/explosion/spaCy/pull/642/commits/a0c4b29dcbacfa784e7522653e18ca6c78084419 and immediately wondered if there was anywhere in the existing codebase where it had already been screwed up. Sure enough, a regex search in Sublime for `\| [^ ]` turned up these 4 locations, all of which are currently rendered with a missing space on the website (although it's not too noticeable in the cases where there's a code block on either side of a comma).