### PR TITLE
Fix issue #1889

### DIFF
--- a/spacy/lang/lex_attrs.py
+++ b/spacy/lang/lex_attrs.py
@@ -136,7 +136,7 @@ def is_lower(string): return string.islower()
 def is_space(string): return string.isspace()
 def is_title(string): return string.istitle()
 def is_upper(string): return string.isupper()
-def is_stop(string, stops=set()): return string in stops
+def is_stop(string, stops=set()): return string.lower() in stops
 def is_oov(string): return True
 def get_prob(string): return -20.
 

--- a/spacy/tests/regression/test_issue1889.py
+++ b/spacy/tests/regression/test_issue1889.py
@@ -1,0 +1,11 @@
+# coding: utf-8
+from __future__ import unicode_literals
+from ...lang.lex_attrs import is_stop
+from ...lang.en.stop_words import STOP_WORDS
+
+import pytest
+
+
+@pytest.mark.parametrize('word', ['the'])
+def test_lex_attrs_stop_words_case_sensitivity(word):
+    assert is_stop(word, STOP_WORDS) == is_stop(word.upper(), STOP_WORDS)


### PR DESCRIPTION
## Description
This PR fixes an issue where `is_stop` returned `False` when a stop word was not lowercased (#1889).

**Before this PR:**

```python
import spacy
nlp = spacy.load('en')

def is_stop(text):
  doc = nlp(text)
  print(doc[0].is_stop)

is_stop('the') # True
is_stop('The') # False
```

**After this PR:**

```python
import spacy
nlp = spacy.load('en')

def is_stop(text):
  doc = nlp(text)
  print(doc[0].is_stop)

is_stop('the') # True
is_stop('The') # True
```

### Types of change
Bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
