### PR TITLE
Fix typo in IOB integer to letter map

### DIFF
--- a/website/docs/api/token.jade
+++ b/website/docs/api/token.jade
@@ -35,7 +35,7 @@ p An individual token — i.e. a word, punctuation symbol, whitespace, etc.
         +cell int
         +cell
             |  IOB code of named entity tag.
-            |  #[code 1="I", 2="O", B="B"]. #[code 0] means no tag is assigned.
+            |  #[code 1="I", 2="O", 3="B"]. #[code 0] means no tag is assigned.
 
     +row
         +cell #[code ent_iob_]


### PR DESCRIPTION
There was a typo in the documentation: the ent_iob value for an ent.iob_ value of 'B' should be 3, not B

## Description
Just fixing a typo in the documentation.  It's the least I can do for such an amazing project!


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [x] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [x] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [x] My change requires a change to spaCy's documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
