### PR TITLE
fix: Add missing period in train data

### DIFF
--- a/examples/training/train_parser.py
+++ b/examples/training/train_parser.py
@@ -21,7 +21,7 @@ TRAIN_DATA = [
         'heads': [1, 1, 4, 4, 5, 1, 1],
         'deps': ['nsubj', 'ROOT', 'compound', 'punct', 'nmod', 'dobj', 'punct']
     }),
-    ("I like London and Berlin", {
+    ("I like London and Berlin.", {
         'heads': [1, 1, 1, 2, 2, 1],
         'deps': ['nsubj', 'ROOT', 'dobj', 'cc', 'conj', 'punct']
     })


### PR DESCRIPTION
## Description
The annotations `heads` and `deps` each contain 6 elements and the last element of `deps` is `'punct'`, so I guess there is a period missing at the end of the example sentence.

### Types of change
Fix in example code.