### PR TITLE
Fix keras_parikh_entailment example bugs

### DIFF
--- a/examples/keras_parikh_entailment/README.md
+++ b/examples/keras_parikh_entailment/README.md
@@ -78,7 +78,7 @@ You can run the `keras_parikh_entailment/` directory as a script, which executes
 [`keras_parikh_entailment/__main__.py`](__main__.py). The first thing you'll want to do is train the model:
 
 ```bash
-python keras_parikh_entailment/ train <your_model_dir> <train_directory> <dev_directory>
+python keras_parikh_entailment/ train <train_directory> <dev_directory>
 ```
 
 Training takes about 300 epochs for full accuracy, and I haven't rerun the full

--- a/examples/keras_parikh_entailment/__main__.py
+++ b/examples/keras_parikh_entailment/__main__.py
@@ -52,7 +52,7 @@ def train(train_loc, dev_loc, shape, settings):
         file_.write(model.to_json())
 
 
-def evaluate(model_dir, dev_loc):
+def evaluate(dev_loc):
     dev_texts1, dev_texts2, dev_labels = read_snli(dev_loc)
     nlp = spacy.load('en',
             create_pipeline=create_similarity_pipeline)

--- a/examples/keras_parikh_entailment/spacy_hook.py
+++ b/examples/keras_parikh_entailment/spacy_hook.py
@@ -80,10 +80,10 @@ def get_word_ids(docs, rnn_encode=False, tree_truncate=False, max_length=100, nr
     return Xs
 
 
-def create_similarity_pipeline(nlp):
+def create_similarity_pipeline(nlp, max_length=100):
     return [
         nlp.tagger,
         nlp.entity,
         nlp.parser,
-        KerasSimilarityShim.load(nlp.path / 'similarity', nlp, max_length=10)
+        KerasSimilarityShim.load(nlp.path / 'similarity', nlp, max_length)
     ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title -->

## Description
1. Removed model_dir from [evaluate function](https://github.com/explosion/spaCy/blob/master/examples/keras_parikh_entailment/__main__.py#L55) which is not needed and not used inside function too
2. Set [max_length](https://github.com/explosion/spaCy/blob/master/examples/keras_parikh_entailment/spacy_hook.py#L88) to 100 for evaluate and demo. This bug is specified in this [issue comment](https://github.com/explosion/spaCy/issues/767#issuecomment-278651113)
3. Update command to run train in README. The model_dir was removed on this [commit](https://github.com/explosion/spaCy/commit/c031c677ccfcf0c425c4ad838ddf1f795add9b5d) and that change is not updated in README. This PR fixes it.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [x] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)


