### PR TITLE
Fixed missing vec_path declaration that was failing if 'add_vectors' …

### DIFF
--- a/spacy/en/__init__.py
+++ b/spacy/en/__init__.py
@@ -44,6 +44,7 @@ def _fix_deprecated_glove_vectors_loading(overrides):
     else:
         path = overrides['path']
         data_path = path.parent
+    vec_path = None
     if 'add_vectors' not in overrides:
         if 'vectors' in overrides:
             vec_path = match_best_version(overrides['vectors'], None, data_path)


### PR DESCRIPTION
Added vec_path variable declaration to avoid accessing it before assignment in case 'add_vectors' is in overrides.

<!--- Provide a general summary of your changes in the Title -->
Added vec_path variable declaration to avoid accessing it before assignment in case 'add_vectors' is in overrides.

## Description
Added vec_path variable declaration to avoid accessing it before assignment in case 'add_vectors' is in overrides.

## Motivation and Context
Without this fix one cannot make loading the vectors optional (7s overhead)

## How Has This Been Tested?
1 line fix, tested manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality to spaCy)
- [ ] Breaking change (fix or feature causing change to spaCy's existing functionality)
- [ ] Documentation (Addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [x] My code follows spaCy's code style.
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.