### PR TITLE
Fix issue #1292 and add test case for the Assertion Error

### DIFF
--- a/spacy/tests/tokenizer/test_customized_tokenizer.py
+++ b/spacy/tests/tokenizer/test_customized_tokenizer.py
@@ -1,0 +1,46 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from ... import load
+from ...tokenizer import Tokenizer
+from ... import util
+
+import pytest
+
+
+def test_customized_tokenizer_handles_infixes():
+    def custom_tokenizer(nlp_model):
+        prefix_re = util.compile_prefix_regex(nlp_model.Defaults.prefixes)
+        suffix_re = util.compile_suffix_regex(nlp_model.Defaults.suffixes)
+        custom_infixes = ['\.\.\.+',
+                          '(?<=[0-9])-(?=[0-9])',
+                          # '(?<=[0-9]+),(?=[0-9]+)',
+                          '[0-9]+(,[0-9]+)+',
+                          u'[\[\]!&:,()\*—–\/-]']
+
+        infix_re = util.compile_infix_regex(custom_infixes)
+
+        # infix_re = re.compile(ur'[\[\]!&:,()]')
+
+        tokenizer = Tokenizer(nlp_model.vocab,
+                              nlp_model.Defaults.tokenizer_exceptions,
+                              prefix_re.search,
+                              suffix_re.search,
+                              infix_re.finditer,
+                              token_match=None)
+        return lambda text: tokenizer(text)
+
+    nlp = load('en', create_make_doc=custom_tokenizer)
+
+    sentence = "The 8 and 10-county definitions are not used for the greater Southern California Megaregion."
+    context = [word.text for word in nlp(sentence)]
+    assert context == [u'The', u'8', u'and', u'10', u'-', u'county', u'definitions', u'are', u'not', u'used',
+                       u'for',
+                       u'the', u'greater', u'Southern', u'California', u'Megaregion', u'.']
+
+    # the trailing '-' may cause Assertion Error
+    sentence = "The 8- and 10-county definitions are not used for the greater Southern California Megaregion."
+    context = [word.text for word in nlp(sentence)]
+    assert context == [u'The', u'8', u'-', u'and', u'10', u'-', u'county', u'definitions', u'are', u'not', u'used',
+                       u'for',
+                       u'the', u'greater', u'Southern', u'California', u'Megaregion', u'.']

--- a/spacy/tests/tokenizer/test_customized_tokenizer.py
+++ b/spacy/tests/tokenizer/test_customized_tokenizer.py
@@ -1,46 +1,40 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-from ... import load
+from ...lang.en import English
 from ...tokenizer import Tokenizer
 from ... import util
 
 import pytest
 
+@pytest.fixture
+def tokenizer(en_vocab):
+    prefix_re = util.compile_prefix_regex(nlp_model.Defaults.prefixes)
+    suffix_re = util.compile_suffix_regex(nlp_model.Defaults.suffixes)
+    custom_infixes = ['\.\.\.+',
+                      '(?<=[0-9])-(?=[0-9])',
+                      # '(?<=[0-9]+),(?=[0-9]+)',
+                      '[0-9]+(,[0-9]+)+',
+                      u'[\[\]!&:,()\*—–\/-]']
 
-def test_customized_tokenizer_handles_infixes():
-    def custom_tokenizer(nlp_model):
-        prefix_re = util.compile_prefix_regex(nlp_model.Defaults.prefixes)
-        suffix_re = util.compile_suffix_regex(nlp_model.Defaults.suffixes)
-        custom_infixes = ['\.\.\.+',
-                          '(?<=[0-9])-(?=[0-9])',
-                          # '(?<=[0-9]+),(?=[0-9]+)',
-                          '[0-9]+(,[0-9]+)+',
-                          u'[\[\]!&:,()\*—–\/-]']
+    infix_re = util.compile_infix_regex(custom_infixes)
+    return Tokenizer(en_vocab,
+                     English.Defaults.tokenizer_exceptions,
+                     prefix_re.search,
+                     suffix_re.search,
+                     infix_re.finditer,
+                     token_match=None)
 
-        infix_re = util.compile_infix_regex(custom_infixes)
-
-        # infix_re = re.compile(ur'[\[\]!&:,()]')
-
-        tokenizer = Tokenizer(nlp_model.vocab,
-                              nlp_model.Defaults.tokenizer_exceptions,
-                              prefix_re.search,
-                              suffix_re.search,
-                              infix_re.finditer,
-                              token_match=None)
-        return lambda text: tokenizer(text)
-
-    nlp = load('en', create_make_doc=custom_tokenizer)
-
+def test_customized_tokenizer_handles_infixes(tokenizer):
     sentence = "The 8 and 10-county definitions are not used for the greater Southern California Megaregion."
-    context = [word.text for word in nlp(sentence)]
+    context = [word.text for word in tokenizer(sentence)]
     assert context == [u'The', u'8', u'and', u'10', u'-', u'county', u'definitions', u'are', u'not', u'used',
                        u'for',
                        u'the', u'greater', u'Southern', u'California', u'Megaregion', u'.']
 
     # the trailing '-' may cause Assertion Error
     sentence = "The 8- and 10-county definitions are not used for the greater Southern California Megaregion."
-    context = [word.text for word in nlp(sentence)]
+    context = [word.text for word in tokenizer(sentence)]
     assert context == [u'The', u'8', u'-', u'and', u'10', u'-', u'county', u'definitions', u'are', u'not', u'used',
                        u'for',
                        u'the', u'greater', u'Southern', u'California', u'Megaregion', u'.']

--- a/spacy/tests/tokenizer/test_customized_tokenizer.py
+++ b/spacy/tests/tokenizer/test_customized_tokenizer.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-from ...lang.en import English
+from ...en import English
 from ...tokenizer import Tokenizer
 from ... import util
 

--- a/spacy/tokenizer.pyx
+++ b/spacy/tokenizer.pyx
@@ -312,7 +312,8 @@ cdef class Tokenizer:
 
                         start = infix_end
                     span = string[start:]
-                    tokens.push_back(self.vocab.get(tokens.mem, span), False)
+                    if span:
+                        tokens.push_back(self.vocab.get(tokens.mem, span), False)
         cdef vector[const LexemeC*].reverse_iterator it = suffixes.rbegin()
         while it != suffixes.rend():
             lexeme = deref(it)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title -->

## Description
<!--- Use this section to describe your changes and how they're affecting the code. -->
<!-- If your changes required testing, include information about the testing environment and the tests you ran. -->
Added a check to the span sub string before push back to the tokens, to avoid a null sub string which may cause Assertion Error.
Tested on python 2.7 with a Ubuntu16.04.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [x] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
