### PR TITLE
docs: fix "installaton" typo

### DIFF
--- a/website/docs/usage/index.jade
+++ b/website/docs/usage/index.jade
@@ -7,7 +7,7 @@ p
     |  runs on #[strong Unix/Linux], #[strong macOS/OS X] and
     |  #[strong Windows]. The latest spaCy releases are currently only
     |  available as source packages over
-    |  #[+a("https://pypi.python.org/pypi/spacy") pip]. Installaton requires a
+    |  #[+a("https://pypi.python.org/pypi/spacy") pip]. Installation requires a
     |  working build environment. See notes on
     |  #[a(href="#source-ubuntu") Ubuntu], #[a(href="#source-osx") macOS/OS X]
     |  and #[a(href="#source-windows") Windows] for details.

--- a/website/docs/usage/processing-text.jade
+++ b/website/docs/usage/processing-text.jade
@@ -31,7 +31,8 @@ p
 p
     |  I've tried to make sure that the #[code Language.__call__] function
     |  doesn't do any "heavy lifting", so that you won't have complicated logic
-    |  to replicate if you need to make your own pipeline class. This is all it |  does.
+    |  to replicate if you need to make your own pipeline class. This is all it
+    |  does.
 
 p
     |  The #[code .make_doc()] method and #[code .pipeline] attribute make it


### PR DESCRIPTION
## Description

There is a typo in the Getting Started guide; this PR fixes it.

## Motivation and Context

This change is required because there is a typo in the Getting Started guide. The problem it solves is that typo.

## How Has This Been Tested?

This change has not been tested, but it is hard to see how adding a single letter to the docs could cause problems!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality to spaCy)
- [ ] Breaking change (fix or feature causing change to spaCy's existing functionality)
- [x] Documentation (Addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [x ] My code follows spaCy's code style.
- [x] My change requires a change to spaCy's documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
