### PR TITLE
Bugfix example script train_ner_standalone.py, fails after training

### DIFF
--- a/examples/training/train_ner_standalone.py
+++ b/examples/training/train_ner_standalone.py
@@ -6,7 +6,7 @@ To achieve that, it duplicates some of spaCy's internal functionality.
 
 Specifically, in this example, we don't use spaCy's built-in Language class to
 wire together the Vocab, Tokenizer and EntityRecognizer. Instead, we write
-our own simle Pipeline class, so that it's easier to see how the pieces
+our own simple Pipeline class, so that it's easier to see how the pieces
 interact.
 
 Input data:
@@ -149,7 +149,8 @@ def report_scores(i, loss, scores):
     precision = '%.2f' % scores['ents_p']
     recall = '%.2f' % scores['ents_r']
     f_measure = '%.2f' % scores['ents_f']
-    print('Epoch %d: %d %s %s %s' % (i, int(loss), precision, recall, f_measure))
+    print('Epoch %d: %d %s %s %s' % (
+        i, int(loss), precision, recall, f_measure))
 
 
 def read_examples(path):

--- a/examples/training/train_ner_standalone.py
+++ b/examples/training/train_ner_standalone.py
@@ -142,16 +142,14 @@ def train(nlp, train_examples, dev_examples, nr_epoch=5):
             inputs, annots = zip(*batch)
             nlp.update(list(inputs), list(annots), sgd, losses=losses)
         scores = nlp.evaluate(dev_examples)
-        report_scores(i, losses['ner'], scores)
-    scores = nlp.evaluate(dev_examples)
-    report_scores(channels, i+1, loss, scores)
+        report_scores(i+1, losses['ner'], scores)
 
 
 def report_scores(i, loss, scores):
     precision = '%.2f' % scores['ents_p']
     recall = '%.2f' % scores['ents_r']
     f_measure = '%.2f' % scores['ents_f']
-    print('%d %s %s %s' % (int(loss), precision, recall, f_measure))
+    print('Epoch %d: %d %s %s %s' % (i, int(loss), precision, recall, f_measure))
 
 
 def read_examples(path):


### PR DESCRIPTION
## Description
Legacy example code uses unused variables `channels` and `loss`, and it printed final epoch's scores twice.  Here I remove the final scoring that included the offending undefined variable names. 

This PR is against the `develop` branch; not sure if I'm following the correct branching strategy for development against 2 alpha.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [x] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [ ] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
