### PR TITLE
Fix error in matching documentation

### DIFF
--- a/website/docs/usage/rule-based-matching.jade
+++ b/website/docs/usage/rule-based-matching.jade
@@ -20,7 +20,7 @@ p
     |  Once we've added the pattern, we can use the #[code matcher] as a
     |  callable, to receive a list of #[code (ent_id, start, end)] tuples.
     |  Note that #[code LOWER] and #[code IS_PUNCT] are data attributes
-    |  of #[code Matcher.attrs].
+    |  of #[code spacy.attrs].
 
 +code.
     from spacy.matcher import Matcher


### PR DESCRIPTION
LOWER and IS_PUNCT are members of `spacy` and not of the `Matcher` class.

## Types of changes
- [ ] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [x] **Documentation** (addition to documentation of spaCy)

## Checklist:
- [x] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
