### PR TITLE
Add noun_chunks to Span

### DIFF
--- a/spacy/syntax/iterators.pyx
+++ b/spacy/syntax/iterators.pyx
@@ -1,13 +1,14 @@
 from spacy.parts_of_speech cimport NOUN, PROPN, PRON
 
 
-def english_noun_chunks(doc):
+def english_noun_chunks(obj):
     labels = ['nsubj', 'dobj', 'nsubjpass', 'pcomp', 'pobj',
               'attr', 'ROOT', 'root']
+    doc = obj.doc
     np_deps = [doc.vocab.strings[label] for label in labels]
     conj = doc.vocab.strings['conj']
     np_label = doc.vocab.strings['NP']
-    for i, word in enumerate(doc):
+    for i, word in enumerate(obj):
         if word.pos in (NOUN, PROPN, PRON) and word.dep in np_deps:
             yield word.left_edge.i, word.i+1, np_label
         elif word.pos == NOUN and word.dep == conj:

--- a/spacy/syntax/iterators.pyx
+++ b/spacy/syntax/iterators.pyx
@@ -2,9 +2,11 @@ from spacy.parts_of_speech cimport NOUN, PROPN, PRON
 
 
 def english_noun_chunks(obj):
+    '''Detect base noun phrases from a dependency parse.
+    Works on both Doc and Span.'''
     labels = ['nsubj', 'dobj', 'nsubjpass', 'pcomp', 'pobj',
               'attr', 'ROOT', 'root']
-    doc = obj.doc
+    doc = obj.doc # Ensure works on both Doc and Span.
     np_deps = [doc.vocab.strings[label] for label in labels]
     conj = doc.vocab.strings['conj']
     np_label = doc.vocab.strings['NP']
@@ -26,14 +28,15 @@ def english_noun_chunks(obj):
 # extended to the right of the NOUN
 # example: "eine Tasse Tee" (a cup (of) tea) returns "eine Tasse Tee" and not
 # just "eine Tasse", same for "das Thema Familie"
-def german_noun_chunks(doc):
+def german_noun_chunks(obj):
     labels = ['sb', 'oa', 'da', 'nk', 'mo', 'ag', 'ROOT', 'root', 'cj', 'pd', 'og', 'app']
+    doc = obj.doc # Ensure works on both Doc and Span.
     np_label = doc.vocab.strings['NP']
     np_deps = set(doc.vocab.strings[label] for label in labels)
     close_app = doc.vocab.strings['nk']
 
     rbracket = 0
-    for i, word in enumerate(doc):
+    for i, word in enumerate(obj):
         if i < rbracket:
             continue
         if word.pos in (NOUN, PROPN, PRON) and word.dep in np_deps:

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -223,6 +223,10 @@ cdef class Doc:
     def __repr__(self):
         return self.__str__()
 
+    @property
+    def doc(self):
+        return self
+
     def similarity(self, other):
         '''Make a semantic similarity estimate. The default estimate is cosine
         similarity using an average of word vectors.


### PR DESCRIPTION
Add noun_chunks to Span

## Description
Support iterating noun_chunks of a Span.  Also add `doc` attribute to `Doc`class for uniformity.  Wasn't sure the best way to remove code duplication between `noun_chunks` in `Doc` and `noun_chunks` in `Span`.

## Motivation and Context
Useful to be able to find noun_chunks in a span, rather than the whole doc.  Eg all noun_chunks in a sentence.

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality to spaCy)
- [ ] Breaking change (fix or feature causing change to spaCy's existing functionality)
- [ ] Documentation (Addition to documentation of spaCy)

## Checklist:
- [x] My code follows spaCy's code style.
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
