### PR TITLE
Add basic Japanese Tokenizer Test

### DIFF
--- a/spacy/ja/__init__.py
+++ b/spacy/ja/__init__.py
@@ -3,21 +3,39 @@ from __future__ import unicode_literals, print_function
 
 from os import path
 
-from ..language import Language
+from ..language import Language, BaseDefaults
+from ..tokenizer import Tokenizer
 from ..attrs import LANG
 from ..tokens import Doc
 
 from .language_data import *
 
-
-class Japanese(Language):
-    lang = 'ja'
-
-    def make_doc(self, text):
+class JapaneseTokenizer(object):
+    def __init__(self, cls, nlp=None):
+        self.vocab = nlp.vocab if nlp is not None else cls.create_vocab(nlp)
         try:
             from janome.tokenizer import Tokenizer
         except ImportError:
             raise ImportError("The Japanese tokenizer requires the Janome library: "
                               "https://github.com/mocobeta/janome")
-        words = [x.surface for x in Tokenizer().tokenize(text)]
+        self.tokenizer = Tokenizer()
+
+    def __call__(self, text):
+        words = [x.surface for x in self.tokenizer.tokenize(text)]
         return Doc(self.vocab, words=words, spaces=[False]*len(words))
+
+class JapaneseDefaults(BaseDefaults):
+    @classmethod
+    def create_tokenizer(cls, nlp=None):
+        return JapaneseTokenizer(cls, nlp)
+
+class Japanese(Language):
+    lang = 'ja'
+
+    Defaults = JapaneseDefaults
+
+    def make_doc(self, text):
+        words = self.tokenizer(text)
+        return Doc(self.vocab, words=words, spaces=[False]*len(words))
+
+        

--- a/spacy/tests/conftest.py
+++ b/spacy/tests/conftest.py
@@ -27,7 +27,7 @@ from pathlib import Path
 import os
 import pytest
 
-
+# These languages get run through generic tokenizer tests
 LANGUAGES = [English, German, Spanish, Italian, French, Portuguese, Dutch,
              Swedish, Hungarian, Finnish, Bengali, Norwegian]
 

--- a/spacy/tests/conftest.py
+++ b/spacy/tests/conftest.py
@@ -5,6 +5,7 @@ from ..en import English
 from ..de import German
 from ..es import Spanish
 from ..it import Italian
+from ..ja import Japanese
 from ..fr import French
 from ..pt import Portuguese
 from ..nl import Dutch
@@ -27,7 +28,7 @@ import os
 import pytest
 
 
-LANGUAGES = [English, German, Spanish, Italian, French, Portuguese, Dutch,
+LANGUAGES = [English, German, Spanish, Italian, Japanese, French, Portuguese, Dutch,
              Swedish, Hungarian, Finnish, Bengali, Norwegian]
 
 
@@ -74,6 +75,11 @@ def hu_tokenizer():
 @pytest.fixture
 def fi_tokenizer():
     return Finnish.Defaults.create_tokenizer()
+
+
+@pytest.fixture
+def ja_tokenizer():
+    return Japanese.Defaults.create_tokenizer()
 
 
 @pytest.fixture

--- a/spacy/tests/conftest.py
+++ b/spacy/tests/conftest.py
@@ -28,7 +28,7 @@ import os
 import pytest
 
 
-LANGUAGES = [English, German, Spanish, Italian, Japanese, French, Portuguese, Dutch,
+LANGUAGES = [English, German, Spanish, Italian, French, Portuguese, Dutch,
              Swedish, Hungarian, Finnish, Bengali, Norwegian]
 
 

--- a/spacy/tests/conftest.py
+++ b/spacy/tests/conftest.py
@@ -79,6 +79,7 @@ def fi_tokenizer():
 
 @pytest.fixture
 def ja_tokenizer():
+    janome = pytest.importorskip("janome")
     return Japanese.Defaults.create_tokenizer()
 
 

--- a/spacy/tests/ja/test_tokenizer.py
+++ b/spacy/tests/ja/test_tokenizer.py
@@ -3,6 +3,15 @@ from __future__ import unicode_literals
 
 import pytest
 
-def test_japanese_tokenizer(ja_tokenizer):
-    tokens = ja_tokenizer("日本語だよ")
-    assert len(tokens) == 3
+TOKENIZER_TESTS = [
+        ("日本語だよ", ['日本語', 'だ', 'よ']),
+        ("東京タワーの近くに住んでいます。", ['東京', 'タワー', 'の', '近く', 'に', '住ん', 'で', 'い', 'ます', '。']),
+        ("吾輩は猫である。", ['吾輩', 'は', '猫', 'で', 'ある', '。']),
+        ("月に代わって、お仕置きよ!", ['月', 'に', '代わっ', 'て', '、', 'お仕置き', 'よ', '!']),
+        ("すもももももももものうち", ['すもも', 'も', 'もも', 'も', 'もも', 'の', 'うち'])
+]
+
+@pytest.mark.parametrize('text,expected_tokens', TOKENIZER_TESTS)
+def test_japanese_tokenizer(ja_tokenizer, text, expected_tokens):
+    tokens = [token.text for token in ja_tokenizer(text)]
+    assert tokens == expected_tokens

--- a/spacy/tests/ja/test_tokenizer.py
+++ b/spacy/tests/ja/test_tokenizer.py
@@ -1,0 +1,8 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import pytest
+
+def test_japanese_tokenizer(ja_tokenizer):
+    tokens = ja_tokenizer("日本語だよ")
+    assert len(tokens) == 3


### PR DESCRIPTION
## Description

I added a basic test for the Japanese tokenizer. I tried to make it work similarly to other tokenizer tests, which required some changes to the way the base Japanese tokenizer was set up. I think it's an improvement since the tokenizer is re-used instead of being recreated every time now, but since no other language seems to work this way, let me know if something should be different.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
(sorry, not clear to me which of these adding tests counts as)
- [ ] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)


## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
