### PR TITLE
Fixed spaCy version string in default meta

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -147,7 +147,7 @@ class Language(object):
         self._meta.setdefault('lang', self.vocab.lang)
         self._meta.setdefault('name', 'model')
         self._meta.setdefault('version', '0.0.0')
-        self._meta.setdefault('spacy_version', about.__version__)
+        self._meta.setdefault('spacy_version', '>={}'.format(about.__version__))
         self._meta.setdefault('description', '')
         self._meta.setdefault('author', '')
         self._meta.setdefault('email', '')


### PR DESCRIPTION
Default spaCy version string in language meta causes error if one tries to install the model package.

## Description
I've noticed that by default blank language [creates meta with current spaCy version](https://github.com/explosion/spaCy/blob/master/spacy/language.py#L150). If one packages this model with default meta, a setup file will be created from [this](https://github.com/explosion/spaCy/blob/master/spacy/cli/package.py#L149) template, which builds requirements from meta and expects `==`, `>=`, or `<=` before version number. So after running `setup.py` a wrong requirement `spacy2.x.x` (instead of `spacy>=2.x.x` or smth like that) causes the error.
I'm not sure, I fixed it in the right place, but it works at least.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
- [x] Bug fix (non-breaking change fixing an issue)

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement (in previous PR)
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
