### PR TITLE
doc: Fix assert statement in Lightning Tour

### DIFF
--- a/website/usage/_spacy-101/_lightning-tour.jade
+++ b/website/usage/_spacy-101/_lightning-tour.jade
@@ -188,7 +188,10 @@ p
     pasta = doc[6]
     hippo = doc[8]
     assert apple.similarity(banana) > pasta.similarity(hippo)
-    assert apple.has_vector, banana.has_vector, pasta.has_vector, hippo.has_vector
+    assert apple.has_vector
+    assert banana.has_vector
+    assert pasta.has_vector
+    assert hippo.has_vector
 
 p
     |  For the best results, you should run this example using the


### PR DESCRIPTION
## Description
Python 3 throws an error message on the original assert statement. Also, according to the Python documentation regarding the assert statement (https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement), `assert` takes at least one argument and at most two. In the two-argument form the second argument is meant as an error message to be displayed when the assertion fails. I don't think this is intended in this case.

### Types of change
Change in documentation in Lighting Tour.