### PR TITLE
💫 Fix streaming data memory growth (!!)

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -526,7 +526,7 @@ class Language(object):
             for word in doc:
                 recent_strings.add(word.text)
             recent_refs.add(doc)
-            if nr_seen < 1000:
+            if nr_seen < 10000:
                 old_refs.add(doc)
                 nr_seen += 1
             elif len(old_refs) == 0:

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -8,6 +8,7 @@ import random
 import ujson
 from collections import OrderedDict
 import itertools
+import weakref
 
 from .tokenizer import Tokenizer
 from .vocab import Vocab
@@ -510,8 +511,33 @@ class Language(object):
             else:
                 # Apply the function, but yield the doc
                 docs = _pipe(proc, docs)
+        # Track weakrefs of "recent" documents, so that we can see when they
+        # expire from memory. When they do, we know we don't need old strings.
+        # This way, we avoid maintaining an unbounded growth in string entries
+        # in the string store.
+        recent_refs = weakref.WeakSet()
+        old_refs = weakref.WeakSet()
+        original_strings_data = self.vocab.strings.to_bytes()
+        StringStore = self.vocab.strings.__class__
+        recent_strings = StringStore().from_bytes(original_strings_data)
+        nr_seen = 0
         for doc in docs:
             yield doc
+            for word in doc:
+                recent_strings.add(word.text)
+            recent_refs.add(doc)
+            if nr_seen < 1000:
+                old_refs.add(doc)
+                nr_seen += 1
+            elif len(old_refs) == 0:
+                # All the docs in the 'old' set have expired, so the only
+                # difference between the backup strings and the current
+                # string-store should be obsolete. We therefore swap out the
+                # old strings data.
+                old_refs, recent_refs = recent_refs, old_refs
+                self.vocab.strings._reset_and_load(recent_strings)
+                recent_strings = StringStore().from_bytes(original_strings_data)
+                nr_seen = 0
 
     def to_disk(self, path, disable=tuple()):
         """Save the current state to a directory.  If a model is loaded, this

--- a/spacy/strings.pxd
+++ b/spacy/strings.pxd
@@ -21,11 +21,9 @@ ctypedef union Utf8Str:
 
 cdef class StringStore:
     cdef Pool mem
-    cdef bint is_frozen
 
     cdef vector[hash_t] keys
     cdef public PreshMap _map
-    cdef public PreshMap _oov
 
     cdef const Utf8Str* intern_unicode(self, unicode py_string)
     cdef const Utf8Str* _intern_utf8(self, char* utf8_string, int length)

--- a/spacy/strings.pyx
+++ b/spacy/strings.pyx
@@ -261,10 +261,6 @@ cdef class StringStore:
         cdef Utf8Str* value = <Utf8Str*>self._map.get(key)
         if value is not NULL:
             return value
-        value = <Utf8Str*>self._oov.get(key)
-        if value is not NULL:
-            return value
-
         value = _allocate(self.mem, <unsigned char*>utf8_string, length)
         self._map.set(key, value)
         self.keys.push_back(key)

--- a/spacy/strings.pyx
+++ b/spacy/strings.pyx
@@ -86,8 +86,6 @@ cdef class StringStore:
         """
         self.mem = Pool()
         self._map = PreshMap()
-        self._oov = PreshMap()
-        self.is_frozen = freeze
         if strings is not None:
             for string in strings:
                 self.add(string)
@@ -243,21 +241,12 @@ cdef class StringStore:
             self.add(word)
         return self
 
-    def set_frozen(self, bint is_frozen):
-        # TODO
-        self.is_frozen = is_frozen
-
-    def flush_oov(self):
-        self._oov = PreshMap()
-
-    def _reset_and_load(self, strings, freeze=False):
+    def _reset_and_load(self, strings):
         self.mem = Pool()
         self._map = PreshMap()
-        self._oov = PreshMap()
         self.keys.clear()
         for string in strings:
             self.add(string)
-        self.is_frozen = freeze
 
     cdef const Utf8Str* intern_unicode(self, unicode py_string):
         # 0 means missing, but we don't bother offsetting the index.
@@ -275,14 +264,6 @@ cdef class StringStore:
         value = <Utf8Str*>self._oov.get(key)
         if value is not NULL:
             return value
-        if self.is_frozen:
-            # OOV store uses 32 bit hashes. Pretty ugly :(
-            key32 = hash32_utf8(utf8_string, length)
-            # Important: Make the OOV store own the memory. That way it's trivial
-            # to flush them all.
-            value = _allocate(self._oov.mem, <unsigned char*>utf8_string, length)
-            self._oov.set(key32, value)
-            return NULL
 
         value = _allocate(self.mem, <unsigned char*>utf8_string, length)
         self._map.set(key, value)

--- a/spacy/tests/parser/test_parse_navigate.py
+++ b/spacy/tests/parser/test_parse_navigate.py
@@ -57,9 +57,9 @@ def test_parser_parse_navigate_consistency(en_tokenizer, text, heads):
     doc = get_doc(tokens.vocab, [t.text for t in tokens], heads=heads)
     for head in doc:
         for child in head.lefts:
-            assert child.head is head
+            assert child.head == head
         for child in head.rights:
-            assert child.head is head
+            assert child.head == head
 
 
 def test_parser_parse_navigate_child_consistency(en_tokenizer, text, heads):

--- a/spacy/tokens/doc.pxd
+++ b/spacy/tokens/doc.pxd
@@ -54,6 +54,8 @@ cdef class Doc:
 
     cdef public object noun_chunks_iterator
 
+    cdef object __weakref__
+
     cdef int push_back(self, LexemeOrToken lex_or_tok, bint has_space) except -1
 
     cpdef np.ndarray to_array(self, object features)

--- a/spacy/tokens/token.pxd
+++ b/spacy/tokens/token.pxd
@@ -19,10 +19,7 @@ cdef class Token:
         if offset < 0 or offset >= doc.length:
             msg = "Attempt to access token at %d, max length %d"
             raise IndexError(msg % (offset, doc.length))
-        if doc._py_tokens[offset] != None:
-            return doc._py_tokens[offset]
         cdef Token self = Token.__new__(Token, vocab, doc, offset)
-        doc._py_tokens[offset] = self
         return self
 
     #cdef inline TokenC struct_from_attrs(Vocab vocab, attrs):


### PR DESCRIPTION
This patch follows through on the changes to the StringStore introduced in v2, and fixes by far the longest open bug: #285 Streaming Data Memory Growth

The solution implemented allows a weakref to be created on `Doc` objects, so that we can figure out when it's safe to flush out old strings. A rolling buffer is created using two StringStore objects. One StringStore contains the set of original strings and strings from recent documents. The other string store is the one current on the Vocab object. The only difference between the two `StringStore` objects are in strings created by increasingly old documents. Once we figure out that all of those old documents have passed out of scope and been reference counted, we figure it's safe to flush the obsolete strings.

This logic is only applied in the `Language.pipe()` method, and requires no API changes. However, it does require breaking the former 2-cycle between the `Doc` and `Token` objects, that had been created by caching the `Token` instances within the `Doc`. I think breaking this cycle is a Good Thing, independent of the `StringStore` changes. We don't need to cache those objects --- almost nothing is done in `Token.__init__`, so there should be no problem with recreating the object. If we like, we could use a weakref on `Token`, but it's simpler to just not cache.

The resolution was checked with this script, to verify the string store does not grow as data streams through:

```python
from __future__ import unicode_literals
import spacy
import numpy.random

def generate_strings():
    while True:
        yield str(numpy.random.random())

def main():
    nlp = spacy.blank('xx')
    nlp.tokenizer.infix_finditer = None
    for i, doc in enumerate(nlp.pipe(generate_strings())):
        if not i % 1000:
            print(i, len(nlp.vocab.strings))

if __name__ == '__main__':
    main()
```

- [x] **Bug fix** (non-breaking change fixing an issue)

## Checklist:

- [ ] My change requires a change to spaCy's documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
