### PR TITLE
Add PART to tag map

### DIFF
--- a/spacy/language_data/tag_map.py
+++ b/spacy/language_data/tag_map.py
@@ -20,5 +20,6 @@ TAG_MAP = {
     "X":        {POS: X},
     "CONJ":     {POS: CONJ},
     "ADJ":      {POS: ADJ},
-    "VERB":     {POS: VERB}
+    "VERB":     {POS: VERB},
+    "PART":     {POS: PART}
 }


### PR DESCRIPTION
Add PART tag in the UD tag set to the tag set mapping, as it is missing.

## Description
Add PART to UD tag set mapping.

## Motivation and Context
16 of the 17 tags in UD tag set are in the mapping; PART is missing.

## How Has This Been Tested?
No tests run.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [x ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality to spaCy)
- [ ] Breaking change (fix or feature causing change to spaCy's existing functionality)
- [ ] Documentation (Addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [x ] My code follows spaCy's code style.
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.