### PR TITLE
Make pipeline components independent

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,6 @@ install:
   - "%PYTHON%\\python.exe -m pip install wheel"
   - "%PYTHON%\\python.exe -m pip install cython"
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
-  - "%PYTHON%\\python.exe setup.py build_ext --inplace"
   - "%PYTHON%\\python.exe -m pip install -e ."
 
 build: off

--- a/spacy/_ml.py
+++ b/spacy/_ml.py
@@ -270,7 +270,7 @@ def Tok2Vec(width, embed_size, **kwargs):
         tok2vec = (
             FeatureExtracter(cols)
             >> with_flatten(
-                embed >> (convolution * 4), pad=4)
+                embed >> (convolution ** 4), pad=4)
         )
 
         # Work around thinc API limitations :(. TODO: Revise in Thinc 7

--- a/spacy/_ml.py
+++ b/spacy/_ml.py
@@ -475,14 +475,16 @@ def getitem(i):
     return layerize(getitem_fwd)
 
 
-def build_tagger_model(nr_class, token_vector_width, pretrained_dims=0, **cfg):
+def build_tagger_model(nr_class, pretrained_dims=0, **cfg):
     embed_size = util.env_opt('embed_size', 4000)
+    if 'token_vector_width' not in cfg:
+        token_vector_width = util.env_opt('token_vector_width', 128)
     with Model.define_operators({'>>': chain, '+': add}):
         tok2vec = Tok2Vec(token_vector_width, embed_size,
                           pretrained_dims=pretrained_dims)
-        model = with_flatten(
+        model = (
             tok2vec
-            >> Softmax(nr_class, token_vector_width)
+            >> with_flatten(Softmax(nr_class, token_vector_width))
         )
     model.nI = None
     model.tok2vec = tok2vec

--- a/spacy/_ml.py
+++ b/spacy/_ml.py
@@ -512,8 +512,11 @@ def build_tagger_model(nr_class, **cfg):
         token_vector_width = util.env_opt('token_vector_width', 128)
     pretrained_dims = cfg.get('pretrained_dims', 0)
     with Model.define_operators({'>>': chain, '+': add}):
-        tok2vec = Tok2Vec(token_vector_width, embed_size,
-                          pretrained_dims=pretrained_dims)
+        if 'tok2vec' in cfg:
+            tok2vec = cfg['tok2vec']
+        else:
+            tok2vec = Tok2Vec(token_vector_width, embed_size,
+                              pretrained_dims=pretrained_dims)
         model = (
             tok2vec
             >> with_flatten(Softmax(nr_class, token_vector_width))

--- a/spacy/about.py
+++ b/spacy/about.py
@@ -3,12 +3,13 @@
 # https://github.com/pypa/warehouse/blob/master/warehouse/__about__.py
 
 __title__ = 'spacy-nightly'
-__version__ = '2.0.0a14'
+__version__ = '2.0.0a15'
 __summary__ = 'Industrial-strength Natural Language Processing (NLP) with Python and Cython'
 __uri__ = 'https://spacy.io'
 __author__ = 'Explosion AI'
 __email__ = 'contact@explosion.ai'
 __license__ = 'MIT'
+__release__ = False
 
 __docs_models__ = 'https://spacy.io/docs/usage/models'
 __download_url__ = 'https://github.com/explosion/spacy-models/releases/download'

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -11,6 +11,8 @@ import tqdm
 from thinc.neural._classes.model import Model
 from thinc.neural.optimizers import linear_decay
 from timeit import default_timer as timer
+import random
+import numpy.random
 
 from ..tokens.doc import Doc
 from ..scorer import Scorer
@@ -20,6 +22,9 @@ from ..util import prints
 from .. import util
 from .. import displacy
 from ..compat import json_dumps
+
+random.seed(0)
+numpy.random.seed(0)
 
 
 @plac.annotations(

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -96,8 +96,7 @@ def train(cmd, lang, output_dir, train_data, dev_data, n_iter=20, n_sents=0,
                 for batch in minibatch(train_docs, size=batch_sizes):
                     docs, golds = zip(*batch)
                     nlp.update(docs, golds, sgd=optimizer,
-                               drop=next(dropout_rates), losses=losses,
-                               update_shared=True)
+                               drop=next(dropout_rates), losses=losses)
                     pbar.update(sum(len(doc) for doc in docs))
 
             with nlp.use_params(optimizer.averages):

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -55,7 +55,7 @@ def train(cmd, lang, output_dir, train_data, dev_data, n_iter=20, n_sents=0,
         prints(dev_path, title="Development data not found", exits=1)
 
 
-    pipeline = ['token_vectors', 'tags', 'dependencies', 'entities']
+    pipeline = ['tags', 'dependencies', 'entities']
     if no_tagger and 'tags' in pipeline: pipeline.remove('tags')
     if no_parser and 'dependencies' in pipeline: pipeline.remove('dependencies')
     if no_entities and 'entities' in pipeline: pipeline.remove('entities')

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -105,10 +105,10 @@ def train(cmd, lang, output_dir, train_data, dev_data, n_iter=20, n_sents=0,
                 nlp.to_disk(epoch_model_path)
                 nlp_loaded = lang_class(pipeline=pipeline)
                 nlp_loaded = nlp_loaded.from_disk(epoch_model_path)
-                scorer = nlp.evaluate(
-                            corpus.dev_docs(
-                                nlp,
-                                gold_preproc=gold_preproc))
+                scorer = nlp_loaded.evaluate(
+                            list(corpus.dev_docs(
+                                nlp_loaded,
+                                gold_preproc=gold_preproc)))
                 acc_loc =(output_path / ('model%d' % i) / 'accuracy.json')
                 with acc_loc.open('w') as file_:
                     file_.write(json_dumps(scorer.scores))

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -130,7 +130,6 @@ def train(cmd, lang, output_dir, train_data, dev_data, n_iter=20, n_sents=0,
 
                 with meta_loc.open('w') as file_:
                     file_.write(json_dumps(meta))
->>>>>>> origin/develop
                 util.set_env_log(True)
             print_progress(i, losses, scorer.scores)
     finally:

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -491,7 +491,6 @@ class Language(object):
         """
         path = util.ensure_path(path)
         serializers = OrderedDict((
-            ('vocab', lambda p: self.vocab.to_disk(p)),
             ('tokenizer', lambda p: self.tokenizer.to_disk(p, vocab=False)),
             ('meta.json', lambda p: p.open('w').write(json_dumps(self.meta)))
         ))
@@ -503,6 +502,7 @@ class Language(object):
             if not hasattr(proc, 'to_disk'):
                 continue
             serializers[proc.name] = lambda p, proc=proc: proc.to_disk(p, vocab=False)
+        serializers['vocab'] = lambda p: self.vocab.to_disk(p)
         util.to_disk(path, serializers, {p: False for p in disable})
 
     def from_disk(self, path, disable=tuple()):

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -279,8 +279,7 @@ class Language(object):
     def make_doc(self, text):
         return self.tokenizer(text)
 
-    def update(self, docs, golds, drop=0., sgd=None, losses=None,
-            update_shared=False):
+    def update(self, docs, golds, drop=0., sgd=None, losses=None):
         """Update the models in the pipeline.
 
         docs (iterable): A batch of `Doc` objects.

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -34,6 +34,7 @@ from .lang.tag_map import TAG_MAP
 from .lang.lex_attrs import LEX_ATTRS
 from . import util
 from .scorer import Scorer
+from ._ml import link_vectors_to_models
 
 
 class BaseDefaults(object):
@@ -370,6 +371,7 @@ class Language(object):
                     self.vocab.vectors.data)
         else:
             device = None
+        link_vectors_to_models(self.vocab)
         for proc in self.pipeline:
             if hasattr(proc, 'begin_training'):
                 context = proc.begin_training(get_gold_tuples(),

--- a/spacy/morphology.pyx
+++ b/spacy/morphology.pyx
@@ -146,6 +146,8 @@ cdef class Morphology:
                 self.add_special_case(tag_str, form_str, attrs)
 
     def lemmatize(self, const univ_pos_t univ_pos, attr_t orth, morphology):
+        if orth not in self.strings:
+            return orth
         cdef unicode py_string = self.strings[orth]
         if self.lemmatizer is None:
             return self.strings.add(py_string.lower())

--- a/spacy/pipeline.pyx
+++ b/spacy/pipeline.pyx
@@ -343,6 +343,7 @@ class NeuralTagger(BaseThincComponent):
 
         tag_scores, bp_tag_scores = self.model.begin_update(docs, drop=drop)
         loss, d_tag_scores = self.get_loss(docs, golds, tag_scores)
+        bp_tag_scores(d_tag_scores, sgd=sgd)
 
         if losses is not None:
             losses[self.name] += loss
@@ -386,15 +387,13 @@ class NeuralTagger(BaseThincComponent):
             vocab.morphology = Morphology(vocab.strings, new_tag_map,
                                           vocab.morphology.lemmatizer,
                                           exc=vocab.morphology.exc)
-        token_vector_width = pipeline[0].model.nO
         if self.model is True:
-            self.model = self.Model(self.vocab.morphology.n_tags, token_vector_width,
+            self.model = self.Model(self.vocab.morphology.n_tags,
                                     pretrained_dims=self.vocab.vectors_length)
 
     @classmethod
-    def Model(cls, n_tags, token_vector_width, pretrained_dims=0, **cfg):
-        return build_tagger_model(n_tags, token_vector_width,
-                                  pretrained_dims, **cfg)
+    def Model(cls, n_tags, **cfg):
+        return build_tagger_model(n_tags, **cfg)
 
     def use_params(self, params):
         with self.model.use_params(params):

--- a/spacy/pipeline.pyx
+++ b/spacy/pipeline.pyx
@@ -145,7 +145,7 @@ class BaseThincComponent(object):
 
         deserialize = OrderedDict((
             ('cfg', lambda b: self.cfg.update(ujson.loads(b))),
-            ('vocab', lambda b: self.vocab.from_bytes(b))
+            ('vocab', lambda b: self.vocab.from_bytes(b)),
             ('model', load_model),
         ))
         util.from_bytes(bytes_data, deserialize, exclude)

--- a/spacy/pipeline.pyx
+++ b/spacy/pipeline.pyx
@@ -747,7 +747,7 @@ cdef class NeuralDependencyParser(NeuralParser):
     TransitionSystem = ArcEager
 
     def init_multitask_objectives(self, gold_tuples, pipeline, **cfg):
-        for target in ['dep']:
+        for target in ['dep', 'ent']:
             labeller = NeuralLabeller(self.vocab, target=target)
             tok2vec = self.model[0]
             labeller.begin_training(gold_tuples, pipeline=pipeline, tok2vec=tok2vec)

--- a/spacy/pipeline.pyx
+++ b/spacy/pipeline.pyx
@@ -291,7 +291,7 @@ class TokenVectorEncoder(BaseThincComponent):
         if self.model is True:
             self.cfg['pretrained_dims'] = self.vocab.vectors_length
             self.model = self.Model(**self.cfg)
-            link_vectors_to_models(self.vocab)
+        link_vectors_to_models(self.vocab)
 
 
 class NeuralTagger(BaseThincComponent):
@@ -395,7 +395,7 @@ class NeuralTagger(BaseThincComponent):
         if self.model is True:
             self.cfg['pretrained_dims'] = self.vocab.vectors.data.shape[1]
             self.model = self.Model(self.vocab.morphology.n_tags, **self.cfg)
-            link_vectors_to_models(self.vocab)
+        link_vectors_to_models(self.vocab)
 
     @classmethod
     def Model(cls, n_tags, **cfg):
@@ -477,9 +477,25 @@ class NeuralTagger(BaseThincComponent):
 
 class NeuralLabeller(NeuralTagger):
     name = 'nn_labeller'
-    def __init__(self, vocab, model=True, **cfg):
+    def __init__(self, vocab, model=True, target='dep_tag_offset', **cfg):
         self.vocab = vocab
         self.model = model
+        if target == 'dep':
+            self.make_label = self.make_dep
+        elif target == 'tag':
+            self.make_label = self.make_tag
+        elif target == 'ent':
+            self.make_label = self.make_ent
+        elif target == 'dep_tag_offset':
+            self.make_label = self.make_dep_tag_offset
+        elif target == 'ent_tag':
+            self.make_label = self.make_ent_tag
+        elif hasattr(target, '__call__'):
+            self.make_label = target
+        else:
+            raise ValueError(
+                "NeuralLabeller target should be function or one of "
+                "['dep', 'tag', 'ent', 'dep_tag_offset', 'ent_tag']")
         self.cfg = dict(cfg)
         self.cfg.setdefault('cnn_maxout_pieces', 2)
         self.cfg.setdefault('pretrained_dims', self.vocab.vectors.data.shape[1])
@@ -495,42 +511,77 @@ class NeuralLabeller(NeuralTagger):
     def set_annotations(self, docs, dep_ids):
         pass
 
-    def begin_training(self, gold_tuples=tuple(), pipeline=None):
+    def begin_training(self, gold_tuples=tuple(), pipeline=None, tok2vec=None):
         gold_tuples = nonproj.preprocess_training_data(gold_tuples)
         for raw_text, annots_brackets in gold_tuples:
             for annots, brackets in annots_brackets:
                 ids, words, tags, heads, deps, ents = annots
-                for dep in deps:
-                    if dep not in self.labels:
-                        self.labels[dep] = len(self.labels)
-        token_vector_width = pipeline[0].model.nO
+                for i in range(len(ids)):
+                    label = self.make_label(i, words, tags, heads, deps, ents)
+                    if label is not None and label not in self.labels:
+                        self.labels[label] = len(self.labels)
+        print(len(self.labels))
         if self.model is True:
-            self.cfg['pretrained_dims'] = self.vocab.vectors.data.shape[1]
-            self.model = self.Model(len(self.labels), **self.cfg)
-            link_vectors_to_models(self.vocab)
+            self.model = chain(
+                tok2vec,
+                Softmax(len(self.labels), 128)
+            )
+        link_vectors_to_models(self.vocab)
 
     @classmethod
-    def Model(cls, n_tags, **cfg):
-        return build_tagger_model(n_tags, **cfg)
+    def Model(cls, n_tags, tok2vec=None, **cfg):
+        return build_tagger_model(n_tags, tok2vec=tok2vec, **cfg)
 
     def get_loss(self, docs, golds, scores):
-        scores = self.model.ops.flatten(scores)
         cdef int idx = 0
         correct = numpy.zeros((scores.shape[0],), dtype='i')
         guesses = scores.argmax(axis=1)
         for gold in golds:
-            for tag in gold.labels:
-                if tag is None or tag not in self.labels:
+            for i in range(len(gold.labels)):
+                label = self.make_label(i, gold.words, gold.tags, gold.heads,
+                                        gold.labels, gold.ents)
+                if label is None or label not in self.labels:
                     correct[idx] = guesses[idx]
                 else:
-                    correct[idx] = self.labels[tag]
+                    correct[idx] = self.labels[label]
                 idx += 1
         correct = self.model.ops.xp.array(correct, dtype='i')
         d_scores = scores - to_categorical(correct, nb_classes=scores.shape[1])
         d_scores /= d_scores.shape[0]
         loss = (d_scores**2).sum()
-        d_scores = self.model.ops.unflatten(d_scores, [len(d) for d in docs])
         return float(loss), d_scores
+
+    @staticmethod
+    def make_dep(i, words, tags, heads, deps, ents):
+        if deps[i] is None or heads[i] is None:
+            return None
+        return deps[i]
+
+    @staticmethod
+    def make_tag(i, words, tags, heads, deps, ents):
+        return tags[i]
+
+    @staticmethod
+    def make_ent(i, words, tags, heads, deps, ents):
+        if ents is None:
+            return None
+        return ents[i]
+
+    @staticmethod
+    def make_dep_tag_offset(i, words, tags, heads, deps, ents):
+        if deps[i] is None or heads[i] is None:
+            return None
+        offset = heads[i] - i
+        offset = min(offset, 2)
+        offset = max(offset, -2)
+        return '%s-%s:%d' % (deps[i], tags[i], offset)
+
+    @staticmethod
+    def make_ent_tag(i, words, tags, heads, deps, ents):
+        if ents is None or ents[i] is None:
+            return None
+        else:
+            return '%s-%s' % (tags[i], ents[i])
 
 
 class SimilarityHook(BaseThincComponent):
@@ -695,6 +746,14 @@ cdef class NeuralDependencyParser(NeuralParser):
     name = 'parser'
     TransitionSystem = ArcEager
 
+    def init_multitask_objectives(self, gold_tuples, pipeline, **cfg):
+        for target in ['dep']:
+            labeller = NeuralLabeller(self.vocab, target=target)
+            tok2vec = self.model[0]
+            labeller.begin_training(gold_tuples, pipeline=pipeline, tok2vec=tok2vec)
+            pipeline.append(labeller)
+            self._multitasks.append(labeller)
+
     def __reduce__(self):
         return (NeuralDependencyParser, (self.vocab, self.moves, self.model), None, None)
 
@@ -705,13 +764,13 @@ cdef class NeuralEntityRecognizer(NeuralParser):
 
     nr_feature = 6
 
-    def predict_confidences(self, docs):
-        tensors = [d.tensor for d in docs]
-        samples = []
-        for i in range(10):
-            states = self.parse_batch(docs, tensors, drop=0.3)
-            for state in states:
-                samples.append(self._get_entities(state))
+    def init_multitask_objectives(self, gold_tuples, pipeline, **cfg):
+        for target in []:
+            labeller = NeuralLabeller(self.vocab, target=target)
+            tok2vec = self.model[0]
+            labeller.begin_training(gold_tuples, pipeline=pipeline, tok2vec=tok2vec)
+            pipeline.append(labeller)
+            self._multitasks.append(labeller)
 
     def __reduce__(self):
         return (NeuralEntityRecognizer, (self.vocab, self.moves, self.model), None, None)

--- a/spacy/syntax/_beam_utils.pyx
+++ b/spacy/syntax/_beam_utils.pyx
@@ -147,10 +147,10 @@ def get_token_ids(states, int n_tokens):
 
 nr_update = 0
 def update_beam(TransitionSystem moves, int nr_feature, int max_steps,
-                states, tokvecs, golds,
+                states, golds,
                 state2vec, vec2scores, 
                 int width, float density,
-                sgd=None, losses=None, drop=0.):
+                losses=None, drop=0.):
     global nr_update
     cdef MaxViolation violn
     nr_update += 1

--- a/spacy/syntax/nn_parser.pxd
+++ b/spacy/syntax/nn_parser.pxd
@@ -13,6 +13,7 @@ cdef class Parser:
     cdef public object model
     cdef readonly TransitionSystem moves
     cdef readonly object cfg
+    cdef public object _multitasks
 
     cdef void _parse_step(self, StateC* state,
             const float* feat_weights,

--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -7,6 +7,7 @@ from __future__ import unicode_literals, print_function
 
 from collections import Counter, OrderedDict
 import ujson
+import json
 import contextlib
 
 from libc.math cimport exp
@@ -829,7 +830,7 @@ cdef class Parser:
             ('upper_model', lambda: self.model[2].to_bytes()),
             ('vocab', lambda: self.vocab.to_bytes()),
             ('moves', lambda: self.moves.to_bytes(strings=False)),
-            ('cfg', lambda: ujson.dumps(self.cfg))
+            ('cfg', lambda: json.dumps(self.cfg, indent=2, sort_keys=True))
         ))
         if 'model' in exclude:
             exclude['tok2vec_model'] = True
@@ -842,7 +843,7 @@ cdef class Parser:
         deserializers = OrderedDict((
             ('vocab', lambda b: self.vocab.from_bytes(b)),
             ('moves', lambda b: self.moves.from_bytes(b, strings=False)),
-            ('cfg', lambda b: self.cfg.update(ujson.loads(b))),
+            ('cfg', lambda b: self.cfg.update(json.loads(b))),
             ('tok2vec_model', lambda b: None),
             ('lower_model', lambda b: None),
             ('upper_model', lambda b: None)

--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -370,6 +370,7 @@ cdef class Parser:
             docs = list(docs)
             if beam_width == 1:
                 parse_states = self.parse_batch(docs)
+                beams = []
             else:
                 beams = self.beam_parse(docs,
                             beam_width=beam_width, beam_density=beam_density)

--- a/spacy/tests/parser/test_neural_parser.py
+++ b/spacy/tests/parser/test_neural_parser.py
@@ -61,33 +61,22 @@ def test_predict_doc(parser, tok2vec, model, doc):
     parser(doc)
 
 
-def test_update_doc(parser, tok2vec, model, doc, gold):
+def test_update_doc(parser, model, doc, gold):
     parser.model = model
-    tokvecs, bp_tokvecs = tok2vec.begin_update([doc])
-    d_tokvecs = parser.update(([doc], tokvecs), [gold])
-    assert d_tokvecs[0].shape == tokvecs[0].shape
     def optimize(weights, gradient, key=None):
         weights -= 0.001 * gradient
-    bp_tokvecs(d_tokvecs, sgd=optimize)
-    assert d_tokvecs[0].sum() == 0.
+    parser.update([doc], [gold], sgd=optimize)
 
 
-def test_predict_doc_beam(parser, tok2vec, model, doc):
-    doc.tensor = tok2vec([doc])[0]
+def test_predict_doc_beam(parser, model, doc):
     parser.model = model
     parser(doc, beam_width=32, beam_density=0.001)
-    for word in doc:
-        print(word.text, word.head, word.dep_)
 
 
-def test_update_doc_beam(parser, tok2vec, model, doc, gold):
+def test_update_doc_beam(parser, model, doc, gold):
     parser.model = model
-    tokvecs, bp_tokvecs = tok2vec.begin_update([doc])
-    d_tokvecs = parser.update_beam(([doc], tokvecs), [gold])
-    assert d_tokvecs[0].shape == tokvecs[0].shape
     def optimize(weights, gradient, key=None):
         weights -= 0.001 * gradient
-    bp_tokvecs(d_tokvecs, sgd=optimize)
-    assert d_tokvecs[0].sum() == 0.
+    parser.update_beam([doc], [gold], sgd=optimize)
 
 

--- a/spacy/tests/serialize/test_serialize_tagger.py
+++ b/spacy/tests/serialize/test_serialize_tagger.py
@@ -11,7 +11,7 @@ import pytest
 def taggers(en_vocab):
     tagger1 = Tagger(en_vocab)
     tagger2 = Tagger(en_vocab)
-    tagger1.model = tagger1.Model(8, 8)
+    tagger1.model = tagger1.Model(8)
     tagger2.model = tagger1.model
     return (tagger1, tagger2)
 

--- a/spacy/tokens/doc.pxd
+++ b/spacy/tokens/doc.pxd
@@ -54,7 +54,7 @@ cdef class Doc:
 
     cdef public object noun_chunks_iterator
 
-    cdef int push_back(self, LexemeOrToken lex_or_tok, bint trailing_space) except -1
+    cdef int push_back(self, LexemeOrToken lex_or_tok, bint has_space) except -1
 
     cpdef np.ndarray to_array(self, object features)
 

--- a/spacy/vocab.pyx
+++ b/spacy/vocab.pyx
@@ -324,7 +324,6 @@ cdef class Vocab:
             self.lexemes_from_bytes(file_.read())
         if self.vectors is not None:
             self.vectors.from_disk(path, exclude='strings.json')
-        link_vectors_to_models(self)
         return self
 
     def to_bytes(self, **exclude):
@@ -364,7 +363,6 @@ cdef class Vocab:
             ('vectors', lambda b: serialize_vectors(b))
         ))
         util.from_bytes(bytes_data, setters, exclude)
-        link_vectors_to_models(self)
         return self
 
     def lexemes_to_bytes(self):

--- a/travis.sh
+++ b/travis.sh
@@ -17,6 +17,7 @@ fi
 
 if [ "${VIA}" == "compile" ]; then
   pip install -r requirements.txt
+  export PYTHONPATH=`pwd`
   python setup.py build_ext --inplace
   pip install -e .
 fi


### PR DESCRIPTION
This patch-set makes the models in the default spaCy pipeline independent of each other, removing the shared multi-task CNN. We still want to set a `doc.tensor` attribute, which we could do from combining the tensor assigned by the different models.

There are a few reasons I want to experiment with this. First, the multi-task CNN makes training rather more fiddly, as we have to select an epoch where *all* of the models are doing well. Without the multi-tasking, the parser, NER and tagger could all be trained on different devices, which would also be a nice time-saving.

The more important reason is that the shared CNN has proven to be a serious usability problem. Updating the model becomes very inconvenient, and it's hard to mix-and-match different pipeline components.

I expect the single-task training will probably do roughly as well as the multi-task training, based on results in the literature. But even if multi-task is an advantage for training, we can simply give each component its own copy of the weights after training.