### PR TITLE
💫 Allow labels to be added to pre-trained parser and NER modes

### DIFF
--- a/spacy/_ml.py
+++ b/spacy/_ml.py
@@ -743,5 +743,3 @@ def concatenate_lists(*layers, **kwargs): # pragma: no cover
         return ys, concatenate_lists_bwd
     model = wrap(concatenate_lists_fwd, concat)
     return model
-
-

--- a/spacy/tests/parser/test_add_label.py
+++ b/spacy/tests/parser/test_add_label.py
@@ -1,0 +1,68 @@
+'''Test the ability to add a label to a (potentially trained) parsing model.'''
+from __future__ import unicode_literals
+import pytest
+import numpy.random
+from thinc.neural.optimizers import Adam
+from thinc.neural.ops import NumpyOps
+
+from ...attrs import NORM
+from ...gold import GoldParse
+from ...vocab import Vocab
+from ...tokens import Doc
+from ...pipeline import NeuralDependencyParser
+
+numpy.random.seed(0)
+
+
+@pytest.fixture
+def vocab():
+    return Vocab(lex_attr_getters={NORM: lambda s: s})
+
+
+@pytest.fixture
+def parser(vocab):
+    parser = NeuralDependencyParser(vocab)
+    parser.cfg['token_vector_width'] = 4
+    parser.cfg['hidden_width'] = 6
+    parser.cfg['hist_size'] = 0
+    parser.add_label('left')
+    parser.begin_training([], **parser.cfg)
+    sgd = Adam(NumpyOps(), 0.001)
+
+    for i in range(30):
+        losses = {}
+        doc = Doc(vocab, words=['a', 'b', 'c', 'd'])
+        gold = GoldParse(doc, heads=[1, 1, 3, 3],
+                deps=['left', 'ROOT', 'left', 'ROOT'])
+        parser.update([doc], [gold], sgd=sgd, losses=losses)
+    return parser
+
+
+def test_add_label(parser):
+    doc = Doc(parser.vocab, words=['a', 'b', 'c', 'd'])
+    doc = parser(doc)
+    assert doc[0].head.i == 1
+    assert doc[0].dep_ == 'left'
+    assert doc[1].head.i == 1
+    assert doc[2].head.i == 3
+    assert doc[2].head.i == 3
+    parser.add_label('right')
+    doc = Doc(parser.vocab, words=['a', 'b', 'c', 'd'])
+    doc = parser(doc)
+    assert doc[0].head.i == 1
+    assert doc[0].dep_ == 'left'
+    assert doc[1].head.i == 1
+    assert doc[2].head.i == 3
+    assert doc[2].head.i == 3
+    sgd = Adam(NumpyOps(), 0.001)
+    for i in range(10):
+        losses = {}
+        doc = Doc(parser.vocab, words=['a', 'b', 'c', 'd'])
+        gold = GoldParse(doc, heads=[1, 1, 3, 3],
+                deps=['right', 'ROOT', 'left', 'ROOT'])
+        parser.update([doc], [gold], sgd=sgd, losses=losses)
+    doc = Doc(parser.vocab, words=['a', 'b', 'c', 'd'])
+    doc = parser(doc)
+    assert doc[0].dep_ == 'right'
+    assert doc[2].dep_ == 'left'
+ 


### PR DESCRIPTION
This patch allows v2 models to add labels to pre-trained parsing and NER models. This functionality was available in v1 (albeit flakily), but was missing in v2, because there's not really a clean way to resize Thinc models.

The solution here is simply to drop in a replacement for the output layer, copying the sections of weights from the previous one. This seems a bit more robust than trying to fiddle with the internal weights representations.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [x] **Bug fix** (non-breaking change fixing an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
