### PR TITLE
Revert "Add acl to symbols.pyx"

### DIFF
--- a/spacy/symbols.pyx
+++ b/spacy/symbols.pyx
@@ -371,7 +371,6 @@ IDS = {
     "ORDINAL": ORDINAL,
     "CARDINAL": CARDINAL,
 
-    "acl": acl,
     "acomp": acomp,
     "advcl": advcl,
     "advmod": advmod,


### PR DESCRIPTION
Reverts explosion/spaCy#676

This patch needs to add the `acl` symbol to the actual `enum`, in the `symbols.pxd` file. Unfortunately, there's an unfortunate problem at the moment.

I made the questionable decision of adding all of these symbols to the `StringStore`, so that when you do `nlp.vocab["NOUN"]` you get back the same integer symbol as `spacy.symbols.NOUN`. That's nice, but the problem is I added these at the *start* of the string table. This means that if we add anything to the symbols list, all of the other strings get pushed back! This means all of the models have to be retrained.

Version 2 will fix this by adding these special symbols towards the *end* of the strings table. Until then we have to just log the changes, because I don't want to make master incompatible with the current model.