### PR TITLE
Require numpy>=1.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cython>=0.24,<0.27.0
 pathlib
-numpy>=1.7
+numpy>=1.12
 cymem>=1.30,<1.32
 preshed>=1.0.0,<2.0.0
 thinc>=6.9.0,<6.10.0

--- a/setup.py
+++ b/setup.py
@@ -191,7 +191,7 @@ def setup_package():
             ext_modules=ext_modules,
             scripts=['bin/spacy'],
             install_requires=[
-                'numpy>=1.7',
+                'numpy>=1.12',
                 'murmurhash>=0.28,<0.29',
                 'cymem>=1.30,<1.32',
                 'preshed>=1.0.0,<2.0.0',


### PR DESCRIPTION
`spacy.util.from_disk` fails below numpy 1.12, so require `numpy >= 1.12`.

## Description

Earlier versions of numpy are not set up to read a `Path`, as is passed from Spacy.

```
/usr/local/lib/python2.7/dist-packages/en_custom/__init__.pyc in load(**overrides)
---> 39     language = load_model_from_init_py(__file__, **overrides)
/usr/local/lib/python2.7/dist-packages/spacy/util.pyc in load_model_from_init_py(init_file, **overrides)
--> 167     return load_model_from_path(data_path, meta, **overrides)
/usr/local/lib/python2.7/dist-packages/spacy/util.pyc in load_model_from_path(model_path, meta, **overrides)
--> 150     return nlp.from_disk(model_path)
/usr/local/lib/python2.7/dist-packages/spacy/language.pyc in from_disk(self, path, disable)
--> 573         util.from_disk(path, deserializers, exclude)
/usr/local/lib/python2.7/dist-packages/spacy/util.pyc in from_disk(path, readers, exclude)
--> 497             reader(path / key)
/usr/local/lib/python2.7/dist-packages/spacy/language.pyc in <lambda>(p)
--> 560             ('vocab', lambda p: self.vocab.from_disk(p)),
vocab.pyx in spacy.vocab.Vocab.from_disk()
vectors.pyx in spacy.vectors.Vectors.from_disk()
/usr/local/lib/python2.7/dist-packages/spacy/util.pyc in from_disk(path, readers, exclude)
--> 497             reader(path / key)
vectors.pyx in spacy.vectors.Vectors.from_disk.load_keys()
/usr/local/lib/python2.7/dist-packages/numpy/lib/npyio.pyc in load(file, mmap_mode, allow_pickle, fix_imports, encoding)
--> 391         magic = fid.read(N)
AttributeError: 'PosixPath' object has no attribute 'read'
```

I can reproduce this (and the fix) on spacy 2alpha. I did not try it on spacy 1+.

One thing for reviewer to be aware of is: https://github.com/explosion/spaCy/issues/1202 — I don't want the now-tighter range of allowed versions to make for impossible dependency resolution in conda.  However that issue does make it sound like `numpy==1.12` is a totally valid solution for both my bug and for conda. 

### Types of changes

- `requirements.txt`
- `setup.py`

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ ] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required details.
