### PR TITLE
Correct typo "chldren" in doc.jade

### DIFF
--- a/website/docs/api/doc.jade
+++ b/website/docs/api/doc.jade
@@ -51,14 +51,14 @@ p A container for accessing linguistic annotations.
         +cell dict
         +cell
             |  A dictionary that allows customisation of properties of
-            |  #[code Token] chldren.
+            |  #[code Token] children.
 
     +row
         +cell #[code user_span_hooks]
         +cell dict
         +cell
             |  A dictionary that allows customisation of properties of
-            |  #[code Span] chldren.
+            |  #[code Span] children.
 
 +h(2, "init") Doc.__init__
     +tag method


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title -->
Correct the typo "chldren" in doc.jade.
## Description
<!--- Describe your changes -->
Added an "i" between "h" and "l" in the two instances of this typo
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If fixing an open issue, please link to the issue here. -->
This change improves the documentation's spelling.
## How Has This Been Tested?
<!--- Please describe in detail your tests. Did you add new tests? -->
<!--- Include details of your testing environment, and the tests you ran too -->
<!--- How were other areas of the code affected? -->
I have checked that this is the correct dictionary spelling for the plural form of "child" by referencing the Oxford English Dictionary.
I have neither run nor written any tests.
This change does not affect any code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality to spaCy)
- [ ] Breaking change (fix or feature causing change to spaCy's existing functionality)
- [ x] Documentation (Addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My code follows spaCy's code style.
- [x ] My change requires a change to spaCy's documentation.
- [x ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
