### PR TITLE
Update zh language error

### DIFF
--- a/spacy/zh/__init__.py
+++ b/spacy/zh/__init__.py
@@ -8,4 +8,5 @@ class Chinese(Language):
     def make_doc(self, text):
         import jieba
         words = list(jieba.cut(text, cut_all=True))
+        words=[x for x in words if x]
         return Doc(self.vocab, words=words, spaces=[False]*len(words))


### PR DESCRIPTION
-remove the empty string return from jieba.cut,this will cause the list of tokens cant be pushed and cause an assert error like this [](https://github.com/explosion/spaCy/issues/1150)
<!--- Provide a general summary of your changes in the Title -->

## Description

<!-- If your changes required testing, include information about the testing environment and the tests you ran. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [x ] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
