### PR TITLE
Deleting (legacy?) whitespace attribute in doc

### DIFF
--- a/website/docs/api/token.jade
+++ b/website/docs/api/token.jade
@@ -238,11 +238,6 @@ p An individual token — i.e. a word, punctuation symbol, whitespace, etc.
         +cell #[code text_with_ws]
         +cell unicode
         +cell Text content, with trailing space character if present.
-
-    +row
-        +cell #[code whitespace]
-        +cell int
-        +cell Trailing space character if present.
     +row
         +cell #[code whitespace_]
         +cell unicode


### PR DESCRIPTION
token.whitespace now raises an AttributeError

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [ ] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [x] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
