### PR TITLE
Fix issue #1706

### DIFF
--- a/.github/contributors/ursachec.md
+++ b/.github/contributors/ursachec.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI UG (haftungsbeschränkt)](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your 
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                     |
+|------------------------------- | ------------------------- |
+| Name                           | Claudiu-Vlad Ursache      |
+| Company name (if applicable)   |                           |
+| Title or role (if applicable)  |                           |
+| Date                           | 2018-02-04                |
+| GitHub username                | ursachec                  |
+| Website (optional)             | https://www.cvursache.com |

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -624,7 +624,7 @@ class Language(object):
         deserializers = OrderedDict((
             ('vocab', lambda p: self.vocab.from_disk(p)),
             ('tokenizer', lambda p: self.tokenizer.from_disk(p, vocab=False)),
-            ('meta.json', lambda p: self.meta.update(ujson.load(p.open('r'))))
+            ('meta.json', lambda p: self.meta.update(util.read_json(p)))
         ))
         for name, proc in self.pipeline:
             if name in disable:

--- a/spacy/pipeline.pyx
+++ b/spacy/pipeline.pyx
@@ -214,7 +214,8 @@ class Pipe(object):
 
 def _load_cfg(path):
     if path.exists():
-        return ujson.load(path.open())
+        with path.open() as file_:
+            return ujson.load(file_)
     else:
         return {}
 
@@ -580,7 +581,8 @@ class Tagger(Pipe):
         def load_model(p):
             if self.model is True:
                 self.model = self.Model(self.vocab.morphology.n_tags, **self.cfg)
-            self.model.from_bytes(p.open('rb').read())
+            with p.open('rb') as file_:
+                self.model.from_bytes(file_.read())
 
         def load_tag_map(p):
             with p.open('rb') as file_:

--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -887,7 +887,7 @@ cdef class Parser:
         deserializers = {
             'vocab': lambda p: self.vocab.from_disk(p),
             'moves': lambda p: self.moves.from_disk(p, strings=False),
-            'cfg': lambda p: self.cfg.update(ujson.load(p.open())),
+            'cfg': lambda p: self.cfg.update(util.read_json(p)),
             'model': lambda p: None
         }
         util.from_disk(path, deserializers, exclude)

--- a/spacy/tests/serialize/test_serialize_language.py
+++ b/spacy/tests/serialize/test_serialize_language.py
@@ -1,0 +1,28 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from ..util import make_tempdir
+from ...language import Language
+
+import pytest
+
+
+@pytest.fixture
+def meta_data():
+    return {
+        'name': 'name-in-fixture',
+        'version': 'version-in-fixture',
+        'description': 'description-in-fixture',
+        'author': 'author-in-fixture',
+        'email': 'email-in-fixture',
+        'url': 'url-in-fixture',
+        'license': 'license-in-fixture',
+    }
+
+
+def test_serialize_language_meta_disk(meta_data):
+    language = Language(meta=meta_data)
+    with make_tempdir() as d:
+        language.to_disk(d)
+        new_language = Language().from_disk(d)
+    assert new_language.meta == language.meta

--- a/spacy/vectors.pyx
+++ b/spacy/vectors.pyx
@@ -347,7 +347,8 @@ cdef class Vectors:
         """
         def load_key2row(path):
             if path.exists():
-                self.key2row = msgpack.load(path.open('rb'))
+                with path.open('rb') as file_:
+                    self.key2row = msgpack.load(file_)
             for key, row in self.key2row.items():
                 if row in self._unset:
                     self._unset.remove(row)


### PR DESCRIPTION
Hello everyone! This PR fixes the issue of files not being closed in a timely manner when a spaCy _Language_ object is used in a `unittest` test case  [#1706](https://github.com/explosion/spaCy/issues/1706)

## Description
Using the simple test case specified in [#1706](https://github.com/explosion/spaCy/issues/1706), I went through all the _ResourceWarnings_ and removed them one by one in a way which made the most sense to me. After ensuring that all relevant file opens were wrapped in a `with` statement or `util.read_json`, I ran the simple unit test again with positive results.
Specifically, these are the warnings which aren't thrown any more:
```
util.py:521: ResourceWarning: unclosed file <_io.BufferedReader name='SPACY_DIR/data/en/en_core_web_sm-2.0.0/vocab/key2row'>
  reader(path / key)                    
language.py:618: ResourceWarning: unclosed file <_io.TextIOWrapper name='SPACY_DIR/data/en/en_core_web_sm-2.0.0/meta.json' mode='r' encoding='UTF-8'>
  ('meta.json', lambda p: self.meta.update(ujson.load(p.open('r'))))                                      
util.py:521: ResourceWarning: unclosed file <_io.TextIOWrapper name='SPACY_DIR/spacy/data/en/en_core_web_sm-2.0.0/tagger/cfg' mode='r' encoding='UTF-8'>
  reader(path / key)
util.py:521: ResourceWarning: unclosed file <_io.BufferedReader name='SPACY_DIR/spacy/data/en/en_core_web_sm-2.0.0/tagger/model'>
  reader(path / key)
  util.py:521: ResourceWarning: unclosed file <_io.TextIOWrapper name='SPACY_DIR/spacy/data/en/en_core_web_sm-2.0.0/parser/cfg' mode='r' encoding='UTF-8'>
  reader(path / key)                                                  
util.py:521: ResourceWarning: unclosed file <_io.TextIOWrapper name='SPACY_DIR/spacy/data/en/en_core_web_sm-2.0.0/ner/cfg' mode='r' encoding='UTF-8'>
  reader(path / key)
```
and this is the simple test file I used:
```
# In a python3 virtualenv; ran with `python -m unittest test.py`
# test.py
import unittest
import spacy

class SpacyTestCase(unittest.TestCase):
    def test_spacy(self):
        nlp = spacy.load('en')
        doc = nlp('this is just a test.')
        print(doc)

```

While I couldn't find a better way of testing that warnings aren't thrown, I did notice that the serialisation is tested already, and given that the tests passed, I assumed that that is enough. If it's not, please provide a hint on how to do it approximately and I'll happily take care of the issue.  Also, while looking into these tests, I found that the `meta.json` serialisation is not tested, so I added a spec for that instead of a `regression` spec.

And that's about it. Looking forward to your feedback, great work you folks are doing.

P.S. Maybe relevant: I couldn't figure out what possible side-effects @ines was referring to when saying
> I think we even have a spacy.util.read_json that does exactly that – it just needs to be tested to make sure it works as expected and has no weird side-effects (since the code is part of an ordered dicts of deserializers).

### Types of change
Bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
