### PR TITLE
Fix CLI arguments for init-model

### DIFF
--- a/spacy/cli/init_model.py
+++ b/spacy/cli/init_model.py
@@ -25,7 +25,7 @@ from ..util import prints, ensure_path, get_lang_class
     prune_vectors=("optional: number of vectors to prune to",
                    "option", "V", int)
 )
-def init_model(lang, output_dir, freqs_loc, clusters_loc=None, vectors_loc=None, prune_vectors=-1):
+def init_model(_cmd, lang, output_dir, freqs_loc, clusters_loc=None, vectors_loc=None, prune_vectors=-1):
     """
     Create a new model from raw data, like word frequencies, Brown clusters
     and word vectors.

--- a/spacy/cli/init_model.py
+++ b/spacy/cli/init_model.py
@@ -36,7 +36,7 @@ def init_model(_cmd, lang, output_dir, freqs_loc, clusters_loc=None, vectors_loc
     vectors_loc = ensure_path(vectors_loc)
 
     probs, oov_prob = read_freqs(freqs_loc)
-    vectors_data, vector_keys = read_vectors(vectors_loc) if vectors_loc else None
+    vectors_data, vector_keys = read_vectors(vectors_loc) if vectors_loc else None, None
     clusters = read_clusters(clusters_loc) if clusters_loc else {}
 
     nlp = create_model(lang, probs, oov_prob, clusters, vectors_data, vector_keys, prune_vectors)
@@ -69,7 +69,7 @@ def create_model(lang, probs, oov_prob, clusters, vectors_data, vector_keys, pru
         lex_added += 1
     nlp.vocab.cfg.update({'oov_prob': oov_prob})
 
-    if len(vectors_data):
+    if vectors_data:
         nlp.vocab.vectors = Vectors(data=vectors_data, keys=vector_keys)
     if prune_vectors >= 1:
         nlp.vocab.prune_vectors(prune_vectors)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
I have made the following changes to `init-model`:
* When I removed the abbreviation for positional plac args in #1710, I overlooked the fact that the first argument passed is the name of the CLI argument (`init-model`). This caused all arguments to be shifted by one. I've added a dummy-argument called `_cmd`.
* `read_vectors` has two return values, but only one default value was specified when no word vectors were specified.
* `create_model` checked for the existence of word vectors be calling `len` but this caused an exception when no word vectors were specified.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Bug fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.