### PR TITLE
Make span.sent work when only manual / custom sbd

### DIFF
--- a/spacy/tests/doc/test_span.py
+++ b/spacy/tests/doc/test_span.py
@@ -19,6 +19,15 @@ def doc(en_tokenizer):
     return get_doc(tokens.vocab, [t.text for t in tokens], heads=heads, deps=deps)
 
 
+@pytest.fixture
+def doc_not_parsed(en_tokenizer):
+    text = "This is a sentence. This is another sentence. And a third."
+    tokens = en_tokenizer(text)
+    d = get_doc(tokens.vocab, [t.text for t in tokens])
+    d.is_parsed = False
+    return d
+
+
 def test_spans_sent_spans(doc):
     sents = list(doc.sents)
     assert sents[0].start == 0
@@ -34,12 +43,14 @@ def test_spans_root(doc):
     assert span.root.text == 'sentence'
     assert span.root.head.text == 'is'
 
+
 def test_spans_string_fn(doc):
     span = doc[0:4]
     assert len(span) == 4
     assert span.text == 'This is a sentence'
     assert span.upper_ == 'THIS IS A SENTENCE'
     assert span.lower_ == 'this is a sentence'
+
 
 def test_spans_root2(en_tokenizer):
     text = "through North and South Carolina"
@@ -49,12 +60,17 @@ def test_spans_root2(en_tokenizer):
     assert doc[-2:].root.text == 'Carolina'
 
 
-def test_spans_span_sent(doc):
+def test_spans_span_sent(doc, doc_not_parsed):
     """Test span.sent property"""
     assert len(list(doc.sents))
     assert doc[:2].sent.root.text == 'is'
     assert doc[:2].sent.text == 'This is a sentence .'
     assert doc[6:7].sent.root.left_edge.text == 'This'
+    # test on manual sbd
+    doc_not_parsed[0].is_sent_start = True
+    doc_not_parsed[5].is_sent_start = True
+    assert doc_not_parsed[1:3].sent == doc_not_parsed[0:5]
+    assert doc_not_parsed[10:14].sent == doc_not_parsed[5:]
 
 
 def test_spans_lca_matrix(en_tokenizer):

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -285,16 +285,33 @@ cdef class Span:
         def __get__(self):
             if 'sent' in self.doc.user_span_hooks:
                 return self.doc.user_span_hooks['sent'](self)
-            # This should raise if we're not parsed.
+            # This should raise if we're not parsed
+            # or doesen't have any sbd component :)
             self.doc.sents
+            # if doc is parsed we can use the deps to find the sentence
+            # otherwise we use the `sent_start` token attribute
             cdef int n = 0
-            root = &self.doc.c[self.start]
-            while root.head != 0:
-                root += root.head
-                n += 1
-                if n >= self.doc.length:
-                    raise RuntimeError
-            return self.doc[root.l_edge:root.r_edge + 1]
+            if self.doc.is_parsed:
+                root = &self.doc.c[self.start]
+                while root.head != 0:
+                    root += root.head
+                    n += 1
+                    if n >= self.doc.length:
+                        raise RuntimeError
+                return self.doc[root.l_edge:root.r_edge + 1]
+            else:
+                # find start of the sentence
+                start = self.start
+                while not self.doc.c[start].sent_start and start > 0:
+                    start += -1
+                # find end of the sentence
+                end = self.end
+                while not self.doc.c[end].sent_start:
+                    end += 1
+                    if n >= self.doc.length:
+                        break
+                #
+                return self.doc[start:end]
 
     property has_vector:
         """RETURNS (bool): Whether a word vector is associated with the object.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Hi,

I noticed that the function allowing to retrieve the sentence from a span => `span.sent` works only when the document is parsed. I added the ability to get the sentence using the `sent_start` attribute, by looking on the left and right of the span for the next sentence boundaries.

Don't know if you want that, or if it should belong to a personal `user_span_hooks`, but in case it's here :)

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

bug fix ?

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
