### PR TITLE
altered definition of conjuncts

### DIFF
--- a/spacy/tokens/token.pyx
+++ b/spacy/tokens/token.pyx
@@ -477,11 +477,10 @@ cdef class Token:
             if 'conjuncts' in self.doc.user_token_hooks:
                 yield from self.doc.user_token_hooks['conjuncts'](self)
             else:
-                if self.dep_ != 'conj':
-                    for word in self.rights:
-                        if word.dep_ == 'conj':
-                            yield word
-                            yield from word.conjuncts
+                for word in self.rights:
+                    if word.dep_ == 'conj':
+                        yield word
+                            
 
     property ent_type:
         def __get__(self):


### PR DESCRIPTION
<!--- removed restriction of token.conjuncts and removed recursive call -->

Removed striction `if self.dep_ != 'conj'` in conjuncts property.

Removed recursion `yield from word.conjuncts. It didn't do anything given the restriction `if self.dep_ != 'conj'`. Without that restriction the recursion would grab nested conjucts, so we remove the recursion too. 

see this [issue](https://github.com/explosion/spaCy/issues/795):

## Description
<!--- Use this section to describe your changes and how they're affecting the code. -->
<!-- If your changes required testing, include information about the testing environment and the tests you ran. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [x] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
