### PR TITLE
Make python 3.4 compat module loading (fix #1733)

### DIFF
--- a/spacy/compat.py
+++ b/spacy/compat.py
@@ -43,15 +43,15 @@ fix_text = ftfy.fix_text
 copy_array = copy_array
 izip = getattr(itertools, 'izip', zip)
 
-is_python2 = six.PY2
-is_python3 = six.PY3
 is_windows = sys.platform.startswith('win')
 is_linux = sys.platform.startswith('linux')
 is_osx = sys.platform == 'darwin'
 
+is_python2 = six.PY2
+is_python3 = six.PY3
+is_python_pre_3_5 = is_python2 or (is_python3 and sys.version_info[1]<5)
 
 if is_python2:
-    import imp
     bytes_ = str
     unicode_ = unicode  # noqa: F821
     basestring_ = basestring  # noqa: F821
@@ -60,7 +60,6 @@ if is_python2:
     path2str = lambda path: str(path).decode('utf8')
 
 elif is_python3:
-    import importlib.util
     bytes_ = bytes
     unicode_ = str
     basestring_ = str
@@ -111,9 +110,11 @@ def normalize_string_keys(old):
 
 def import_file(name, loc):
     loc = str(loc)
-    if is_python2:
+    if is_python_pre_3_5:
+        import imp
         return imp.load_source(name, loc)
     else:
+        import importlib.util
         spec = importlib.util.spec_from_file_location(name, str(loc))
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)


### PR DESCRIPTION
## Description
Use `imp` rather than `importlib` in Python 3.4.
Tested on a computer running 3.4.

### Types of change
compat

## Checklist
- [ ] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

I have not run the tests, I assume you have CI for that, and I don't have a copy checked out in git.