### PR TITLE
fix setup.py spacy req string for packaging

### DIFF
--- a/spacy/cli/package.py
+++ b/spacy/cli/package.py
@@ -146,7 +146,7 @@ def list_files(data_dir):
 
 def list_requirements(meta):
     parent_package = meta.get('parent_package', 'spacy')
-    requirements = [parent_package + meta['spacy_version']]
+    requirements = [parent_package + ">=" + meta['spacy_version']]
     if 'setup_requires' in meta:
         requirements += meta['setup_requires']
     return requirements


### PR DESCRIPTION
## Description
spacy requirement string for model packages was broken.
It should be `spacy>=2.0.2` instead of `spacy2.0.2`

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed. (There are no tests for the cli packaging)
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
