### PR TITLE
Fixes typo in method calling Pseudoprojectivity method in create_pipeline method of BaseDefaults class

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -144,7 +144,7 @@ class BaseDefaults(object):
             pipeline.append(nlp.tagger)
         if nlp.parser:
             pipeline.append(nlp.parser)
-            pipeline.append(Pseudoprojectivity.deprojectivize)
+            pipeline.append(PseudoProjectivity.deprojectivize)
         if nlp.entity:
             pipeline.append(nlp.entity)
         return pipeline


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title -->

## Description
Small typo in language.py caused new train cli to fail when adding the parser to the pipeline and the PseudoProjectivity.deprojectivize method. 

I did not add any test for this issue, as this is a very minor thing. Anyway, I ran all existing tests and they passed.

Testing environment:

```
 * **spaCy version:** 1.7.3
* **Platform:** Darwin-16.4.0-x86_64-i386-64bit
* **Python version:** 3.6.0
* **Installed models:**
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [x] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
