### PR TITLE
Fixing links to SyntaxNet

### DIFF
--- a/website/docs/api/index.jade
+++ b/website/docs/api/index.jade
@@ -6,7 +6,7 @@ include ../../_includes/_mixins
 
 p
     |  Here's a quick comparison of the functionalities offered by spaCy,
-    |  #[+a("https://github.com/tensorflow/models/tree/master/syntaxnet") SyntaxNet],
+    |  #[+a("https://github.com/tensorflow/models/tree/master/research/syntaxnet") SyntaxNet],
     |  #[+a("http://www.nltk.org/py-modindex.html") NLTK] and
     |  #[+a("http://stanfordnlp.github.io/CoreNLP/") CoreNLP].
 
@@ -107,7 +107,7 @@ p
 
 p
     |  In 2016, Google released their
-    |  #[+a("https://github.com/tensorflow/models/tree/master/syntaxnet") SyntaxNet]
+    |  #[+a("https://github.com/tensorflow/models/tree/master/research/syntaxnet") SyntaxNet]
     |  library, setting a new state of the art for syntactic dependency parsing
     |  accuracy. SyntaxNet's algorithm is very similar to spaCy's. The main
     |  difference is that SyntaxNet uses a neural network while spaCy uses a
@@ -129,7 +129,7 @@ p
             +cell=data
 
     +row
-        +cell #[+a("https://github.com/tensorflow/models/tree/master/syntaxnet") Parsey McParseface]
+        +cell #[+a("https://github.com/tensorflow/models/tree/master/research/syntaxnet") Parsey McParseface]
         each data in [ 94.15, 89.08, 94.77 ]
             +cell=data
 


### PR DESCRIPTION
## Description
Links to SyntaxNet are broken as the models moved to a subdirectory in Google's repo (see their changelog for similar fixes to links)

## Types of changes
Changed URLs

## Checklist:
N/A