### PR TITLE
Better token splitting regexes for numbers preceding unit suffixes (Issue #1235)

### DIFF
--- a/spacy/language_data/punctuation.py
+++ b/spacy/language_data/punctuation.py
@@ -84,7 +84,8 @@ TOKENIZER_SUFFIXES = (
         r'(?<=[0-9])\+',
         r'(?<=°[FfCcKk])\.',
         r'(?<=[0-9])(?:{c})'.format(c=CURRENCY),
-        r'(?<=[0-9])(?:{u})'.format(u=UNITS),
+        r'(?<=^[0-9]+(\.[0-9]*)?)(?:{u})'.format(u=UNITS),
+        r'(?<=^[0-9]{{1,3}}(,[0-9]{{3}})*(\.[0-9]*)?)(?:{u})'.format(u=UNITS),
         r'(?<=[0-9{al}{p}(?:{q})])\.'.format(al=ALPHA_LOWER, p=r'%²\-\)\]\+', q=QUOTES),
         r'(?<=[{au}][{au}])\.'.format(au=ALPHA_UPPER),
         "'s", "'S", "’s", "’S"

--- a/spacy/tests/en/test_prefix_suffix_infix.py
+++ b/spacy/tests/en/test_prefix_suffix_infix.py
@@ -134,3 +134,9 @@ def test_tokenizer_splits_em_dash_infix(en_tokenizer):
     assert tokens[6].text == "Puddleton"
     assert tokens[7].text == "?"
     assert tokens[8].text == "\u2014"
+
+@pytest.mark.parametrize('case', [('a2g', 1), ('24g', 2), ('20,000mb', 2), ('23,342,212.93m/s', 2), ('12321.34in', 2)])
+def test_num_unit_suffix_split(en_tokenizer, case):
+    unsplit, exp_len = case
+    res = en_tokenizer(unsplit)
+    assert len(res) == exp_len


### PR DESCRIPTION
Thought I'd help out with an easy issue, so worked on addressing issue #1235 to better split numeric quantities with joined unit suffix.

## Description
Replaced simple tokenizer regex with 2 regexes to ensure splitting only happens when prefixed by numeric quantities, with possible decimal and thousands place comma separators. Added a unit test to show new splitting functionality.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [x] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
