### PR TITLE
Enable pruning out rare words from clusters data

### DIFF
--- a/spacy/cli/model.py
+++ b/spacy/cli/model.py
@@ -98,10 +98,6 @@ def read_clusters(clusters_path):
 
 
 def populate_vocab(vocab, clusters, probs, oov_prob):
-    # Ensure probs has entries for all words seen during clustering.
-    for word in clusters:
-        if word not in probs:
-            probs[word] = oov_prob
     for word, prob in reversed(sorted(list(probs.items()), key=lambda item: item[1])):
         lexeme = vocab[word]
         lexeme.prob = prob


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title -->

## Description
<!--- Use this section to describe your changes and how they're affecting the code. -->
<!-- If your changes required testing, include information about the testing environment and the tests you ran. -->
Makes effective pruning out the vocabulary when clusters.vocab is larger than the actual vocabulary by not including unseen words in the vocabulary of freqs_data.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [ ] **Bug fix** (non-breaking change fixing an issue)
- [x] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
