### PR TITLE
💫 Add vector meta data to model meta.json on train/package and show in docs

### DIFF
--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -144,7 +144,10 @@ def train(cmd, lang, output_dir, train_data, dev_data, n_iter=30, n_sents=0,
                     file_.write(json_dumps(scorer.scores))
                 meta_loc = output_path / ('model%d' % i) / 'meta.json'
                 meta['accuracy'] = scorer.scores
-                meta['speed'] = {'nwords': nwords, 'cpu':cpu_wps, 'gpu': gpu_wps}
+                meta['speed'] = {'nwords': nwords, 'cpu': cpu_wps,
+                                 'gpu': gpu_wps}
+                meta['vectors'] = {'entries': nlp.vocab.vectors_length,
+                                   'width': 0}
                 meta['lang'] = nlp.lang
                 meta['pipeline'] = pipeline
                 meta['spacy_version'] = '>=%s' % about.__version__

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -146,8 +146,8 @@ def train(cmd, lang, output_dir, train_data, dev_data, n_iter=30, n_sents=0,
                 meta['accuracy'] = scorer.scores
                 meta['speed'] = {'nwords': nwords, 'cpu': cpu_wps,
                                  'gpu': gpu_wps}
-                meta['vectors'] = {'entries': nlp.vocab.vectors_length,
-                                   'width': 0}
+                meta['vectors'] = {'width': nlp.vocab.vectors_length,
+                                   'entries': len(nlp.vocab.vectors)}
                 meta['lang'] = nlp.lang
                 meta['pipeline'] = pipeline
                 meta['spacy_version'] = '>=%s' % about.__version__

--- a/website/_includes/_page_models.jade
+++ b/website/_includes/_page_models.jade
@@ -38,7 +38,7 @@ for id in CURRENT_MODELS
                 +cell #[+label Size]
                 +cell #[+tag=comps.size] #[span(data-tpl=id data-tpl-key="size") #[em n/a]]
 
-            each label in ["Pipeline", "Sources", "Author", "License"]
+            each label in ["Pipeline", "Vectors", "Sources", "Author", "License"]
                 - var field = label.toLowerCase()
                 +row
                     +cell.u-nowrap

--- a/website/assets/js/main.js
+++ b/website/assets/js/main.js
@@ -140,6 +140,10 @@ class ModelLoader {
         else return ({ ok: res.ok })
     }
 
+    convertNumber(num, separator = ',') {
+        return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, separator);
+    }
+
     getModels(compat) {
         this.compat = compat;
         for (let modelId of this.modelIds) {
@@ -159,7 +163,7 @@ class ModelLoader {
         const template = new Templater(modelId);
         template.get('table').removeAttribute('data-loading');
         template.get('error').style.display = 'block';
-        for (let key of ['sources', 'pipeline', 'author', 'license']) {
+        for (let key of ['sources', 'pipeline', 'vectors', 'author', 'license']) {
             template.get(key).parentElement.parentElement.style.display = 'none';
         }
     }
@@ -167,13 +171,14 @@ class ModelLoader {
     /**
      * Update model details in tables. Currently quite hacky :(
      */
-    render({ lang, name, version, sources, pipeline, url, author, license, accuracy, size, description, notes }) {
+    render({ lang, name, version, sources, pipeline, vectors, url, author, license, accuracy, size, description, notes }) {
         const modelId = `${lang}_${name}`;
         const model = `${modelId}-${version}`;
         const template = new Templater(modelId);
 
         const getSources = s => (s instanceof Array) ? s.join(', ') : s;
         const getPipeline = p => p.map(comp => `<code>${comp}</code>`).join(', ');
+        const getVectors = v => `${this.convertNumber(v.entries)} (${v.width} dimensions)`;
         const getLink = (t, l) => `<a href="${l}" target="_blank">${t}</a>`;
 
         const keys = { version, size, description, notes }
@@ -182,6 +187,8 @@ class ModelLoader {
         if (sources) template.fill('sources', getSources(sources));
         if (pipeline && pipeline.length) template.fill('pipeline', getPipeline(pipeline), true);
         else template.get('pipeline').parentElement.parentElement.style.display = 'none';
+        if (vectors) template.fill('vectors', getVectors(vectors));
+        else template.get('vectors').parentElement.parentElement.style.display = 'none';
 
         if (author) template.fill('author', url ? getLink(author, url) : author, true);
         if (license) template.fill('license', this.licenses[license] ? getLink(license, this.licenses[license]) : license, true);


### PR DESCRIPTION
Related issues: #1457, #1092, #1341

## Description
This PR implements part of the suggestion described in #1457. After training, the vector meta data is read from the model and added to the model's `meta.json`. When you run `spacy package` with the `--create-meta` flag set (to overwrite the meta), the model's pipeline and vectors data is also read off automatically. This solves another issue with setting the pipeline meta on the command line (which was annoying, unnecessary and error-prone).

The following vectors meta is set:

| Key | Description | Source |
| --- | --- | --- |
| `width` | Vector dimensions. | `nlp.vocab.vectors_length` |
| `entries` | Number of vectors set in the model. | `len(nlp.vocab.vectors)` |

This data will also be displayed in the [models directory](https://alpha.spacy.io/models), if available.

### Types of changes
Enhancement, documentation.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required details.
