### PR TITLE
💫 Improve runtime CPU efficiency of parser/NER

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ MOD_NAMES = [
 COMPILE_OPTIONS =  {
     'msvc': ['/Ox', '/EHsc'],
     'mingw32' : ['-O3', '-Wno-strict-prototypes', '-Wno-unused-function'],
-    'other' : ['-O3', '-Wno-strict-prototypes', '-Wno-unused-function']
+    'other' : ['-O3', '-Wno-strict-prototypes', '-Wno-unused-function',
+               '-march=native']
 }
 
 

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -10,6 +10,7 @@ from collections import OrderedDict
 import itertools
 import weakref
 import functools
+import tqdm
 
 from .tokenizer import Tokenizer
 from .vocab import Vocab
@@ -447,11 +448,9 @@ class Language(object):
         golds = list(golds)
         for name, pipe in self.pipeline:
             if not hasattr(pipe, 'pipe'):
-                for doc in docs:
-                    pipe(doc)
+                docs = (pipe(doc) for doc in docs)
             else:
-                docs = list(pipe.pipe(docs))
-        assert len(docs) == len(golds)
+                docs = pipe.pipe(docs, batch_size=256)
         for doc, gold in zip(docs, golds):
             if verbose:
                 print(doc)

--- a/spacy/syntax/nn_parser.pxd
+++ b/spacy/syntax/nn_parser.pxd
@@ -15,8 +15,6 @@ cdef class Parser:
     cdef readonly object cfg
     cdef public object _multitasks
 
-    cdef void _parse_step(self, StateC* state,
+    cdef void _parseC(self, StateC* state, 
             const float* feat_weights, const float* hW, const float* hb,
             int nr_class, int nr_hidden, int nr_feat, int nr_piece) nogil
-
-    #cdef int parseC(self, TokenC* tokens, int length, int nr_feat) nogil

--- a/spacy/syntax/nn_parser.pxd
+++ b/spacy/syntax/nn_parser.pxd
@@ -16,7 +16,7 @@ cdef class Parser:
     cdef public object _multitasks
 
     cdef void _parse_step(self, StateC* state,
-            const float* feat_weights,
-            int nr_class, int nr_feat, int nr_piece) nogil
+            const float* feat_weights, const float* hW, const float* hb,
+            int nr_class, int nr_hidden, int nr_feat, int nr_piece) nogil
 
     #cdef int parseC(self, TokenC* tokens, int length, int nr_feat) nogil

--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -289,8 +289,6 @@ cdef class Parser:
                     zero_init(Affine(nr_class, hidden_width, drop_factor=0.0))
                 )
                 upper.is_noop = False
-                print(upper._layers)
-                print(upper._layers[0]._layers)
 
         # TODO: This is an unfortunate hack atm!
         # Used to set input dimensions in network.

--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -422,9 +422,9 @@ cdef class Parser:
         hW = <float*>hidden_weights.data
         hb = <float*>hidden_bias.data
         cdef int nr_hidden = hidden_weights.shape[0]
-       
+        cdef int nr_task = states.size()
         with nogil:
-            for i in cython.parallel.prange(states.size(), num_threads=2,
+            for i in cython.parallel.prange(nr_task, num_threads=2,
                                             schedule='guided'):
                 self._parseC(states[i],
                     feat_weights, hW, hb,

--- a/spacy/syntax/transition_system.pyx
+++ b/spacy/syntax/transition_system.pyx
@@ -148,7 +148,8 @@ cdef class TransitionSystem:
 
     def add_action(self, int action, label_name):
         cdef attr_t label_id
-        if not isinstance(label_name, (int, long)):
+        if not isinstance(label_name, int) and \
+        not isinstance(label_name, long):
             label_id = self.strings.add(label_name)
         else:
             label_id = label_name

--- a/website/api/_top-level/_cli.jade
+++ b/website/api/_top-level/_cli.jade
@@ -315,30 +315,30 @@ p
         +cell Number of rows in embedding tables.
         +cell #[code 7500]
 
-    +row
-        +cell #[code parser_maxout_pieces]
-        +cell Number of pieces in the parser's and NER's first maxout layer.
-        +cell #[code 2]
+    //- +row
+    //-     +cell #[code parser_maxout_pieces]
+    //-     +cell Number of pieces in the parser's and NER's first maxout layer.
+    //-     +cell #[code 2]
 
-    +row
-        +cell #[code parser_hidden_depth]
-        +cell Number of hidden layers in the parser and NER.
-        +cell #[code 1]
+    //- +row
+    //-     +cell #[code parser_hidden_depth]
+    //-     +cell Number of hidden layers in the parser and NER.
+    //-     +cell #[code 1]
 
     +row
         +cell #[code hidden_width]
         +cell Size of the parser's and NER's hidden layers.
         +cell #[code 128]
 
-    +row
-        +cell #[code history_feats]
-        +cell Number of previous action ID features for parser and NER.
-        +cell #[code 128]
+    //- +row
+    //-     +cell #[code history_feats]
+    //-     +cell Number of previous action ID features for parser and NER.
+    //-     +cell #[code 128]
 
-    +row
-        +cell #[code history_width]
-        +cell Number of embedding dimensions for each action ID.
-        +cell #[code 128]
+    //- +row
+    //-     +cell #[code history_width]
+    //-     +cell Number of embedding dimensions for each action ID.
+    //-     +cell #[code 128]
 
     +row
         +cell #[code learn_rate]


### PR DESCRIPTION
This patch pares down the tangle of options in the parser, in order to improve run-time efficiency. Re #1426 , #1419 

The parser pre-computes feature weights for the hidden states for each token. This is nicely parallel -- we can do a whole batch in one matrix multiplication. However, then we need to step through each state. This portion of the parsing algorithm is done on CPU, and overhead matters a lot.

In order to make things fast and keep the code simple, I've currently hard-coded that there's one hidden layer, and 2 maxout pieces. This allows a nice fused maxpool/dot product, with the maxpool being a simple max of two values. This saves a loop and a temporary array, which is nice.

Benchmarks on my machine (a Dell XPS 13, core i7), with numpy linked to MKL:

|   | After | Before
| --- | -----  | -----
| Words    | 216,270 | 216,270
| Words/s | 10,453   | 5,223
| Time | 20.69 s       | 41.41 s

Not a bad day's work!

I'm curious to see how it runs on GPU. I think we might see some big improvements there, because the poor CPU performance was a bottleneck.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [x] **Bug fix** (non-breaking change fixing an issue)
- [x] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [x] My change requires a change to spaCy's documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
