### PR TITLE
Fix error in pipeline loading documentation

### DIFF
--- a/website/docs/usage/language-processing-pipeline.jade
+++ b/website/docs/usage/language-processing-pipeline.jade
@@ -99,7 +99,7 @@ p
             |  is ignored.
 
     +row
-        +cell #[vocab]
+        +cell #[code vocab]
         +cell Supply a pre-built Vocab instance, instead of constructing one.
 
     +row


### PR DESCRIPTION
The cell for the `vocab` parameter is not displayed, making it seem as if the explanation belongs to the previous param.

<!--- Provide a general summary of your changes in the Title -->

## Description
<!--- Use this section to describe your changes and how they're affecting the code. -->
<!-- If your changes required testing, include information about the testing environment and the tests you ran. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [ ] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [x] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [x] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
