### PR TITLE
Make token.lemma property return hash instead of unicode

### DIFF
--- a/spacy/tokens/token.pyx
+++ b/spacy/tokens/token.pyx
@@ -269,8 +269,8 @@ cdef class Token:
         """
         def __get__(self):
             if self.c.lemma == 0:
-                lemma = self.vocab.morphology.lemmatizer.lookup(self.orth_)
-                return lemma
+                lemma_ = self.vocab.morphology.lemmatizer.lookup(self.orth_)
+                return self.vocab.strings[lemma_]
             else:
                 return self.c.lemma
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

`token.lemma` wasn't always returning an integer ! When the lemma wasn't set on the c attribute, the `lemma` property calls the `lemmatizer` lookup table but it returned the unicode instead of the hash.

Small fix, but quite annoying bug ^^.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
