### PR TITLE
update link to Honnibal and Johnson 2015

### DIFF
--- a/website/usage/_facts-figures/_benchmarks.jade
+++ b/website/usage/_facts-figures/_benchmarks.jade
@@ -13,7 +13,7 @@ p
     |  Their results and subsequent discussions helped us develop a novel
     |  psychologically-motivated technique to improve spaCy's accuracy, which
     |  we published in joint work with Macquarie University
-    |  #[+a("https://aclweb.org/anthology/D/D15/D15-1162.pdf") (Honnibal and Johnson, 2015)].
+    |  #[+a("https://www.aclweb.org/anthology/D/D15/D15-1162.pdf") (Honnibal and Johnson, 2015)].
 
 include _benchmarks-choi-2015
 


### PR DESCRIPTION
aclweb.org is throwing a gateway timeout on the URL as `https`+`aclweb.org`, but is fine with `https`+`www.aclweb.org` (also with `http`+`aclweb.org`, but let's keep it in `https`, shall we?

Arguably this is an aclweb server configuration issue, but it's quicker to make a PR to spaCy than to fix aclweb!

Checklist:
- [x] I have submitted the spaCy contributor agreement
- [x] Tests pass
- [x] This is a minor documentation change