### PR TITLE
Quick typo fix

### DIFF
--- a/spacy/lang/en/lemmatizer/lookup.py
+++ b/spacy/lang/en/lemmatizer/lookup.py
@@ -1310,7 +1310,7 @@ LOOKUP = {
     "alphabets": "alphabet",
     "alphas": "alpha",
     "alpines": "alpine",
-    "also": "conjurer",
+    "also": "also",
     "also-rans": "also-ran",
     "altars": "altar",
     "alterations": "alteration",

--- a/spacy/lang/en/lemmatizer/lookup.py
+++ b/spacy/lang/en/lemmatizer/lookup.py
@@ -1310,6 +1310,7 @@ LOOKUP = {
     "alphabets": "alphabet",
     "alphas": "alpha",
     "alpines": "alpine",
+    "also": "also",
     "also-rans": "also-ran",
     "altars": "altar",
     "alterations": "alteration",

--- a/spacy/lang/en/lemmatizer/lookup.py
+++ b/spacy/lang/en/lemmatizer/lookup.py
@@ -1310,7 +1310,6 @@ LOOKUP = {
     "alphabets": "alphabet",
     "alphas": "alpha",
     "alpines": "alpine",
-    "also": "also",
     "also-rans": "also-ran",
     "altars": "altar",
     "alterations": "alteration",


### PR DESCRIPTION
Very minor typo fix

## Description
Referencing #2063 , I noticed that  `also` has lemma `conjurer`, I thought it might be a copy paste typo. I mapped it to itself, adverbs has lemma themselves (with some exceptions:) ).

The reason I'm making a one liner pull request is that, "also" is a common adverb and bad lemmatization cause huge shifts at the end.

### Types of change
Very minor change, I only removed one line.
I also made a quick awk to go over adverb and adjective lists and check if any of them exists somewhere else. 

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ x] I have submitted the spaCy Contributor Agreement.
- [ x] I ran the tests, and all new and existing tests passed.
- [ x] My changes don't require a change to the documentation, or if they do, I've added all required information.
