### PR TITLE
Added html5lib==1.0b8 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ thinc>=6.5.0,<6.6.0
 murmurhash>=0.26,<0.27
 plac<1.0.0,>=0.9.6
 six
+html5lib==1.0b8
 ujson>=1.35
 dill>=0.2,<0.3
 requests>=2.13.0,<3.0.0


### PR DESCRIPTION
There's a frequent issue with `six` that occasionally causes spaCy to fail. The solution was found [here](https://stackoverflow.com/questions/39658404/python-cannot-import-name-viewkeys).