### PR TITLE
Issue #934 symlink should not convert paths as_posix under windows.

### DIFF
--- a/spacy/cli/link.py
+++ b/spacy/cli/link.py
@@ -46,7 +46,7 @@ def symlink(model_path, link_name, force):
     # Add workaround for Python 2 on Windows (see issue #909)
     if util.is_python2() and util.is_windows():
         import subprocess
-        command = ['mklink', '/d', link_path.as_posix(), model_path.as_posix()]
+        command = ['mklink', '/d', link_path, model_path]
         subprocess.call(command, shell=True)
     else:
         link_path.symlink_to(model_path)


### PR DESCRIPTION

## Description
symlink function in link.py was incorrectly converting WindowPaths to the posix version. Per Python docs Path should correctly instantiate as a WindowsPath and generate paths with backslashes. Windows process mklink expects paths to be valid windows paths(with backslashes).


## Types of changes
- [ X] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
