### PR TITLE
doc: Replace 'is not' with '!=' in code example

### DIFF
--- a/website/usage/_spacy-101/_lightning-tour.jade
+++ b/website/usage/_spacy-101/_lightning-tour.jade
@@ -264,7 +264,7 @@ p
     def dependency_labels_to_root(token):
         """Walk up the syntactic tree, collecting the arc labels."""
         dep_labels = []
-        while token.head is not token:
+        while token.head != token:
             dep_labels.append(token.dep)
             token = token.head
         return dep_labels


### PR DESCRIPTION
## Description

The function `dependency_labels_to_root(token)` defined in section *Get syntactic dependencies* does not terminate. Here is a complete example (which doesn't terminate):

    import spacy
    
    nlp = spacy.load('en')
    doc = nlp("Apple and banana are similar. Pasta and hippo aren't.")
    
    def dependency_labels_to_root(token):
        """Walk up the syntactic tree, collecting the arc labels."""
        dep_labels = []
        while token.head is not token:
            dep_labels.append(token.dep)
            token = token.head
        return dep_labels
    
    dep_labels = dependency_labels_to_root(doc[1])
    dep_labels

Replacing `is not` with `!=` solves the issue:

    import spacy
    
    nlp = spacy.load('en')
    doc = nlp("Apple and banana are similar. Pasta and hippo aren't.")
    
    def dependency_labels_to_root(token):
        """Walk up the syntactic tree, collecting the arc labels."""
        dep_labels = []
        while token.head != token:
            dep_labels.append(token.dep)
            token = token.head
        return dep_labels
    
    dep_labels = dependency_labels_to_root(doc[1])
    dep_labels

The output is

    [404, 426]

### Types of change
Change in code example in documentation in *Lightning tour*.