### PR TITLE
Pattern matcher fixes

### DIFF
--- a/spacy/matcher.pyx
+++ b/spacy/matcher.pyx
@@ -8,12 +8,14 @@ from cymem.cymem cimport Pool
 from preshed.maps cimport PreshMap
 from libcpp.vector cimport vector
 from libcpp.pair cimport pair
-from libcpp.unordered_map cimport unordered_map as umap
 from cython.operator cimport dereference as deref
 from murmurhash.mrmr cimport hash64
 from libc.stdint cimport int32_t
 
-from libc.stdio cimport printf
+try:
+    from libcpp.unordered_map cimport unordered_map as umap
+except:
+    from libcpp.map cimport map as umap
 
 from .typedefs cimport attr_t
 from .typedefs cimport hash_t

--- a/spacy/matcher.pyx
+++ b/spacy/matcher.pyx
@@ -12,10 +12,10 @@ from cython.operator cimport dereference as deref
 from murmurhash.mrmr cimport hash64
 from libc.stdint cimport int32_t
 
-try:
-    from libcpp.unordered_map cimport unordered_map as umap
-except:
-    from libcpp.map cimport map as umap
+# try:
+#     from libcpp.unordered_map cimport unordered_map as umap
+# except:
+#     from libcpp.map cimport map as umap
 
 from .typedefs cimport attr_t
 from .typedefs cimport hash_t
@@ -72,6 +72,7 @@ cdef enum action_t:
     ACCEPT_PREV
     PANIC
 
+
 # Each token pattern consists of a quantifier and 0+ (attr, value) pairs.
 # A state is an (int, pattern pointer) pair, where the int is the start
 # position, and the pattern pointer shows where we're up to
@@ -89,13 +90,26 @@ cdef struct TokenPatternC:
 
 
 ctypedef TokenPatternC* TokenPatternC_ptr
-ctypedef pair[int, TokenPatternC_ptr] StateC
+# ctypedef pair[int, TokenPatternC_ptr] StateC
 
 # Match Dictionary entry type
 cdef struct MatchEntryC:
     int32_t start
     int32_t end
     int32_t offset
+
+# A state instance represents the information that defines a 
+# partial match
+# start: the index of the first token in the partial match
+# pattern: a pointer to the current token pattern in the full
+#       pattern
+# last_match: The entry of the last span matched by the
+#       same pattern
+cdef struct StateC:
+    int32_t start
+    TokenPatternC_ptr pattern
+    MatchEntryC* last_match
+
 
 cdef TokenPatternC* init_pattern(Pool mem, attr_t entity_id,
                                  object token_specs) except NULL:
@@ -346,11 +360,15 @@ cdef class Matcher:
         cdef StateC state
         cdef int j = 0
         cdef int k
-        cdef bint add_match,overlap = False
-        cdef TokenPatternC_ptr final_state
-        cdef umap[TokenPatternC_ptr,MatchEntryC] matches_dict
-        cdef umap[TokenPatternC_ptr,MatchEntryC].iterator state_match
-        cdef MatchEntryC new_match
+        cdef bint overlap = False
+        cdef MatchEntryC* state_match 
+        cdef MatchEntryC* last_matches = <MatchEntryC*>self.mem.alloc(self.patterns.size(),sizeof(MatchEntryC))
+
+        for i in range(self.patterns.size()):
+            last_matches[i].start = 0
+            last_matches[i].end = 0
+            last_matches[i].offset = 0
+
         matches = []
         for token_i in range(doc.length):
             token = &doc.c[token_i]
@@ -361,7 +379,7 @@ cdef class Matcher:
             j=0
             while j < n_partials:
                 state = partials[j]
-                action = get_action(state.second, token)
+                action = get_action(state.pattern, token)
                 j += 1
                 # Skip patterns that would overlap with an existing match
                 # Patterns overlap an existing match if they point to the
@@ -369,33 +387,29 @@ cdef class Matcher:
                 # of said match.
                 # Different patterns with the same label are allowed to 
                 # overlap.
-                final_state = state.second
-                while final_state.nr_attr != 0:
-                    final_state+=1
-                state_match = matches_dict.find(final_state)
-                if (state_match != matches_dict.end() 
-                    and state.first>deref(state_match).second.start 
-                    and state.first<deref(state_match).second.end):
+                state_match = state.last_match
+                if (state.start > state_match.start 
+                    and state.start < state_match.end):
                     continue
                 if action == PANIC:
                     raise Exception("Error selecting action in matcher")
                 while action == ADVANCE_ZERO:
-                    state.second += 1
-                    action = get_action(state.second, token)
+                    state.pattern += 1
+                    action = get_action(state.pattern, token)
                 if action == PANIC:
                     raise Exception("Error selecting action in matcher")
                 
                 # ADVANCE_PLUS acts like REPEAT, but also pushes a partial that
                 # acts like and ADVANCE_ZERO
                 if action == ADVANCE_PLUS:
-                    state.second += 1
+                    state.pattern += 1
                     partials.push_back(state)
                     n_partials += 1
-                    state.second -= 1
+                    state.pattern -= 1
                     action = REPEAT
 
                 if action == ADVANCE:
-                    state.second += 1
+                    state.pattern += 1
 
                 # Check for partial matches that are at the same spec in the same pattern
                 # Keep the longer of the matches
@@ -404,7 +418,7 @@ cdef class Matcher:
 
                 overlap=False
                 for i in range(q):
-                    if state.second == partials[i].second and state.first < partials[i].first:
+                    if state.pattern == partials[i].pattern and state.start < partials[i].start:
                         partials[i] = state
                         j = i
                         overlap = True
@@ -413,7 +427,7 @@ cdef class Matcher:
                     continue
                 overlap=False
                 for i in range(q):
-                    if state.second == partials[i].second:
+                    if state.pattern == partials[i].pattern:
                         overlap = True
                         break
                 if overlap:
@@ -434,60 +448,53 @@ cdef class Matcher:
                 elif action in (ACCEPT, ACCEPT_PREV):
                     # TODO: What to do about patterns starting with ZERO? Need
                     # to adjust the start position.
-                    start = state.first
+                    start = state.start
                     end = token_i+1 if action == ACCEPT else token_i
-                    ent_id = state.second[1].attrs[0].value
-                    # ent_id = get_pattern_key(state.second)
-                    label = state.second[1].attrs[1].value
+                    ent_id = state.pattern[1].attrs[0].value
+                    label = state.pattern[1].attrs[1].value
                     # Check that this match doesn't overlap with an earlier match.
                     # Only overwrite an earlier match if it is a substring of this
                     # match (i.e. it starts after this match starts).
-                    final_state = state.second+1
-                    state_match = matches_dict.find(final_state)
+                    state_match = state.last_match
 
-                    if state_match == matches_dict.end():
-                        new_match.start = start
-                        new_match.end = end
-                        new_match.offset = len(matches)
-                        matches_dict[final_state] = new_match
+                    if start >= state_match.end:
+                        state_match.start = start
+                        state_match.end = end
+                        state_match.offset = len(matches)
                         matches.append((ent_id,start,end))
-                    elif start >= deref(state_match).second.end:
-                        new_match.start = start
-                        new_match.end = end
-                        new_match.offset = len(matches)
-                        matches_dict[final_state] = new_match
-                        matches.append((ent_id,start,end))
-                    elif start <= deref(state_match).second.start and end>=deref(state_match).second.end:
-                        i = deref(state_match).second.offset
-                        matches[i] = (ent_id,start,end)
-                        new_match.start = start
-                        new_match.end = end
-                        new_match.offset = i
-                        matches_dict[final_state] = new_match
+                    elif start <= state_match.start and end >= state_match.end:
+                        if len(matches) == 0:
+                            assert state_match.offset==0
+                            state_match.offset = 0
+                            matches.append((ent_id,start,end))
+                        else:
+                            i = state_match.offset
+                            matches[i] = (ent_id,start,end)
+                        state_match.start = start
+                        state_match.end = end
                     else:
                         pass
 
             partials.resize(q)
             n_partials = q
             # Check whether we open any new patterns on this token
+            i=0
             for pattern in self.patterns:
                 # Skip patterns that would overlap with an existing match
-                ent_id = get_pattern_key(pattern)
-                final_state = pattern
-                while final_state.nr_attr != 0:
-                    final_state+=1
-                state_match = matches_dict.find(final_state)
-                if (state_match != matches_dict.end() 
-                    and token_i>deref(state_match).second.start 
-                    and token_i<deref(state_match).second.end):
+                # state_match = pattern.last_match
+                state_match = &last_matches[i]
+                i+=1
+                if (token_i > state_match.start 
+                    and token_i < state_match.end):
                     continue
                 action = get_action(pattern, token)
                 if action == PANIC:
                     raise Exception("Error selecting action in matcher")
                 while action in (ADVANCE_PLUS,ADVANCE_ZERO):
                     if action == ADVANCE_PLUS:
-                        state.first = token_i
-                        state.second = pattern
+                        state.start = token_i
+                        state.pattern = pattern
+                        state.last_match = state_match
                         partials.push_back(state)
                         n_partials += 1
                     pattern += 1
@@ -498,7 +505,7 @@ cdef class Matcher:
                 j=0
                 overlap = False
                 for j in range(q):
-                    if pattern == partials[j].second:
+                    if pattern == partials[j].pattern:
                         overlap = True
                         break
                 if overlap:
@@ -506,15 +513,17 @@ cdef class Matcher:
 
 
                 if action == REPEAT:
-                    state.first = token_i
-                    state.second = pattern
+                    state.start = token_i
+                    state.pattern = pattern
+                    state.last_match = state_match
                     partials.push_back(state)
                     n_partials += 1
                 elif action == ADVANCE:
                     # TODO: What to do about patterns starting with ZERO? Need
                     # to adjust the start position.
-                    state.first = token_i
-                    state.second = pattern
+                    state.start = token_i
+                    state.pattern = pattern
+                    state.last_match = state_match
                     partials.push_back(state)
                     n_partials += 1
                 elif action in (ACCEPT, ACCEPT_PREV):
@@ -523,60 +532,47 @@ cdef class Matcher:
                     ent_id = pattern[1].attrs[0].value
 
                     label = pattern[1].attrs[1].value
-                    final_state = pattern+1
-                    state_match = matches_dict.find(final_state)
-                    if state_match == matches_dict.end():
-                        new_match.start = start
-                        new_match.end = end
-                        new_match.offset = len(matches)
-                        matches_dict[final_state] = new_match
+                    if start >= state_match.end:
+                        state_match.start = start
+                        state_match.end = end
+                        state_match.offset = len(matches)
                         matches.append((ent_id,start,end))
-                    elif start >= deref(state_match).second.end:
-                        new_match.start = start
-                        new_match.end = end
-                        new_match.offset = len(matches)
-                        matches_dict[final_state] = new_match
-                        matches.append((ent_id,start,end))
-                    elif start <= deref(state_match).second.start and end>=deref(state_match).second.end:
-                        j = deref(state_match).second.offset
-                        matches[j] = (ent_id,start,end)
-                        new_match.start = start
-                        new_match.end = end
-                        new_match.offset = j
-                        matches_dict[final_state] = new_match
+                    if start <= state_match.start and end >= state_match.end:
+                        if len(matches) == 0:
+                            state_match.offset = 0
+                            matches.append((ent_id,start,end))
+                        else:
+                            j = state_match.offset
+                            matches[j] = (ent_id,start,end)
+                        state_match.start = start
+                        state_match.end = end
                     else:
                         pass
 
         # Look for open patterns that are actually satisfied
         for state in partials:
-            while state.second.quantifier in (ZERO, ZERO_ONE, ZERO_PLUS):
-                state.second += 1
-                if state.second.nr_attr == 0:
-                    start = state.first
+            while state.pattern.quantifier in (ZERO, ZERO_ONE, ZERO_PLUS):
+                state.pattern += 1
+                if state.pattern.nr_attr == 0:
+                    start = state.start
                     end = len(doc)
-                    ent_id = state.second.attrs[0].value
-                    label = state.second.attrs[1].value
-                    final_state = state.second
-                    state_match = matches_dict.find(final_state)
-                    if state_match == matches_dict.end():
-                        new_match.start = start
-                        new_match.end = end
-                        new_match.offset = len(matches)
-                        matches_dict[final_state] = new_match
+                    ent_id = state.pattern.attrs[0].value
+                    label = state.pattern.attrs[1].value
+                    state_match = state.last_match
+                    if start >= state_match.end:
+                        state_match.start = start
+                        state_match.end = end
+                        state_match.offset = len(matches)
                         matches.append((ent_id,start,end))
-                    elif start >= deref(state_match).second.end:
-                        new_match.start = start
-                        new_match.end = end
-                        new_match.offset = len(matches)
-                        matches_dict[final_state] = new_match
-                        matches.append((ent_id,start,end))
-                    elif start <= deref(state_match).second.start and end>=deref(state_match).second.end:
-                        j = deref(state_match).second.offset
-                        matches[j] = (ent_id,start,end)
-                        new_match.start = start
-                        new_match.end = end
-                        new_match.offset = j
-                        matches_dict[final_state] = new_match
+                    if start <= state_match.start and end >= state_match.end:
+                        j = state_match.offset
+                        if len(matches) == 0:
+                            state_match.offset = 0
+                            matches.append((ent_id,start,end))
+                        else:
+                            matches[j] = (ent_id,start,end)
+                        state_match.start = start
+                        state_match.end = end
                     else:
                         pass
         for i, (ent_id, start, end) in enumerate(matches):

--- a/spacy/tests/regression/test_issue1450.py
+++ b/spacy/tests/regression/test_issue1450.py
@@ -13,8 +13,8 @@ from ...vocab import Vocab
         ('a b', 0, 2),
         ('a c', 0, 1),
         ('a b c', 0, 2),
-        ('a b b c', 0, 2),
-        ('a b b', 0, 2),
+        ('a b b c', 0, 3),
+        ('a b b', 0, 3),
     ]
 )
 def test_issue1450_matcher_end_zero_plus(string, start, end):

--- a/spacy/tests/regression/test_issue1855.py
+++ b/spacy/tests/regression/test_issue1855.py
@@ -1,0 +1,63 @@
+# coding: utf-8
+from __future__ import unicode_literals
+import re
+
+from ..matcher import Matcher
+
+import pytest
+
+pattern1	= [{'ORTH':'A','OP':'1'},{'ORTH':'A','OP':'*'}]
+pattern2	= [{'ORTH':'A','OP':'*'},{'ORTH':'A','OP':'1'}]
+pattern3	= [{'ORTH':'A','OP':'1'},{'ORTH':'A','OP':'1'}]
+pattern4	= [{'ORTH':'B','OP':'1'},{'ORTH':'A','OP':'*'},{'ORTH':'B','OP':'1'}]
+pattern5 	= [{'ORTH':'B','OP':'*'},{'ORTH':'A','OP':'*'},{'ORTH':'B','OP':'1'}]
+
+re_pattern1	= 'AA*'
+re_pattern2 = 'A*A'
+re_pattern3	= 'AA'
+re_pattern4	= 'BA*B'
+re_pattern5	= 'B*A*B'
+
+@pytest.fixture
+def text():
+	return "(ABBAAAAAB)."
+
+@pytest.fixture
+def doc(en_tokenizer,text):
+    doc = en_tokenizer(' '.join(text))
+    return doc
+
+@pytest.mark.parametrize('pattern,re_pattern',[
+	(pattern1,re_pattern1),
+	(pattern2,re_pattern2),
+	(pattern3,re_pattern3),
+	(pattern4,re_pattern4),
+	(pattern5,re_pattern5)])
+def test_greedy_matching(doc,text,pattern,re_pattern):
+	"""
+	Test that the greedy matching behavior of the * op
+	is consistant with other re implementations
+	"""
+	matcher = Matcher(doc.vocab)
+	matcher.add(re_pattern,None,pattern)
+	matches = matcher(doc)
+	re_matches = [m.span() for m in re.finditer(re_pattern,text)]
+	for match,re_match in zip(matches,re_matches):
+		assert match[1:]==re_match
+
+@pytest.mark.parametrize('pattern,re_pattern',[
+	(pattern1,re_pattern1),
+	(pattern2,re_pattern2),
+	(pattern3,re_pattern3),
+	(pattern4,re_pattern4),
+	(pattern5,re_pattern5)])
+def test_match_consuming(doc,text,pattern,re_pattern):
+	"""
+	Test that matcher.__call__ consumes tokens on a match
+	similar to re.findall
+	"""
+	matcher = Matcher(doc.vocab)
+	matcher.add(re_pattern,None,pattern)
+	matches = matcher(doc)
+	re_matches = [m.span() for m in re.finditer(re_pattern,text)]
+	assert len(matches)==len(re_matches)

--- a/spacy/tests/regression/test_issue1855.py
+++ b/spacy/tests/regression/test_issue1855.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 import re
 
-from ..matcher import Matcher
+from ...matcher import Matcher
 
 import pytest
 

--- a/spacy/tests/test_matcher_greedy.py
+++ b/spacy/tests/test_matcher_greedy.py
@@ -1,0 +1,63 @@
+# coding: utf-8
+from __future__ import unicode_literals
+import re
+
+from ..matcher import Matcher
+
+import pytest
+
+pattern1	= [{'ORTH':'A','OP':'1'},{'ORTH':'A','OP':'*'}]
+pattern2	= [{'ORTH':'A','OP':'*'},{'ORTH':'A','OP':'1'}]
+pattern3	= [{'ORTH':'A','OP':'1'},{'ORTH':'A','OP':'1'}]
+pattern4	= [{'ORTH':'B','OP':'1'},{'ORTH':'A','OP':'*'},{'ORTH':'B','OP':'1'}]
+pattern5 	= [{'ORTH':'B','OP':'*'},{'ORTH':'A','OP':'*'},{'ORTH':'B','OP':'1'}]
+
+re_pattern1	= 'AA*'
+re_pattern2 = 'A*A'
+re_pattern3	= 'AA'
+re_pattern4	= 'BA*B'
+re_pattern5	= 'B*A*B'
+
+@pytest.fixture
+def text():
+	return "(ABBAAAAAB)."
+
+@pytest.fixture
+def doc(en_tokenizer,text):
+    doc = en_tokenizer(' '.join(text))
+    return doc
+
+@pytest.mark.parametrize('pattern,re_pattern',[
+	(pattern1,re_pattern1),
+	(pattern2,re_pattern2),
+	(pattern3,re_pattern3),
+	(pattern4,re_pattern4),
+	(pattern5,re_pattern5)])
+def test_greedy_matching(doc,text,pattern,re_pattern):
+	"""
+	Test that the greedy matching behavior of the * op
+	is consistant with other re implementations
+	"""
+	matcher = Matcher(doc.vocab)
+	matcher.add(re_pattern,None,pattern)
+	matches = matcher(doc)
+	re_matches = [m.span() for m in re.finditer(re_pattern,text)]
+	for match,re_match in zip(matches,re_matches):
+		assert match[1:]==re_match
+
+@pytest.mark.parametrize('pattern,re_pattern',[
+	(pattern1,re_pattern1),
+	(pattern2,re_pattern2),
+	(pattern3,re_pattern3),
+	(pattern4,re_pattern4),
+	(pattern5,re_pattern5)])
+def test_match_consuming(doc,text,pattern,re_pattern):
+	"""
+	Test that matcher.__call__ consumes tokens on a match
+	similar to re.findall
+	"""
+	matcher = Matcher(doc.vocab)
+	matcher.add(re_pattern,None,pattern)
+	matches = matcher(doc)
+	re_matches = [m.span() for m in re.finditer(re_pattern,text)]
+	assert len(matches)==len(re_matches)

--- a/website/usage/_linguistic-features/_rule-based-matching.jade
+++ b/website/usage/_linguistic-features/_rule-based-matching.jade
@@ -161,11 +161,7 @@ p
 
 p
     |  The #[code +] and #[code *] operators are usually interpretted
-    |  "greedily", i.e. longer matches are returned where possible. However, if
-    |  you specify two #[code +] and #[code *] patterns in a row and their
-    |  matches overlap, the first operator will behave non-greedily. This quirk
-    |  in the semantics makes the matcher more efficient, by avoiding the need
-    |  for back-tracking.
+    |  "greedily", i.e. longer matches are returned where possible. 
 
 +h(3, "adding-phrase-patterns") Adding phrase patterns
 


### PR DESCRIPTION
<!---s #<!--- Provide a general summary of your changes in the title. -->
#1503 
## Description
This PR includes fixes and improvements to the pattern matching behavior of spacy.matcher.Matcher.  Specifically, the '*' and '+' operators are not greedy and are inconsistent with the output of standard regular expression libraries.

The PR adds a ADVANCE_PLUS action that behaves as if both ADVANCE_ZERO and REPEAT were the action.  This allows greedy matching to be implemented without backtracking.  Due to the restrictions of the token patterns (i.e. one operator per token), the partial match list can be pruned to never be larger than twice the number of specs in a pattern.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

1. Fixed bug in matching state logic preventing '*' from ever being greedy
2. Expanded functionality to allow multiple variable length quantifiers without backtracking 

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ x] I have submitted the spaCy Contributor Agreement.
- [ x] I ran the tests, and all new and existing tests passed.
- [ x] My changes don't require a change to the documentation, or if they do, I've added all required information.
