### PR TITLE
Remove duplicate keys in [en|fi] language data dicts

### DIFF
--- a/spacy/en/morph_rules.py
+++ b/spacy/en/morph_rules.py
@@ -21,7 +21,6 @@ MORPH_RULES = {
         "them":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Plur", "Case": "Acc"},
 
         "mine":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Poss": "Yes", "Reflex": "Yes"},
-        "yours":        {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Poss": "Yes", "Reflex": "Yes"},
         "his":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Masc", "Poss": "Yes", "Reflex": "Yes"},
         "hers":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Fem",  "Poss": "Yes", "Reflex": "Yes"},
         "its":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Neut", "Poss": "Yes", "Reflex": "Yes"},

--- a/spacy/fi/tokenizer_exceptions.py
+++ b/spacy/fi/tokenizer_exceptions.py
@@ -193,9 +193,6 @@ TOKENIZER_EXCEPTIONS = {
     "vm.": [
         {ORTH: "vm.", LEMMA: "viimeksi mainittu"}
     ],
-    "siht.": [
-        {ORTH: "siht.", LEMMA: "sihteeri"}
-    ],
     "srk.": [
         {ORTH: "srk.", LEMMA: "seurakunta"}
     ]


### PR DESCRIPTION
In en and fi data language files, some dictionary keys were duplicated.

## Types of changes
- [x] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
