### PR TITLE
Make the website nav header's hysteresis a bit more robust

### DIFF
--- a/website/assets/js/main.js
+++ b/website/assets/js/main.js
@@ -14,7 +14,7 @@
     const updateNav = () => {
         const vh = updateVh()
         const newScrollY = (window.pageYOffset || document.scrollTop) - (document.clientTop || 0)
-        scrollUp = newScrollY <= scrollY
+        if (newScrollY != scrollY) scrollUp = newScrollY <= scrollY
         scrollY = newScrollY
 
         if(scrollUp && !(isNaN(scrollY) || scrollY <= vh)) nav.classList.add(fixedClass)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title -->

## Description

When browsing the website in Firefox, the header navbar (which disappears when scrolling down) keeps reappearing every time you stop scrolling down. The `scroll` event seems to fire a bit more than on Chrome, leading `scrollUp` to go back to `true` when scrolling ends, when in fact we're not moving any more.

This change just keeps the latest `scrollUp` value if we haven't actually moved.

No tests needed, no documentation change, so the checklist is empty.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [x] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
