### PR TITLE
Don't pass CLI command name as dummy argument

### DIFF
--- a/spacy/__init__.py
+++ b/spacy/__init__.py
@@ -25,4 +25,4 @@ def blank(name, **kwargs):
 
 
 def info(model=None, markdown=False):
-    return cli_info(None, model, markdown)
+    return cli_info(model, markdown)

--- a/spacy/__main__.py
+++ b/spacy/__main__.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     command = sys.argv.pop(1)
     sys.argv[0] = 'spacy %s' % command
     if command in commands:
-        plac.call(commands[command])
+        plac.call(commands[command], sys.argv[1:])
     else:
         prints(
             "Available: %s" % ', '.join(commands),

--- a/spacy/cli/convert.py
+++ b/spacy/cli/convert.py
@@ -24,8 +24,7 @@ CONVERTERS = {
     n_sents=("Number of sentences per doc", "option", "n", int),
     converter=("Name of converter (auto, iob, conllu or ner)", "option", "c", str),
     morphology=("Enable appending morphology to tags", "flag", "m", bool))
-def convert(_cmd, input_file, output_dir, n_sents=1, morphology=False,
-            converter='auto'):
+def convert(input_file, output_dir, n_sents=1, morphology=False, converter='auto'):
     """
     Convert files into JSON format for use with train command and other
     experiment management functions.

--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -38,8 +38,7 @@ def download(model, direct=False):
                 # package, which fails if model was just installed via
                 # subprocess
                 package_path = get_package_path(model_name)
-                link(None, model_name, model, force=True,
-                     model_path=package_path)
+                link(model_name, model, force=True, model_path=package_path)
             except:
                 # Dirty, but since spacy.download and the auto-linking is
                 # mostly a convenience wrapper, it's best to show a success

--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -16,7 +16,7 @@ from .. import about
     model=("model to download, shortcut or name)", "positional", None, str),
     direct=("force direct download. Needs model name with version and won't "
             "perform compatibility check", "flag", "d", bool))
-def download(_cmd, model, direct=False):
+def download(model, direct=False):
     """
     Download compatible model from default download path using pip. Model
     can be shortcut, model name or, if --direct flag is set, full model name

--- a/spacy/cli/evaluate.py
+++ b/spacy/cli/evaluate.py
@@ -25,8 +25,8 @@ numpy.random.seed(0)
     displacy_path=("directory to output rendered parses as HTML", "option",
                    "dp", str),
     displacy_limit=("limit of parses to render as HTML", "option", "dl", int))
-def evaluate(_cmd, model, data_path, gpu_id=-1, gold_preproc=False,
-             displacy_path=None, displacy_limit=25):
+def evaluate(model, data_path, gpu_id=-1, gold_preproc=False, displacy_path=None,
+             displacy_limit=25):
     """
     Evaluate a model. To render a sample of parses in a HTML file, set an
     output directory as the displacy_path argument.

--- a/spacy/cli/info.py
+++ b/spacy/cli/info.py
@@ -13,7 +13,7 @@ from .. import util
 @plac.annotations(
     model=("optional: shortcut link of model", "positional", None, str),
     markdown=("generate Markdown for GitHub issues", "flag", "md", str))
-def info(_cmd, model=None, markdown=False):
+def info(model=None, markdown=False):
     """Print info about spaCy installation. If a model shortcut link is
     speficied as an argument, print model information. Flag --markdown
     prints details in Markdown for easy copy-pasting to GitHub issues.

--- a/spacy/cli/init_model.py
+++ b/spacy/cli/init_model.py
@@ -25,7 +25,7 @@ from ..util import prints, ensure_path, get_lang_class
     prune_vectors=("optional: number of vectors to prune to",
                    "option", "V", int)
 )
-def init_model(_cmd, lang, output_dir, freqs_loc, clusters_loc=None, vectors_loc=None, prune_vectors=-1):
+def init_model(lang, output_dir, freqs_loc, clusters_loc=None, vectors_loc=None, prune_vectors=-1):
     """
     Create a new model from raw data, like word frequencies, Brown clusters
     and word vectors.

--- a/spacy/cli/link.py
+++ b/spacy/cli/link.py
@@ -13,7 +13,7 @@ from .. import util
     origin=("package name or local path to model", "positional", None, str),
     link_name=("name of shortuct link to create", "positional", None, str),
     force=("force overwriting of existing link", "flag", "f", bool))
-def link(_cmd, origin, link_name, force=False, model_path=None):
+def link(origin, link_name, force=False, model_path=None):
     """
     Create a symlink for models within the spacy/data directory. Accepts
     either the name of a pip package, or the local path to the model data

--- a/spacy/cli/package.py
+++ b/spacy/cli/package.py
@@ -20,7 +20,7 @@ from .. import about
                  "the command line prompt", "flag", "c", bool),
     force=("force overwriting of existing model directory in output directory",
            "flag", "f", bool))
-def package(_cmd, input_dir, output_dir, meta_path=None, create_meta=False,
+def package(input_dir, output_dir, meta_path=None, create_meta=False,
             force=False):
     """
     Generate Python package for model data, including meta and required

--- a/spacy/cli/profile.py
+++ b/spacy/cli/profile.py
@@ -29,7 +29,7 @@ def read_inputs(loc):
 @plac.annotations(
     lang=("model/language", "positional", None, str),
     inputs=("Location of input file", "positional", None, read_inputs))
-def profile(_cmd, lang, inputs=None):
+def profile(lang, inputs=None):
     """
     Profile a spaCy pipeline, to find out which functions take the most time.
     """

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -38,7 +38,7 @@ numpy.random.seed(0)
     version=("Model version", "option", "V", str),
     meta_path=("Optional path to meta.json. All relevant properties will be "
                "overwritten.", "option", "m", Path))
-def train(_cmd, lang, output_dir, train_data, dev_data, n_iter=30, n_sents=0,
+def train(lang, output_dir, train_data, dev_data, n_iter=30, n_sents=0,
           use_gpu=-1, vectors=None, no_tagger=False,
           no_parser=False, no_entities=False, gold_preproc=False,
           version="0.0.0", meta_path=None):

--- a/spacy/cli/validate.py
+++ b/spacy/cli/validate.py
@@ -10,7 +10,7 @@ from ..util import prints, get_data_path, read_json
 from .. import about
 
 
-def validate(_cmd):
+def validate():
     """Validate that the currently installed version of spaCy is compatible
     with the installed models. Should be run after `pip install -U spacy`.
     """

--- a/spacy/cli/vocab.py
+++ b/spacy/cli/vocab.py
@@ -21,8 +21,7 @@ from ..util import prints, ensure_path
     prune_vectors=("optional: number of vectors to prune to.",
                    "option", "V", int)
 )
-def make_vocab(_cmd, lang, output_dir, lexemes_loc,
-               vectors_loc=None, prune_vectors=-1):
+def make_vocab(lang, output_dir, lexemes_loc, vectors_loc=None, prune_vectors=-1):
     """Compile a vocabulary from a lexicon jsonl file and word vectors."""
     if not lexemes_loc.exists():
         prints(lexemes_loc, title="Can't find lexical data", exits=1)

--- a/spacy/tests/regression/test_issue1622.py
+++ b/spacy/tests/regression/test_issue1622.py
@@ -86,6 +86,6 @@ def test_cli_trained_model_can_be_saved(tmpdir):
 
     # spacy train -n 1 -g -1 nl output_nl training_corpus.json training \
     # corpus.json
-    train(cmd, lang, output_dir, train_data, dev_data, n_iter=1)
+    train(lang, output_dir, train_data, dev_data, n_iter=1)
 
     assert True

--- a/spacy/tests/regression/test_issue1622.py
+++ b/spacy/tests/regression/test_issue1622.py
@@ -9,7 +9,6 @@ from ...cli.train import train
 
 @pytest.mark.xfail
 def test_cli_trained_model_can_be_saved(tmpdir):
-    cmd = None
     lang = 'nl'
     output_dir = str(tmpdir)
     train_file = NamedTemporaryFile('wb', dir=output_dir, delete=False)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Running spaCy from the CLI, specifying a command but omitting one or more required arguments, will print a help text. This help text includes names of required and optional arguments. However, it also print both the command name *and* the name of the dummy variable containing the command name.

For example, calling `spacy package` would result in the following output:
```
usage: spacy package [-h] [-m None] [-c] [-f] _cmd input_dir output_dir
spacy package: error: the following arguments are required: input_dir, output_dir
```

Note that the first line contains `spacy package` but it also lists the variable name `_cmd` as one of the arguments. I think that's confusing as it can lead the user to think he or she needs to specify a command *in addition* to the already specified command. 

This PR completely avoids the dummy variables (`_cmd`) by skipping the first command line argument when passing arguments to the plac-annotated functions. This is done by changing `plac.call(commands[command])` to `plac.call(commands[command], sys.argv[1:])`.

This makes the above command simply print the following:
```
usage: spacy package [-h] [-m None] [-c] [-f] input_dir output_dir
spacy package: error: the following arguments are required: input_dir, output_dir
```

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.