### PR TITLE
#781 Apply suggested patch -- passing regression test added

### DIFF
--- a/spacy/lemmatizer.py
+++ b/spacy/lemmatizer.py
@@ -86,13 +86,16 @@ def lemmatize(string, index, exceptions, rules):
     #if string in index:
     #    forms.append(string)
     forms.extend(exceptions.get(string, []))
+    oov_forms = []
     for old, new in rules:
         if string.endswith(old):
             form = string[:len(string) - len(old)] + new
             if form in index or not form.isalpha():
                 forms.append(form)
+            else:
+                oov_forms.append(form)
     if not forms:
-        forms.append(string)
+        forms.extend(oov_forms)
     return set(forms)
 
 

--- a/spacy/tests/regression/test_issue781.py
+++ b/spacy/tests/regression/test_issue781.py
@@ -5,6 +5,6 @@ import pytest
 
 
 # Note: "chromosomes" worked previous the bug fix
-@pytest.mark.parametrize('word,lemma', [("chromosomes", "chromosome"), ("endosomes", "endosome"), ("colocalizes", "colocalize")])
-def test_issue781(path, lemmatizer, word, lemma):
-    assert lemmatizer(word, 'noun', morphology={'number': 'plur'}) == set([lemma])
+@pytest.mark.parametrize('word,lemmas', [("chromosomes", ["chromosome"]), ("endosomes", ["endosome"]), ("colocalizes", ["colocalize", "colocaliz"])])
+def test_issue781(path, lemmatizer, word, lemmas):
+    assert lemmatizer(word, 'noun', morphology={'number': 'plur'}) == set(lemmas)

--- a/spacy/tests/regression/test_issue781.py
+++ b/spacy/tests/regression/test_issue781.py
@@ -1,0 +1,10 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import pytest
+
+
+# Note: "chromosomes" worked previous the bug fix
+@pytest.mark.parametrize('word,lemma', [("chromosomes", "chromosome"), ("endosomes", "endosome"), ("colocalizes", "colocalize")])
+def test_issue781(path, lemmatizer, word, lemma):
+    assert lemmatizer(word, 'noun', morphology={'number': 'plur'}) == set([lemma])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title -->

## Description
<!--- Use this section to describe your changes and how they're affecting the code. -->
<!-- If your changes required testing, include information about the testing environment and the tests you ran. -->

I applied the suggested patch of issue #781 

It's unclear whether the line `forms.extend(exceptions.get(string, []))` is anymore needed (also related to #435). I suggest to remove it. The regression test passes with and without that line. It seems redundant, from my current understanding of the code.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [x] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. (**note: general spaCy tests failed previous change, at least in my installation, so I cannot test this. New test passes**)