### PR TITLE
Model Load Performance Improvement by more than 5x

### DIFF
--- a/.github/contributors/avadhpatel.md
+++ b/.github/contributors/avadhpatel.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI UG (haftungsbeschränkt)](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your 
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           | Avadh Patel          |
+| Company name (if applicable)   |                      |
+| Title or role (if applicable)  |                      |
+| Date                           | 17.01.2018           |
+| GitHub username                | avadhpatel           |
+| Website (optional)             |                      |

--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -271,7 +271,8 @@ cdef class Parser:
 
         # TODO: This is an unfortunate hack atm!
         # Used to set input dimensions in network.
-        lower.begin_training(lower.ops.allocate((500, token_vector_width)))
+        if not cfg.get('from_disk', False):
+            lower.begin_training(lower.ops.allocate((500, token_vector_width)))
         cfg = {
             'nr_class': nr_class,
             'hidden_depth': depth,
@@ -888,7 +889,7 @@ cdef class Parser:
             path = util.ensure_path(path)
             if self.model is True:
                 self.cfg['pretrained_dims'] = self.vocab.vectors_length
-                self.model, cfg = self.Model(**self.cfg)
+                self.model, cfg = self.Model(from_disk=True, **self.cfg)
             else:
                 cfg = {}
             with (path / 'tok2vec_model').open('rb') as file_:


### PR DESCRIPTION
Performance of loading a model from disk was too slow. After profiling, I found that the issue was random-initialization of weights which will be overwritten by data from the disk. This patch improves the performance of load from disk by more than 5x.

## Description
After doing performance profiling on loading models from disk, I found out that each model is initialized with some random weights and then those weights are overwritten by data from disk. This overhead of random initialization was ~80% of total load time.

In my test that loads 38 different models. Below is the profiling of that script without this patch:
`         2897440 function calls (2730892 primitive calls) in 94.368 seconds

   Ordered by: internal time
   List reduced from 3254 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      228   37.318    0.164   37.318    0.164 {built-in method numpy.core.multiarray.dot}
      228   28.010    0.123   74.568    0.327 _ml.py:198(predict)
      228    8.025    0.035    8.025    0.035 {built-in method numpy.core.multiarray.concatenate}
       38    3.777    0.099    4.491    0.118 {method 'from_disk' of 'spacy.vocab.Vocab' objects}
     1786    3.429    0.002    3.429    0.002 {method 'uniform' of 'mtrand.RandomState' objects}
       76    2.439    0.032   79.594    1.047 _ml.py:175(init_weights)
       76    2.026    0.027    2.026    0.027 {method 'normal' of 'mtrand.RandomState' objects}
       38    1.291    0.034    1.647    0.043 language.py:54(create_tokenizer)
      228    1.113    0.005   46.523    0.204 _ml.py:131(begin_update)
       38    1.023    0.027    1.148    0.030 {method 'from_disk' of 'spacy.tokenizer.Tokenizer' objects}
`
The script's total time was 94.36 seconds.

After small modification of how the Model is initialized, the profiling of the script is below:
`         2881472 function calls (2715159 primitive calls) in 15.252 seconds

   Ordered by: internal time
   List reduced from 3227 to 10 due to restriction <10>


   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       38    3.832    0.101    4.580    0.121 {method 'from_disk' of 'spacy.vocab.Vocab' objects}
     1710    3.368    0.002    3.368    0.002 {method 'uniform' of 'mtrand.RandomState' objects}
       38    1.254    0.033    1.604    0.042 language.py:54(create_tokenizer)
       76    1.107    0.015    4.950    0.065 nn_parser.pyx:856(from_disk)
       38    0.996    0.026    1.092    0.029 {method 'from_disk' of 'spacy.tokenizer.Tokenizer' objects}
       38    0.667    0.018    0.667    0.018 _ml.py:228(link_vectors_to_models)
     3800    0.499    0.000    0.501    0.000 util.py:46(copy_array)
       38    0.432    0.011    2.271    0.060 pipeline.pyx:580(load_model)
      418    0.305    0.001    0.556    0.001 {msgpack._unpacker.unpackb}
      456    0.229    0.001    3.362    0.007 hash_embed.py:15(wrapped)
`
Total runtime of the test reduced to 15.25 seconds - which is more than 6x performance improvement.

### Types of change
It's a performance enhancement in loading a model from disk.

## Checklist

- [X] I have submitted the spaCy Contributor Agreement.
- [X] I ran the tests, and all new and existing tests passed.
- [X] My changes don't require a change to the documentation, or if they do, I've added all required information.