### PR TITLE
Fix typo Span -> Token on Token API page

### DIFF
--- a/website/api/token.jade
+++ b/website/api/token.jade
@@ -461,7 +461,7 @@ p A real-valued meaning representation.
         +cell #[code.u-break numpy.ndarray[ndim=1, dtype='float32']]
         +cell A 1D numpy array representing the token's semantics.
 
-+h(2, "vector_norm") Span.vector_norm
++h(2, "vector_norm") Token.vector_norm
     +tag property
     +tag-model("vectors")
 


### PR DESCRIPTION
Change Span.vector_norm to Token.vector_norm.
