### PR TITLE
Fix infinite recursion in spacy.info

### DIFF
--- a/spacy/__init__.py
+++ b/spacy/__init__.py
@@ -49,7 +49,3 @@ def load(name, **overrides):
         overrides['path'] = model_path
 
     return cls(**overrides)
-
-
-def info(name, markdown):
-    info(name, markdown)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title -->

## Description
<!--- Use this section to describe your changes and how they're affecting the code. -->
<!-- If your changes required testing, include information about the testing environment and the tests you ran. -->
Remove definition of `info` from `__init.py__` as it is imported from `cli` module. Removed function caused `RecursionError: maximum recursion depth exceeded`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [x] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
