### PR TITLE
Add `lower_` and `upper_` properties and `map` fn to `Span` class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,7 +106,6 @@ website/announcement.jade
 website/www/
 website/.gitignore
 
-# Personal (Eric)
+# Python virtualenv
 venv
 venv/*
-.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,8 @@ website/package.json
 website/announcement.jade
 website/www/
 website/.gitignore
+
+# Personal (Eric)
+venv
+venv/*
+.gitignore

--- a/spacy/tests/spans/test_span.py
+++ b/spacy/tests/spans/test_span.py
@@ -35,7 +35,6 @@ def test_spans_string_fn(doc):
     span = doc[0:4]
     assert len(span) == 4
     assert span.text == 'This is a sentence'
-    assert span.mapStr((lambda x, i, arg="_": x + i + arg), "y", "z") == 'This yzis yza yzsentence yz'
     assert span.upper_ == 'THIS IS A SENTENCE'
     assert span.lower_ == 'this is a sentence'
 

--- a/spacy/tests/spans/test_span.py
+++ b/spacy/tests/spans/test_span.py
@@ -31,6 +31,13 @@ def test_spans_root(doc):
     assert span.root.text == 'sentence'
     assert span.root.head.text == 'is'
 
+def test_spans_string_fn(doc):
+    span = doc[0:4]
+    assert len(span) == 4
+    assert span.text == 'This is a sentence'
+    assert span.mapStr((lambda x, i, arg="_": x + i + arg), "y", "z") == 'This yzis yza yzsentence yz'
+    assert span.upper_ == 'THIS IS A SENTENCE'
+    assert span.lower_ == 'this is a sentence'
 
 def test_spans_root2(en_tokenizer):
     text = "through North and South Carolina"

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -118,17 +118,6 @@ cdef class Span:
             return 0.0
         return numpy.dot(self.vector, other.vector) / (self.vector_norm * other.vector_norm)
 
-    def mapStr(self, fn, *argv, **kargs):
-      '''Perform a function on the string representation of each token in this span.
-      
-      Arguments:
-          fn (function): First argument will always be string of a token. Additional arguments
-          will be defined according to *argv and **kargs passed to this mapStr() method.
-          *argv (unpacked tuple): Arguments to be passed to fn
-          **kargs (unpacked dict): Arguments to be passed to fn
-      '''
-      return ''.join([fn(t.string, *argv, **kargs) for t in self]).strip()
-
     cpdef int _recalculate_indices(self) except -1:
         if self.end > self.doc.length \
         or self.doc.c[self.start].idx != self.start_char \

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -118,6 +118,17 @@ cdef class Span:
             return 0.0
         return numpy.dot(self.vector, other.vector) / (self.vector_norm * other.vector_norm)
 
+    def mapStr(self, fn, *argv, **kargs):
+      '''Perform a function on the string representation of each token in this span.
+      
+      Arguments:
+          fn (function): First argument will always be string of a token. Additional arguments
+          will be defined according to *argv and **kargs passed to this mapStr() method.
+          *argv (unpacked tuple): Arguments to be passed to fn
+          **kargs (unpacked dict): Arguments to be passed to fn
+      '''
+      return ''.join([fn(t.string, *argv, **kargs) for t in self]).strip()
+
     cpdef int _recalculate_indices(self) except -1:
         if self.end > self.doc.length \
         or self.doc.c[self.start].idx != self.start_char \
@@ -364,6 +375,14 @@ cdef class Span:
     property lemma_:
         def __get__(self):
             return ' '.join([t.lemma_ for t in self]).strip()
+
+    property upper_:
+        def __get__(self):
+            return ''.join([t.string.upper() for t in self]).strip()
+
+    property lower_:
+        def __get__(self):
+            return ''.join([t.string.lower() for t in self]).strip()
 
     property string:
         def __get__(self):


### PR DESCRIPTION
Added lower_ and upper_ properties as described in https://github.com/explosion/spaCy/issues/669.
I also added a generic map function to execute on the string representations of each token in a span.

## Types of changes
I added some simple features via very minor additions to `spacy/tokens/span.pyx`, and added corresponding tests to `spacy/tests/spans/test_span.py`.

## Checklist:
- [ ] My change requires a change to spaCy's documentation. (Not sure about this, sorry)
- [ ] I have updated the documentation accordingly. (Should I do so in this case?)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

This is my first commit to a major open-source project - please let me know if I should fix/add anything, and apologies ahead of time in case I somehow break something.

- Eric