### PR TITLE
Fixed python2 issue with the package command

### DIFF
--- a/spacy/cli/package.py
+++ b/spacy/cli/package.py
@@ -6,9 +6,15 @@ import shutil
 import requests
 from pathlib import Path
 
+import six
+
 from .. import about
 from .. import util
 
+if six.PY2:
+    json_dumps = lambda data: json.dumps(data, indent=2).decode("utf8")
+elif six.PY3:
+    json_dumps = lambda data: json.dumps(data, indent=2)
 
 def package(input_dir, output_dir, force):
     input_path = Path(input_dir)
@@ -27,7 +33,7 @@ def package(input_dir, output_dir, force):
 
     create_dirs(package_path, force)
     shutil.copytree(input_path.as_posix(), (package_path / model_name_v).as_posix())
-    create_file(main_path / 'meta.json', json.dumps(meta, indent=2))
+    create_file(main_path / 'meta.json', json_dumps(meta))
     create_file(main_path / 'setup.py', template_setup)
     create_file(main_path / 'MANIFEST.in', template_manifest)
     create_file(package_path / '__init__.py', template_init)


### PR DESCRIPTION
## Description

When running `python -m spacy package` the package creation failed with an error in Python 2 environments. It was due to `json.dumps` returns `str` not `unicode`. The fix aims to make the CLI work equally well on both python versions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [X] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
