### PR TITLE
Capture more noun chunks

### DIFF
--- a/spacy/syntax/iterators.pyx
+++ b/spacy/syntax/iterators.pyx
@@ -9,7 +9,7 @@ def english_noun_chunks(obj):
     Detect base noun phrases from a dependency parse.
     Works on both Doc and Span.
     """
-    labels = ['nsubj', 'dobj', 'nsubjpass', 'pcomp', 'pobj',
+    labels = ['nsubj', 'dobj', 'nsubjpass', 'pcomp', 'pobj', 'dative', 'appos',
               'attr', 'ROOT']
     doc = obj.doc # Ensure works on both Doc and Span.
     np_deps = [doc.vocab.strings[label] for label in labels]

--- a/spacy/tests/parser/test_noun_chunks.py
+++ b/spacy/tests/parser/test_noun_chunks.py
@@ -47,6 +47,36 @@ def test_parser_noun_chunks_pp_chunks(en_tokenizer):
     assert chunks[1].text_with_ws == "another phrase "
 
 
+def test_parser_noun_chunks_appositional_modifiers(en_tokenizer):
+    text = "Sam, my brother, arrived to the house."
+    heads = [5, -1, 1, -3, -4, 0, -1, 1, -2, -4]
+    tags = ['NNP', ',', 'PRP$', 'NN', ',', 'VBD', 'IN', 'DT', 'NN', '.']
+    deps = ['nsubj', 'punct', 'poss', 'appos', 'punct', 'ROOT', 'prep', 'det', 'pobj', 'punct']
+
+    tokens = en_tokenizer(text)
+    doc = get_doc(tokens.vocab, [t.text for t in tokens], tags=tags, deps=deps, heads=heads)
+    chunks = list(doc.noun_chunks)
+    assert len(chunks) == 3
+    assert chunks[0].text_with_ws == "Sam "
+    assert chunks[1].text_with_ws == "my brother "
+    assert chunks[2].text_with_ws == "the house "
+
+
+def test_parser_noun_chunks_dative(en_tokenizer):
+    text = "She gave Bob a raise."
+    heads = [1, 0, -1, 1, -3, -4]
+    tags = ['PRP', 'VBD', 'NNP', 'DT', 'NN', '.']
+    deps = ['nsubj', 'ROOT', 'dative', 'det', 'dobj', 'punct']
+
+    tokens = en_tokenizer(text)
+    doc = get_doc(tokens.vocab, [t.text for t in tokens], tags=tags, deps=deps, heads=heads)
+    chunks = list(doc.noun_chunks)
+    assert len(chunks) == 3
+    assert chunks[0].text_with_ws == "She "
+    assert chunks[1].text_with_ws == "Bob "
+    assert chunks[2].text_with_ws == "a raise "
+
+
 def test_parser_noun_chunks_standard_de(de_tokenizer):
     text = "Eine Tasse steht auf dem Tisch."
     heads = [1, 1, 0, -1, 1, -2, -4]


### PR DESCRIPTION
Capture more noun chunks, specifically appositional modifiers and indirect objects.

Closes #1226 

## Description

I added two tests and ran `py.test spacy/tests/parser/test_noun_chunks.py`. (Please inform me if the new tests would be better to go in a file `test_issue1226.py`)

## Types of changes
- [ ] **Bug fix** (non-breaking change fixing an issue)
- [x] **New feature** (non-breaking change adding functionality to spaCy) 
    * Improves performance
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
