### PR TITLE
Fixed minor typo

### DIFF
--- a/website/docs/usage/data-model.jade
+++ b/website/docs/usage/data-model.jade
@@ -14,7 +14,7 @@ p After reading this page, you should be able to:
 +h(3, "no-job-too-big") No job too big
 
 p
-    |  When writing spaCy, one of my motos was #[em no job too big]. I wanted
+    |  When writing spaCy, one of my mottos was #[em no job too big]. I wanted
     |  to make sure that if Google or Facebook were founded tomorrow, spaCy
     |  would be the obvious choice for them. I wanted spaCy to be the obvious
     |  choice for web-scale NLP. This meant sweating about performance, because


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title -->

## Description
The word `motto` was missing the second `t`.

## Motivation and Context
Minor typo in the documentation site.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality to spaCy)
- [ ] Breaking change (fix or feature causing change to spaCy's existing functionality)
- [x] Documentation (Addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My code follows spaCy's code style.
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
