### PR TITLE
Fixed NER model loading bug

### DIFF
--- a/spacy/syntax/parser.pyx
+++ b/spacy/syntax/parser.pyx
@@ -147,6 +147,9 @@ cdef class Parser:
         # TODO: remove this shim when we don't have to support older data
         if 'labels' in cfg and 'actions' not in cfg:
             cfg['actions'] = cfg.pop('labels')
+        # Convert string keys to int
+        if cfg.get('actions'):
+            cfg['actions'] = {int(action_name): labels for action_name, labels in cfg['actions'].items()}
         # TODO: remove this shim when we don't have to support older data
         for action_name, labels in dict(cfg.get('actions', {})).items():
             # We need this to be sorted


### PR DESCRIPTION
Fix for the bug #1174.

## Description
Simple fix for the bug #1174 due to JSON keys being loaded from the configuration file as strings instead of integers.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [x] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
