### PR TITLE
Split CONLLX file using tabs and not default split separators

### DIFF
--- a/bin/parser/train_ud.py
+++ b/bin/parser/train_ud.py
@@ -1,18 +1,13 @@
 from __future__ import unicode_literals
 import plac
 import json
-from os import path
-import shutil
-import os
 import random
-import io
 import pathlib
 
 from spacy.tokens import Doc
 from spacy.syntax.nonproj import PseudoProjectivity
 from spacy.language import Language
 from spacy.gold import GoldParse
-from spacy.vocab import Vocab
 from spacy.tagger import Tagger
 from spacy.pipeline import DependencyParser, BeamDependencyParser
 from spacy.syntax.parser import get_templates
@@ -21,7 +16,6 @@ from spacy.scorer import Scorer
 from spacy.language_data.tag_map import TAG_MAP as DEFAULT_TAG_MAP
 import spacy.attrs
 import io
-
 
 
 def read_conllx(loc, n=0):
@@ -35,7 +29,8 @@ def read_conllx(loc, n=0):
                 lines.pop(0)
             tokens = []
             for line in lines:
-                id_, word, lemma, pos, tag, morph, head, dep, _1, _2 = line.split()
+                id_, word, lemma, pos, tag, morph, head, dep, _1, \
+                _2 = line.split('\t')
                 if '-' in id_ or '.' in id_:
                     continue
                 try:

--- a/bin/parser/train_ud.py
+++ b/bin/parser/train_ud.py
@@ -129,7 +129,7 @@ def main(lang_name, train_loc, dev_loc, model_dir, clusters_loc=None):
         random.shuffle(train_sents)
         scorer = score_model(vocab, tagger, parser, read_conllx(dev_loc))
         print('%d:\t%.3f\t%.3f\t%.3f' % (itn, loss, scorer.uas, scorer.tags_acc))
-    nlp = Language(vocab=vocab, tagger=tagger, parser=parser)
+    nlp = LangClass(vocab=vocab, tagger=tagger, parser=parser)
     nlp.end_training(model_dir)
     scorer = score_model(vocab, tagger, parser, read_conllx(dev_loc))
     print('%d:\t%.3f\t%.3f\t%.3f' % (itn, scorer.uas, scorer.las, scorer.tags_acc))


### PR DESCRIPTION
I encountered various errors while trying to train the parser for French using train_ud.py script.

- the different columns of the CONLLX file were splitted using split function default separators, instead of tabs. It could lead to an error if one field contains space (for instance the token '100 000'), as the number of field is greater than expected.
- use of the LangGlass defined above instead of the base Language class to instanciate the language.
Without this, I got the following error, due to recent change in Spacy Language class (commit 9605cf39cc1c8119535616ebd1df0d011cb4e9f8):

```
Traceback (most recent call last):
  File "train_ud.py", line 139, in <module>
    plac.call(main)
  File "/home/raphael/.virtualenvs/spacy/lib/python3.5/site-packages/plac_core.py", line 328, in call
    cmd, result = parser.consume(arglist)
  File "/home/raphael/.virtualenvs/spacy/lib/python3.5/site-packages/plac_core.py", line 207, in consume
    return cmd, self.func(*(args + varargs + extraopts), **kwargs)
  File "train_ud.py", line 132, in main
    nlp = Language(vocab=vocab, tagger=tagger, parser=parser)
  File "/home/raphael/git_core/spaCy/spacy/language.py", line 282, in __init__
    path = util.get_data_path() / self.lang
  File "/usr/lib64/python3.5/pathlib.py", line 889, in __truediv__
    return self._make_child((key,))
  File "/usr/lib64/python3.5/pathlib.py", line 681, in _make_child
    drv, root, parts = self._parse_args(args)
  File "/usr/lib64/python3.5/pathlib.py", line 643, in _parse_args
    % type(a))
TypeError: argument should be a path or str object, not <class 'NoneType'>
```
## Types of changes
- [x] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
