### PR TITLE
Fix Custom Tokenizer docs

### DIFF
--- a/website/docs/usage/customizing-tokenizer.jade
+++ b/website/docs/usage/customizing-tokenizer.jade
@@ -26,6 +26,9 @@ p
     |  #[+api("tokenizer") #[code Tokenizer]] instance:
 
 +code.
+    import spacy
+    from spacy.symbols import ORTH, LEMMA, POS
+
     nlp = spacy.load('en')
     assert [w.text for w in nlp(u'gimme that')] == [u'gimme', u'that']
     nlp.tokenizer.add_special_case(u'gimme',
@@ -37,7 +40,7 @@ p
             {
                 ORTH: u'me'}])
     assert [w.text for w in nlp(u'gimme that')] == [u'gim', u'me', u'that']
-    assert [w.lemma_ for w in nlp(u'gimme that')] == [u'give', u'-PRON-', u'that']
+    assert [w.lemma_ for w in nlp(u'gimme that')] == [u'give', u'me', u'that']
 
 p
     |  The special case doesn't have to match an entire whitespace-delimited
@@ -52,9 +55,9 @@ p
     |  The special case rules have precedence over the punctuation splitting:
 
 +code.
-    nlp.tokenizer.add_special_case(u"...gimme...?",
+    nlp.tokenizer.add_special_case(u'...gimme...?',
         [{
-            ORTH: u'...gimme...?", LEMMA: "give", TAG: "VB"}])
+            ORTH: u'...gimme...?', LEMMA: u'give', TAG: u'VB'}])
     assert len(nlp(u'...gimme...?')) == 1
 
 p


### PR DESCRIPTION
## Description
- Fix mismatched quotations
- Make it more clear where `ORTH`, `LEMMA`, and `POS` symbols come from
- Make strings consistent (unicode strings)
- Fix lemma_ assertion s/`-PRON-`/`me`/

I ran `harp server` to ensure that the changes appeared correctly and the templates were rendering correctly.

![image](https://cloud.githubusercontent.com/assets/1113327/22034522/6d3e3554-dca1-11e6-86b6-31e00928978e.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [ ] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [x] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [x] My change requires a change to spaCy's documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
