### PR TITLE
Specify version number for ujson and plac

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ thinc>=6.2.0,<6.3.0
 murmurhash>=0.26,<0.27
 plac<0.9.3
 six
-ujson
+ujson>=1.35
 cloudpickle
 sputnik>=0.9.2,<0.10.0

--- a/setup.py
+++ b/setup.py
@@ -234,7 +234,7 @@ def setup_package():
                 'cymem>=1.30,<1.32',
                 'preshed>=0.46.0,<0.47.0',
                 'thinc>=6.2.0,<6.3.0',
-                'plac',
+                'plac<0.9.3',
                 'six',
                 'cloudpickle',
                 'pathlib',


### PR DESCRIPTION
The required version was specified for plac in requirements.txt but not in setup.py, which could cause a conflicting version error (see issue #771). Similarly, set the version of ujson in requirements.txt to be the same as in setup.py

## Types of changes
- [x] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
