### PR TITLE
Corrected char index instead of token index

### DIFF
--- a/website/usage/_linguistic-features/_rule-based-matching.jade
+++ b/website/usage/_linguistic-features/_rule-based-matching.jade
@@ -354,7 +354,8 @@ p
         # append mock entity for match in displaCy style to matched_sents
         # get the match span by ofsetting the start and end of the span with the
         # start and end of the sentence in the doc
-        match_ents = [{'start': span.start-sent.start, 'end': span.end-sent.start,
+        match_ents = [{'start': span.start_char - sent.start_char, 
+                       'end': span.end_char - sent.start_char,
                        'label': 'MATCH'}]
         matched_sents.append({'text': sent.text, 'ents': match_ents })
 


### PR DESCRIPTION
Changed the index used to add the label because `displacy.render` apparently uses char index

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
