### PR TITLE
Fix issue #805

### DIFF
--- a/spacy/sv/language_data.py
+++ b/spacy/sv/language_data.py
@@ -5,12 +5,14 @@ from .. import language_data as base
 from ..language_data import update_exc, strings_to_exc
 
 from .stop_words import STOP_WORDS
+from .tokenizer_exceptions import TOKENIZER_EXCEPTIONS, ORTH_ONLY
 
 
 STOP_WORDS = set(STOP_WORDS)
 
-
-TOKENIZER_EXCEPTIONS = strings_to_exc(base.EMOTICONS)
+TOKENIZER_EXCEPTIONS = dict(TOKENIZER_EXCEPTIONS)
+update_exc(TOKENIZER_EXCEPTIONS, strings_to_exc(ORTH_ONLY))
+update_exc(TOKENIZER_EXCEPTIONS, strings_to_exc(base.EMOTICONS))
 update_exc(TOKENIZER_EXCEPTIONS, strings_to_exc(base.ABBREVIATIONS))
 
 

--- a/spacy/sv/tokenizer_exceptions.py
+++ b/spacy/sv/tokenizer_exceptions.py
@@ -107,7 +107,6 @@ ORTH_ONLY = [
     "p.g.a.",
     "ref.",
     "resp.",
-    "s.",
     "s.a.s.",
     "s.k.",
     "st.",

--- a/spacy/tests/conftest.py
+++ b/spacy/tests/conftest.py
@@ -69,6 +69,11 @@ def fi_tokenizer():
 
 
 @pytest.fixture
+def sv_tokenizer():
+    return Swedish.Defaults.create_tokenizer()
+
+
+@pytest.fixture
 def stringstore():
     return StringStore()
 

--- a/spacy/tests/regression/test_issue805.py
+++ b/spacy/tests/regression/test_issue805.py
@@ -1,0 +1,15 @@
+# encoding: utf8
+from __future__ import unicode_literals
+
+import pytest
+
+SV_TOKEN_EXCEPTION_TESTS = [
+    ('Smörsåsen används bl.a. till fisk', ['Smörsåsen', 'används', 'bl.a.', 'till', 'fisk']),
+    ('Jag kommer först kl. 13 p.g.a. diverse förseningar', ['Jag', 'kommer', 'först', 'kl.', '13', 'p.g.a.', 'diverse', 'förseningar'])
+]
+
+@pytest.mark.parametrize('text,expected_tokens', SV_TOKEN_EXCEPTION_TESTS)
+def test_issue805(sv_tokenizer, text, expected_tokens):
+    tokens = sv_tokenizer(text)
+    token_list = [token.text for token in tokens if not token.is_space]
+    assert expected_tokens == token_list


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title -->
## Description
Aims to fix issue #805 by importing the Swedish-specific `ORTH_ONLY` and `TOKENIZER_EXCEPTIONS`-exceptions in the `language_data.py`-file. This requires for the `s.`-exception to be removed from the Swedish-specific exceptions to not conflict with global abbreviations.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [x] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
