### PR TITLE
Try to add ability to clean up StringStore in pipe

### DIFF
--- a/.github/contributors/ligser.md
+++ b/.github/contributors/ligser.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI UG (haftungsbeschränkt)](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                              |
+|------------------------------- | --------------------               |
+| Name                           | Roman Domrachev                    |
+| Company name (if applicable)   |                                    |
+| Title or role (if applicable)  |                                    |
+| Date                           | 11 November 2017                   |
+| GitHub username                | ligser                             |
+| Website (optional)             |                                    |

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -12,7 +12,6 @@ from copy import copy
 from thinc.neural import Model
 from thinc.neural.optimizers import Adam
 
-from .strings import StringStore
 from .tokenizer import Tokenizer
 from .vocab import Vocab
 from .lemmatizer import Lemmatizer

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -560,7 +560,11 @@ class Language(object):
             elif len(old_refs) == 0:
                 self.vocab.strings._cleanup_stale_strings()
                 nr_seen = 0
-        self.vocab.strings._reset_and_load(original_strings_data)
+        # Last batch can be not garbage collected and we cannot know it — last
+        # doc still here. Not erase that strings — just extend with original
+        # content
+        for string in original_strings_data:
+            self.vocab.strings.add(string)
 
     def to_disk(self, path, disable=tuple()):
         """Save the current state to a directory.  If a model is loaded, this

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -560,9 +560,9 @@ class Language(object):
             elif len(old_refs) == 0:
                 self.vocab.strings._cleanup_stale_strings()
                 nr_seen = 0
-        # Last batch can be not garbage collected and we cannot know it — last
-        # doc still here. Not erase that strings — just extend with original
-        # content
+        # We can't know which strings from the last batch have really expired.
+        # So we don't erase the strings — we just extend with the original
+        # content.
         for string in original_strings_data:
             self.vocab.strings.add(string)
 

--- a/spacy/strings.pxd
+++ b/spacy/strings.pxd
@@ -1,5 +1,6 @@
 from libc.stdint cimport int64_t
 from libcpp.vector cimport vector
+from libcpp.set cimport set
 
 from cymem.cymem cimport Pool
 from preshed.maps cimport PreshMap
@@ -23,6 +24,7 @@ cdef class StringStore:
     cdef Pool mem
 
     cdef vector[hash_t] keys
+    cdef set[hash_t] hits
     cdef public PreshMap _map
 
     cdef const Utf8Str* intern_unicode(self, unicode py_string)

--- a/spacy/strings.pyx
+++ b/spacy/strings.pyx
@@ -251,7 +251,7 @@ cdef class StringStore:
 
     def _cleanup_stale_strings(self):
         if self.hits.size() == 0:
-            # If no any hits — just skip cleanup
+            # If we don't have any hits, just skip cleanup
             return
 
         cdef vector[hash_t] tmp

--- a/spacy/tests/regression/test_issue1506.py
+++ b/spacy/tests/regression/test_issue1506.py
@@ -1,0 +1,28 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+import random
+import string
+
+import itertools
+from compat import izip
+
+from ...lang.en import English
+
+
+def test_issue1506():
+    nlp = English()
+
+    def string_generator():
+        for (_, t) in izip(range(10001), itertools.repeat("It's sentence produced by that bug.")):
+            yield t
+
+        for (_, t) in izip(range(10001), itertools.repeat("I erase lemmas.")):
+            yield t
+
+        for (_, t) in izip(range(10001), itertools.repeat("It's sentence produced by that bug.")):
+            yield t
+
+    for d in nlp.pipe(string_generator()):
+        for t in d:
+            str(t.lemma_)

--- a/spacy/tests/regression/test_issue1506.py
+++ b/spacy/tests/regression/test_issue1506.py
@@ -1,12 +1,6 @@
 # coding: utf8
 from __future__ import unicode_literals
 
-import random
-import string
-
-import itertools
-from compat import izip
-
 from ...lang.en import English
 
 
@@ -14,14 +8,14 @@ def test_issue1506():
     nlp = English()
 
     def string_generator():
-        for (_, t) in izip(range(10001), itertools.repeat("It's sentence produced by that bug.")):
-            yield t
+        for _ in range(10001):
+            yield "It's sentence produced by that bug."
 
-        for (_, t) in izip(range(10001), itertools.repeat("I erase lemmas.")):
-            yield t
+        for _ in range(10001):
+            yield "I erase lemmas."
 
-        for (_, t) in izip(range(10001), itertools.repeat("It's sentence produced by that bug.")):
-            yield t
+        for _ in range(10001):
+            yield "It's sentence produced by that bug."
 
     for d in nlp.pipe(string_generator()):
         for t in d:


### PR DESCRIPTION
## Description
I try to fix #1506 by allowing StringStore to clean up old strings when using it to iterate through many documents in a pipe. I try to do it with little effort on memory or speed, but I might not see all effect of my changes.
Because that method is written as the feature only for `pipe` method of the Language class — the method marked as internal by the underscore.

### Types of change
It's bug fix.

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
