### PR TITLE
Fix url broken

### DIFF
--- a/website/docs/usage/models.jade
+++ b/website/docs/usage/models.jade
@@ -203,7 +203,7 @@ p
 p
     |  If you've trained your own model, for example for
     |  #[+a("/docs/usage/adding-languages") additional languages] or
-    |  #[+a("/docs/usage/train-ner") custom named entities], you can save its
+    |  #[+a("/docs/usage/training-ner") custom named entities], you can save its
     |  state using the #[code Language.save_to_directory()] method. To make the
     |  model more convenient to deploy, we recommend wrapping it as a Python
     |  package.


### PR DESCRIPTION
In [Models](https://spacy.io/docs/usage/models) documentation, the related url to **custom named entities** is broken:
https://spacy.io/docs/usage/train-ner is a 404.
Changed to https://spacy.io/docs/usage/training-ner

<!--- Provide a general summary of your changes in the Title -->

## Description
<!--- Use this section to describe your changes and how they're affecting the code. -->
<!-- If your changes required testing, include information about the testing environment and the tests you ran. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [ ] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [x] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [x] My change requires a change to spaCy's documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
