### PR TITLE
doc: Add missing *-operator to nlp.disable_pipes() in Lightning Tour

### DIFF
--- a/website/usage/_spacy-101/_lightning-tour.jade
+++ b/website/usage/_spacy-101/_lightning-tour.jade
@@ -112,7 +112,7 @@ p
     nlp = spacy.load('en')
     train_data = [("Uber blew through $1 million", {'entities': [(0, 4, 'ORG')]})]
 
-    with nlp.disable_pipes([pipe for pipe in nlp.pipe_names if pipe != 'ner']):
+    with nlp.disable_pipes(*[pipe for pipe in nlp.pipe_names if pipe != 'ner']):
         optimizer = nlp.begin_training()
         for i in range(10):
             random.shuffle(train_data)


### PR DESCRIPTION
## Description

I'm using SpaCy version 2.0.3. If I don't use the *-operator in the example, Python throws an error message. With the operator it works fine. Also according to the documentation of the function `nlp.disable_pipes()`, it expects one or more strings as arguments and not one argument being a list of strings.

### Types of change
Change in documentation in spaCy 101.
