### PR TITLE
Fix memory leak in beam parser

### DIFF
--- a/spacy/gold.pyx
+++ b/spacy/gold.pyx
@@ -179,7 +179,7 @@ class GoldCorpus(object):
             gold_tuples = read_json_file(loc)
             for item in gold_tuples:
                 yield item
-                i += 1
+                i += len(item[1])
                 if self.limit and i >= self.limit:
                     break
 

--- a/spacy/syntax/_beam_utils.pyx
+++ b/spacy/syntax/_beam_utils.pyx
@@ -81,10 +81,7 @@ cdef class ParserBeam(object):
             self._set_scores(beam, scores[i])
             if self.golds is not None:
                 self._set_costs(beam, self.golds[i], follow_gold=follow_gold)
-            if follow_gold:
-                beam.advance(_transition_state, _hash_state, <void*>self.moves.c)
-            else:
-                beam.advance(_transition_state, _hash_state, <void*>self.moves.c)
+            beam.advance(_transition_state, NULL, <void*>self.moves.c)
             beam.check_done(_check_final_state, NULL)
             # This handles the non-monotonic stuff for the parser.
             if beam.is_done and self.golds is not None:

--- a/spacy/syntax/ner.pyx
+++ b/spacy/syntax/ner.pyx
@@ -123,14 +123,14 @@ cdef class BiluoPushDown(TransitionSystem):
         entities = {}
         probs = beam.probs
         for i in range(beam.size):
-            stcls = <StateClass>beam.at(i)
-            if stcls.is_final():
-                self.finalize_state(stcls.c)
+            state = <StateC*>beam.at(i)
+            if state.is_final():
+                self.finalize_state(state)
                 prob = probs[i]
-                for j in range(stcls.c._e_i):
-                    start = stcls.c._ents[j].start
-                    end = stcls.c._ents[j].end
-                    label = stcls.c._ents[j].label
+                for j in range(state._e_i):
+                    start = state._ents[j].start
+                    end = state._ents[j].end
+                    label = state._ents[j].label
                     entities.setdefault((start, end, label), 0.0)
                     entities[(start, end, label)] += prob
         return entities
@@ -139,15 +139,15 @@ cdef class BiluoPushDown(TransitionSystem):
         parses = []
         probs = beam.probs
         for i in range(beam.size):
-            stcls = <StateClass>beam.at(i)
-            if stcls.is_final():
-                self.finalize_state(stcls.c)
+            state = <StateC*>beam.at(i)
+            if state.is_final():
+                self.finalize_state(state)
                 prob = probs[i]
                 parse = []
-                for j in range(stcls.c._e_i):
-                    start = stcls.c._ents[j].start
-                    end = stcls.c._ents[j].end
-                    label = stcls.c._ents[j].label
+                for j in range(state._e_i):
+                    start = state._ents[j].start
+                    end = state._ents[j].end
+                    label = state._ents[j].label
                     parse.append((start, end, self.strings[label]))
                 parses.append((prob, parse))
         return parses

--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -526,7 +526,7 @@ cdef class Parser:
                         for k in range(nr_class):
                             beam.scores[i][k] = c_scores[j * scores.shape[1] + k]
                         j += 1
-                beam.advance(_transition_state, _hash_state, <void*>self.moves.c)
+                beam.advance(_transition_state, NULL, <void*>self.moves.c)
                 beam.check_done(_check_final_state, NULL)
             beams.append(beam)
         tokvecs = self.model[0].ops.unflatten(tokvecs,
@@ -998,16 +998,16 @@ def _cleanup(Beam beam):
             state = <StateC*>addr
             del state
             seen.add(addr)
+        else:
+            print(i, addr)
+            print(seen)
+            raise Exception
         addr = <size_t>beam._states[i].content
         if addr not in seen:
             state = <StateC*>addr
             del state
             seen.add(addr)
-
-
-cdef hash_t _hash_state(void* _state, void* _) except 0:
-    state = <StateC*>_state
-    if state.is_final():
-        return 1
-    else:
-        return state.hash()
+        else:
+            print(i, addr)
+            print(seen)
+            raise Exception

--- a/spacy/syntax/stateclass.pxd
+++ b/spacy/syntax/stateclass.pxd
@@ -13,12 +13,22 @@ from ._state cimport StateC
 cdef class StateClass:
     cdef Pool mem
     cdef StateC* c
+    cdef int _borrowed
 
     @staticmethod
     cdef inline StateClass init(const TokenC* sent, int length):
         cdef StateClass self = StateClass()
         self.c = new StateC(sent, length)
         return self
+    
+    @staticmethod
+    cdef inline StateClass borrow(StateC* ptr):
+        cdef StateClass self = StateClass()
+        del self.c
+        self.c = ptr
+        self._borrowed = 1
+        return self
+
 
     @staticmethod
     cdef inline StateClass init_offset(const TokenC* sent, int length, int

--- a/spacy/syntax/stateclass.pyx
+++ b/spacy/syntax/stateclass.pyx
@@ -11,12 +11,14 @@ cdef class StateClass:
     def __init__(self, Doc doc=None, int offset=0):
         cdef Pool mem = Pool()
         self.mem = mem
+        self._borrowed = 0
         if doc is not None:
             self.c = new StateC(doc.c, doc.length)
             self.c.offset = offset
 
     def __dealloc__(self):
-        del self.c
+        if self._borrowed != 1:
+            del self.c
 
     @property
     def stack(self):

--- a/spacy/syntax/transition_system.pyx
+++ b/spacy/syntax/transition_system.pyx
@@ -23,8 +23,7 @@ class OracleError(Exception):
 
 
 cdef void* _init_state(Pool mem, int length, void* tokens) except NULL:
-    cdef StateClass st = StateClass.init(<const TokenC*>tokens, length)
-    Py_INCREF(st)
+    cdef StateC* st = new StateC(<const TokenC*>tokens, length)
     return <void*>st
 
 


### PR DESCRIPTION
This patch fixes a memory leak and intermittent crash that occurred in the beam parser. This should the implementation. The beam parser is especially useful for assigning probabilities, and will be useful for harder parsing tasks over short texts, e.g. for semantic parsing.

- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
