### PR TITLE
Fixed error training NER documentation and example

### DIFF
--- a/examples/training/train_new_entity_type.py
+++ b/examples/training/train_new_entity_type.py
@@ -52,6 +52,7 @@ def train_ner(nlp, train_data, output_dir):
         random.shuffle(train_data)
         loss = 0.
         for raw_text, entity_offsets in train_data:
+            doc = nlp.make_doc(raw_text)
             gold = GoldParse(doc, entities=entity_offsets)
             # By default, the GoldParse class assumes that the entities
             # described by offset are complete, and all other words should
@@ -63,7 +64,6 @@ def train_ner(nlp, train_data, output_dir):
             #for i in range(len(gold.ner)):
                 #if not gold.ner[i].endswith('ANIMAL'):
                 #    gold.ner[i] = '-'
-            doc = nlp.make_doc(raw_text)
             nlp.tagger(doc)
             # As of 1.9, spaCy's parser now lets you supply a dropout probability
             # This might help the model generalize better from only a few

--- a/website/docs/usage/training-ner.jade
+++ b/website/docs/usage/training-ner.jade
@@ -150,8 +150,8 @@ p
         for itn in range(20):
             random.shuffle(train_data)
             for raw_text, entity_offsets in train_data:
-                gold = GoldParse(doc, entities=entity_offsets)
                 doc = nlp.make_doc(raw_text)
+                gold = GoldParse(doc, entities=entity_offsets)
                 nlp.tagger(doc)
                 loss = nlp.entity.update(doc, gold)
         nlp.end_training()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title -->
This simply fixes the error in the documentation for training a new entity type for the NER. It changes it in both the example code and the website documentation. This is a known error and was acknowledged in [this issue](https://github.com/explosion/spaCy/issues/1140), but was closed without being fixed.

I can see that in the tag `v2.0.0-ALPHA` that it has been fixed for the [website](https://github.com/explosion/spaCy/blob/v2.0.0-alpha/website/docs/usage/training-ner.jade) with a new example, but not in the [training example](https://github.com/explosion/spaCy/blob/v2.0.0-alpha/examples/training/train_new_entity_type.py). Maybe it is on the _TODO_ list, making this PR redundant, but might serve as a reminder.

## Description
<!--- Use this section to describe your changes and how they're affecting the code. -->
<!-- If your changes required testing, include information about the testing environment and the tests you ran. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [x] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [x] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
