### PR TITLE
Ignore entire data folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,10 +29,7 @@ spacy/orthography/*.cpp
 ext/murmurhash.cpp
 ext/sparsehash.cpp
 
-data/en/pos
-data/en/ner
-data/en/lexemes
-data/en/strings
+/spacy/data/
 
 _build/
 .env/


### PR DESCRIPTION
Previously only some of its content was ignored, so running `python -m spacy.en.download all` after installing from a local repo would create unstaged changes.