### PR TITLE
Add option to use label=ent_type in doc.merge arguments (Bug fix for issue #862)

### DIFF
--- a/spacy/tests/spans/test_merge.py
+++ b/spacy/tests/spans/test_merge.py
@@ -19,6 +19,15 @@ def test_spans_merge_tokens(en_tokenizer):
     assert doc[0].text == 'Los Angeles'
     assert doc[0].head.text == 'start'
 
+    doc = get_doc(tokens.vocab, [t.text for t in tokens], heads=heads)
+    assert len(doc) == 4
+    assert doc[0].head.text == 'Angeles'
+    assert doc[1].head.text == 'start'
+    doc.merge(0, len('Los Angeles'), tag='NNP', lemma='Los Angeles', label='GPE')
+    assert len(doc) == 3
+    assert doc[0].text == 'Los Angeles'
+    assert doc[0].head.text == 'start'
+    assert doc[0].ent_type_ == 'GPE'
 
 def test_spans_merge_heads(en_tokenizer):
     text = "I found a pilates class near work."

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -667,6 +667,13 @@ cdef class Doc:
             attributes[TAG] = self.vocab.strings[tag]
             attributes[LEMMA] = self.vocab.strings[lemma]
             attributes[ENT_TYPE] = self.vocab.strings[ent_type]
+        elif not args:
+            if "label" in attributes and ENT_TYPE not in attributes:
+                if type(attributes["label"]) == int:
+                    attributes[ENT_TYPE] = attributes["label"]
+                else:
+                    attributes[ENT_TYPE] = self.vocab.strings[attributes["label"]]
+
         elif args:
             raise ValueError(
                 "Doc.merge received %d non-keyword arguments. "


### PR DESCRIPTION
Small fix for bug described here: https://github.com/explosion/spaCy/issues/862

## Description
Issue #862 is due to (from what I could see so I might be wrong) the label argument passed to doc.merge by span.merge, so I simply included a few lines to keep track of a potential 'label' argument.
I appended some relevant assertions to a spans/test_merge test.

## Types of changes
- [x ] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
