### PR TITLE
Add contractions for won't

### DIFF
--- a/spacy/en/tokenizer_exceptions.py
+++ b/spacy/en/tokenizer_exceptions.py
@@ -491,6 +491,16 @@ OTHER = {
         {ORTH: "'s", LEMMA: PRON_LEMMA, NORM: "us"}
     ],
 
+    "won't": [
+        {ORTH: "wo", LEMMA: "will"},
+        {ORTH: "n't", LEMMA: "not"}
+    ],
+
+    "Won't": [
+        {ORTH: "Wo", LEMMA: "will"},
+        {ORTH: "n't", LEMMA: "not"}
+    ],
+
     "\u2014": [
         {ORTH: "\u2014", TAG: ":", LEMMA: "--"}
     ],


### PR DESCRIPTION
Hi, I tried implementing the fix for this issue, but alas it did not work in my local environment.

The issue is that Won't & won't return lemma wo and nt. Whereas I would expect to get will not.

Saw a similar issue for Let's -> Let us, but it also didn't work for me. I wonder if there is any documentation on how to test the tokenizer exceptions before submitting pull requests? Anyway, feel free to close it and implement in a better way if necessary.

Cheers
Bruno

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [ X ] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.
