### PR TITLE
Add more Danish morph rules and clean up existing ones

### DIFF
--- a/spacy/lang/da/__init__.py
+++ b/spacy/lang/da/__init__.py
@@ -22,7 +22,7 @@ class DanishDefaults(Language.Defaults):
     lex_attr_getters[NORM] = add_lookups(Language.Defaults.lex_attr_getters[NORM],
                                          BASE_NORMS, NORM_EXCEPTIONS)
     tokenizer_exceptions = update_exc(BASE_EXCEPTIONS, TOKENIZER_EXCEPTIONS)
-    # morph_rules = MORPH_RULES
+    morph_rules = MORPH_RULES
     tag_map = TAG_MAP
     stop_words = STOP_WORDS
 

--- a/spacy/lang/da/morph_rules.py
+++ b/spacy/lang/da/morph_rules.py
@@ -3,31 +3,55 @@ from __future__ import unicode_literals
 
 from ...symbols import LEMMA, PRON_LEMMA
 
+# Source: Danish Universal Dependencies and http://fjern-uv.dk/pronom.php
+
+# Note: The Danish Universal Dependencies specify Case=Acc for all instances
+# of "den"/"det" even when the case is in fact "Nom". In the rules below, Case
+# is left unspecified for "den" and "det".
 
 MORPH_RULES = {
     "PRON": {
-        "jeg":            {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Case": "Nom"},
-        "mig":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Case": "Acc"},
-        "du":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two"},
-        "han":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Masc", "Case": "Nom"},
-        "ham":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Masc", "Case": "Acc"},
-        "hun":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Fem",  "Case": "Nom"},
-        "hende":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Fem",  "Case": "Acc"},
-        "den":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Neut"},
-        "det":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Neut"},
-        "vi":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Plur", "Case": "Nom"},
-        "os":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Plur", "Case": "Acc"},
-        "de":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Plur", "Case": "Nom"},
-        "dem":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Plur", "Case": "Acc"},
+        "jeg":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Case": "Nom", "Gender": "Com"},                           # Case=Nom|Gender=Com|Number=Sing|Person=1|PronType=Prs
+        "mig":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Case": "Acc", "Gender": "Com"},                           # Case=Acc|Gender=Com|Number=Sing|Person=1|PronType=Prs
+        "min":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Number[psor]": "Sing", "Poss": "Yes", "Gender": "Com"},   # Gender=Com|Number=Sing|Number[psor]=Sing|Person=1|Poss=Yes|PronType=Prs
+        "mit":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Number[psor]": "Sing", "Poss": "Yes", "Gender": "Neut"},  # Gender=Neut|Number=Sing|Number[psor]=Sing|Person=1|Poss=Yes|PronType=Prs
+        "vor":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Number[psor]": "Plur", "Poss": "Yes", "Gender": "Com"},   # Gender=Com|Number=Sing|Number[psor]=Plur|Person=1|Poss=Yes|PronType=Prs|Style=Form
+        "vort":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Number[psor]": "Plur", "Poss": "Yes", "Gender": "Neut"},  # Gender=Neut|Number=Sing|Number[psor]=Plur|Person=1|Poss=Yes|PronType=Prs|Style=Form
+        "du":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Sing", "Case": "Nom", "Gender": "Com"},                           # Case=Nom|Gender=Com|Number=Sing|Person=2|PronType=Prs
+        "dig":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Sing", "Case": "Acc", "Gender": "Com"},                           # Case=Acc|Gender=Com|Number=Sing|Person=2|PronType=Prs
+        "din":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Sing", "Number[psor]": "Sing", "Poss": "Yes", "Gender": "Com"},   # Gender=Com|Number=Sing|Number[psor]=Sing|Person=2|Poss=Yes|PronType=Prs
+        "dit":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Sing", "Number[psor]": "Sing", "Poss": "Yes", "Gender": "Neut"},  # Gender=Neut|Number=Sing|Number[psor]=Sing|Person=2|Poss=Yes|PronType=Prs
+        "han":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Case": "Nom", "Gender": "Com"},                         # Case=Nom|Gender=Com|Number=Sing|Person=3|PronType=Prs
+        "hun":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Case": "Nom", "Gender": "Com"},                         # Case=Nom|Gender=Com|Number=Sing|Person=3|PronType=Prs
+        "den":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Com"},                                        # Case=Acc|Gender=Com|Number=Sing|Person=3|PronType=Prs, See note above.
+        "det":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Neut"},                                       # Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs See note above.
+        "ham":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Case": "Acc", "Gender": "Com"},                         # Case=Acc|Gender=Com|Number=Sing|Person=3|PronType=Prs
+        "hende":        {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Case": "Acc", "Gender": "Com"},                         # Case=Acc|Gender=Com|Number=Sing|Person=3|PronType=Prs
+        "sin":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Number[psor]": "Sing", "Poss": "Yes", "Gender": "Com", "Reflex": "Yes"},   # Gender=Com|Number=Sing|Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs|Reflex=Yes
+        "sit":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Number[psor]": "Sing", "Poss": "Yes", "Gender": "Neut", "Reflex": "Yes"},  # Gender=Neut|Number=Sing|Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs|Reflex=Yes
 
-        "min":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Poss": "Yes", "Reflex": "Yes"},
-        "din":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Sing", "Poss": "Yes", "Reflex": "Yes"},
-        "hans":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Masc", "Poss": "Yes", "Reflex": "Yes"},
-        "hendes":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Fem",  "Poss": "Yes", "Reflex": "Yes"},
-        "dens":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Neut", "Poss": "Yes", "Reflex": "Yes"},
-        "dets":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Neut", "Poss": "Yes", "Reflex": "Yes"},
-        "vores":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Plur", "Poss": "Yes", "Reflex": "Yes"},
-        "deres":       {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Plur", "Poss": "Yes", "Reflex": "Yes"},
+        "vi":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Plur", "Case": "Nom", "Gender": "Com"},                           # Case=Nom|Gender=Com|Number=Plur|Person=1|PronType=Prs
+        "os":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Plur", "Case": "Acc", "Gender": "Com"},                           # Case=Acc|Gender=Com|Number=Plur|Person=1|PronType=Prs
+        "mine":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Plur", "Number[psor]": "Sing", "Poss": "Yes"},                    # Number=Plur|Number[psor]=Sing|Person=1|Poss=Yes|PronType=Prs
+        "vore":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Plur", "Number[psor]": "Plur", "Poss": "Yes"},                    # Number=Plur|Number[psor]=Plur|Person=1|Poss=Yes|PronType=Prs|Style=Form
+        "I":            {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Plur", "Case": "Nom", "Gender": "Com"},                           # Case=Nom|Gender=Com|Number=Plur|Person=2|PronType=Prs
+        "jer":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Plur", "Case": "Acc", "Gender": "Com"},                           # Case=Acc|Gender=Com|Number=Plur|Person=2|PronType=Prs
+        "dine":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Plur", "Number[psor]": "Sing", "Poss": "Yes"},                    # Number=Plur|Number[psor]=Sing|Person=2|Poss=Yes|PronType=Prs
+        "de":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Plur", "Case": "Nom"},                                          # Case=Nom|Number=Plur|Person=3|PronType=Prs
+        "dem":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Plur", "Case": "Acc"},                                          # Case=Acc|Number=Plur|Person=3|PronType=Prs
+        "sine":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Plur", "Number[psor]": "Sing", "Poss": "Yes", "Reflex": "Yes"}, # Number=Plur|Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs|Reflex=Yes
+
+        "vores":        {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number[psor]": "Plur", "Poss": "Yes"},                                      # Number[psor]=Plur|Person=1|Poss=Yes|PronType=Prs
+        "De":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Case": "Nom", "Gender": "Com"},                                             # Case=Nom|Gender=Com|Person=2|Polite=Form|PronType=Prs
+        "Dem":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Case": "Acc", "Gender": "Com"},                                             # Case=Acc|Gender=Com|Person=2|Polite=Form|PronType=Prs
+        "Deres":        {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Poss": "Yes"},                                                              # Person=2|Polite=Form|Poss=Yes|PronType=Prs
+        "jeres":        {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number[psor]": "Plur", "Poss": "Yes"},                                      # Number[psor]=Plur|Person=2|Poss=Yes|PronType=Prs
+        "sig":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Case": "Acc", "Reflex": "Yes"},                                           # Case=Acc|Person=3|PronType=Prs|Reflex=Yes
+        "hans":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number[psor]": "Sing", "Poss": "Yes"},                                    # Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs
+        "hendes":       {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number[psor]": "Sing", "Poss": "Yes"},                                    # Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs
+        "dens":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number[psor]": "Sing", "Poss": "Yes"},                                    # Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs
+        "dets":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number[psor]": "Sing", "Poss": "Yes"},                                    # Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs
+        "deres":        {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number[psor]": "Plur", "Poss": "Yes"},                                    # Number[psor]=Plur|Person=3|Poss=Yes|PronType=Prs
     },
 
     "VERB": {

--- a/spacy/lang/da/morph_rules.py
+++ b/spacy/lang/da/morph_rules.py
@@ -11,47 +11,47 @@ from ...symbols import LEMMA, PRON_LEMMA
 
 MORPH_RULES = {
     "PRON": {
-        "jeg":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Case": "Nom", "Gender": "Com"},                           # Case=Nom|Gender=Com|Number=Sing|Person=1|PronType=Prs
-        "mig":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Case": "Acc", "Gender": "Com"},                           # Case=Acc|Gender=Com|Number=Sing|Person=1|PronType=Prs
-        "min":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Number[psor]": "Sing", "Poss": "Yes", "Gender": "Com"},   # Gender=Com|Number=Sing|Number[psor]=Sing|Person=1|Poss=Yes|PronType=Prs
-        "mit":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Number[psor]": "Sing", "Poss": "Yes", "Gender": "Neut"},  # Gender=Neut|Number=Sing|Number[psor]=Sing|Person=1|Poss=Yes|PronType=Prs
-        "vor":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Number[psor]": "Plur", "Poss": "Yes", "Gender": "Com"},   # Gender=Com|Number=Sing|Number[psor]=Plur|Person=1|Poss=Yes|PronType=Prs|Style=Form
-        "vort":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Number[psor]": "Plur", "Poss": "Yes", "Gender": "Neut"},  # Gender=Neut|Number=Sing|Number[psor]=Plur|Person=1|Poss=Yes|PronType=Prs|Style=Form
-        "du":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Sing", "Case": "Nom", "Gender": "Com"},                           # Case=Nom|Gender=Com|Number=Sing|Person=2|PronType=Prs
-        "dig":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Sing", "Case": "Acc", "Gender": "Com"},                           # Case=Acc|Gender=Com|Number=Sing|Person=2|PronType=Prs
-        "din":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Sing", "Number[psor]": "Sing", "Poss": "Yes", "Gender": "Com"},   # Gender=Com|Number=Sing|Number[psor]=Sing|Person=2|Poss=Yes|PronType=Prs
-        "dit":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Sing", "Number[psor]": "Sing", "Poss": "Yes", "Gender": "Neut"},  # Gender=Neut|Number=Sing|Number[psor]=Sing|Person=2|Poss=Yes|PronType=Prs
-        "han":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Case": "Nom", "Gender": "Com"},                         # Case=Nom|Gender=Com|Number=Sing|Person=3|PronType=Prs
-        "hun":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Case": "Nom", "Gender": "Com"},                         # Case=Nom|Gender=Com|Number=Sing|Person=3|PronType=Prs
-        "den":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Com"},                                        # Case=Acc|Gender=Com|Number=Sing|Person=3|PronType=Prs, See note above.
-        "det":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Neut"},                                       # Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs See note above.
-        "ham":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Case": "Acc", "Gender": "Com"},                         # Case=Acc|Gender=Com|Number=Sing|Person=3|PronType=Prs
-        "hende":        {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Case": "Acc", "Gender": "Com"},                         # Case=Acc|Gender=Com|Number=Sing|Person=3|PronType=Prs
-        "sin":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Number[psor]": "Sing", "Poss": "Yes", "Gender": "Com", "Reflex": "Yes"},   # Gender=Com|Number=Sing|Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs|Reflex=Yes
-        "sit":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Number[psor]": "Sing", "Poss": "Yes", "Gender": "Neut", "Reflex": "Yes"},  # Gender=Neut|Number=Sing|Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs|Reflex=Yes
+        "jeg":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Case": "Nom", "Gender": "Com"},                      # Case=Nom|Gender=Com|Number=Sing|Person=1|PronType=Prs
+        "mig":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Case": "Acc", "Gender": "Com"},                      # Case=Acc|Gender=Com|Number=Sing|Person=1|PronType=Prs
+        "min":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Poss": "Yes", "Gender": "Com"},                      # Gender=Com|Number=Sing|Number[psor]=Sing|Person=1|Poss=Yes|PronType=Prs
+        "mit":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Poss": "Yes", "Gender": "Neut"},                     # Gender=Neut|Number=Sing|Number[psor]=Sing|Person=1|Poss=Yes|PronType=Prs
+        "vor":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Poss": "Yes", "Gender": "Com"},                      # Gender=Com|Number=Sing|Number[psor]=Plur|Person=1|Poss=Yes|PronType=Prs|Style=Form
+        "vort":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Sing", "Poss": "Yes", "Gender": "Neut"},                     # Gender=Neut|Number=Sing|Number[psor]=Plur|Person=1|Poss=Yes|PronType=Prs|Style=Form
+        "du":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Sing", "Case": "Nom", "Gender": "Com"},                      # Case=Nom|Gender=Com|Number=Sing|Person=2|PronType=Prs
+        "dig":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Sing", "Case": "Acc", "Gender": "Com"},                      # Case=Acc|Gender=Com|Number=Sing|Person=2|PronType=Prs
+        "din":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Sing", "Poss": "Yes", "Gender": "Com"},                      # Gender=Com|Number=Sing|Number[psor]=Sing|Person=2|Poss=Yes|PronType=Prs
+        "dit":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Sing", "Poss": "Yes", "Gender": "Neut"},                     # Gender=Neut|Number=Sing|Number[psor]=Sing|Person=2|Poss=Yes|PronType=Prs
+        "han":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Case": "Nom", "Gender": "Com"},                    # Case=Nom|Gender=Com|Number=Sing|Person=3|PronType=Prs
+        "hun":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Case": "Nom", "Gender": "Com"},                    # Case=Nom|Gender=Com|Number=Sing|Person=3|PronType=Prs
+        "den":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Com"},                                   # Case=Acc|Gender=Com|Number=Sing|Person=3|PronType=Prs, See note above.
+        "det":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Gender": "Neut"},                                  # Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs See note above.
+        "ham":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Case": "Acc", "Gender": "Com"},                    # Case=Acc|Gender=Com|Number=Sing|Person=3|PronType=Prs
+        "hende":        {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Case": "Acc", "Gender": "Com"},                    # Case=Acc|Gender=Com|Number=Sing|Person=3|PronType=Prs
+        "sin":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Poss": "Yes", "Gender": "Com", "Reflex": "Yes"},   # Gender=Com|Number=Sing|Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs|Reflex=Yes
+        "sit":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Sing", "Poss": "Yes", "Gender": "Neut", "Reflex": "Yes"},  # Gender=Neut|Number=Sing|Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs|Reflex=Yes
 
-        "vi":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Plur", "Case": "Nom", "Gender": "Com"},                           # Case=Nom|Gender=Com|Number=Plur|Person=1|PronType=Prs
-        "os":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Plur", "Case": "Acc", "Gender": "Com"},                           # Case=Acc|Gender=Com|Number=Plur|Person=1|PronType=Prs
-        "mine":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Plur", "Number[psor]": "Sing", "Poss": "Yes"},                    # Number=Plur|Number[psor]=Sing|Person=1|Poss=Yes|PronType=Prs
-        "vore":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Plur", "Number[psor]": "Plur", "Poss": "Yes"},                    # Number=Plur|Number[psor]=Plur|Person=1|Poss=Yes|PronType=Prs|Style=Form
-        "I":            {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Plur", "Case": "Nom", "Gender": "Com"},                           # Case=Nom|Gender=Com|Number=Plur|Person=2|PronType=Prs
-        "jer":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Plur", "Case": "Acc", "Gender": "Com"},                           # Case=Acc|Gender=Com|Number=Plur|Person=2|PronType=Prs
-        "dine":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Plur", "Number[psor]": "Sing", "Poss": "Yes"},                    # Number=Plur|Number[psor]=Sing|Person=2|Poss=Yes|PronType=Prs
-        "de":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Plur", "Case": "Nom"},                                          # Case=Nom|Number=Plur|Person=3|PronType=Prs
-        "dem":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Plur", "Case": "Acc"},                                          # Case=Acc|Number=Plur|Person=3|PronType=Prs
-        "sine":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Plur", "Number[psor]": "Sing", "Poss": "Yes", "Reflex": "Yes"}, # Number=Plur|Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs|Reflex=Yes
+        "vi":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Plur", "Case": "Nom", "Gender": "Com"},                      # Case=Nom|Gender=Com|Number=Plur|Person=1|PronType=Prs
+        "os":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Plur", "Case": "Acc", "Gender": "Com"},                      # Case=Acc|Gender=Com|Number=Plur|Person=1|PronType=Prs
+        "mine":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Plur", "Poss": "Yes"},                                       # Number=Plur|Number[psor]=Sing|Person=1|Poss=Yes|PronType=Prs
+        "vore":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number": "Plur", "Poss": "Yes"},                                       # Number=Plur|Number[psor]=Plur|Person=1|Poss=Yes|PronType=Prs|Style=Form
+        "I":            {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Plur", "Case": "Nom", "Gender": "Com"},                      # Case=Nom|Gender=Com|Number=Plur|Person=2|PronType=Prs
+        "jer":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Plur", "Case": "Acc", "Gender": "Com"},                      # Case=Acc|Gender=Com|Number=Plur|Person=2|PronType=Prs
+        "dine":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number": "Plur", "Poss": "Yes"},                                       # Number=Plur|Number[psor]=Sing|Person=2|Poss=Yes|PronType=Prs
+        "de":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Plur", "Case": "Nom"},                                     # Case=Nom|Number=Plur|Person=3|PronType=Prs
+        "dem":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Plur", "Case": "Acc"},                                     # Case=Acc|Number=Plur|Person=3|PronType=Prs
+        "sine":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number": "Plur", "Poss": "Yes", "Reflex": "Yes"},                    # Number=Plur|Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs|Reflex=Yes
 
-        "vores":        {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Number[psor]": "Plur", "Poss": "Yes"},                                      # Number[psor]=Plur|Person=1|Poss=Yes|PronType=Prs
-        "De":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Case": "Nom", "Gender": "Com"},                                             # Case=Nom|Gender=Com|Person=2|Polite=Form|PronType=Prs
-        "Dem":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Case": "Acc", "Gender": "Com"},                                             # Case=Acc|Gender=Com|Person=2|Polite=Form|PronType=Prs
-        "Deres":        {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Poss": "Yes"},                                                              # Person=2|Polite=Form|Poss=Yes|PronType=Prs
-        "jeres":        {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Number[psor]": "Plur", "Poss": "Yes"},                                      # Number[psor]=Plur|Person=2|Poss=Yes|PronType=Prs
-        "sig":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Case": "Acc", "Reflex": "Yes"},                                           # Case=Acc|Person=3|PronType=Prs|Reflex=Yes
-        "hans":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number[psor]": "Sing", "Poss": "Yes"},                                    # Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs
-        "hendes":       {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number[psor]": "Sing", "Poss": "Yes"},                                    # Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs
-        "dens":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number[psor]": "Sing", "Poss": "Yes"},                                    # Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs
-        "dets":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number[psor]": "Sing", "Poss": "Yes"},                                    # Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs
-        "deres":        {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Number[psor]": "Plur", "Poss": "Yes"},                                    # Number[psor]=Plur|Person=3|Poss=Yes|PronType=Prs
+        "vores":        {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "One", "Poss": "Yes"},                                                         # Number[psor]=Plur|Person=1|Poss=Yes|PronType=Prs
+        "De":           {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Case": "Nom", "Gender": "Com"},                                        # Case=Nom|Gender=Com|Person=2|Polite=Form|PronType=Prs
+        "Dem":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Case": "Acc", "Gender": "Com"},                                        # Case=Acc|Gender=Com|Person=2|Polite=Form|PronType=Prs
+        "Deres":        {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Poss": "Yes"},                                                         # Person=2|Polite=Form|Poss=Yes|PronType=Prs
+        "jeres":        {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Two", "Poss": "Yes"},                                                         # Number[psor]=Plur|Person=2|Poss=Yes|PronType=Prs
+        "sig":          {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Case": "Acc", "Reflex": "Yes"},                                      # Case=Acc|Person=3|PronType=Prs|Reflex=Yes
+        "hans":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Poss": "Yes"},                                                       # Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs
+        "hendes":       {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Poss": "Yes"},                                                       # Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs
+        "dens":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Poss": "Yes"},                                                       # Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs
+        "dets":         {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Poss": "Yes"},                                                       # Number[psor]=Sing|Person=3|Poss=Yes|PronType=Prs
+        "deres":        {LEMMA: PRON_LEMMA, "PronType": "Prs", "Person": "Three", "Poss": "Yes"},                                                       # Number[psor]=Plur|Person=3|Poss=Yes|PronType=Prs
     },
 
     "VERB": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
I have made some changes to the Danish morph rules. Specifically I've done the following:

* I systematically went through all forms of Danish personal pronouns, adding missing ones and fixing incorrect ones.
* I used the Danish Universal Dependencies for reference in all cases, except 'den'/'det' (Danish for the English word 'it'). I believe  Danish UD contains systematic errors for those words: Case is always specified as 'acc' even when the word refers to the subject (and consequently, Case should be set to 'nom'). I have left Case unspecified for 'den' and 'det'.
* I removed use of 'Masc' and 'Fem' for Gender as Danish only has the genders  'Neut' and 'Com' (common).

### Types of change
Bug fix / enhancement
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.