### PR TITLE
Fix lemmatize issue

### DIFF
--- a/spacy/lemmatizer.py
+++ b/spacy/lemmatizer.py
@@ -106,7 +106,7 @@ def lemmatize(string, index, exceptions, rules):
                 else:
                     oov_forms.append(form)
     if not forms:
-        forms.extend(oov_forms)
-    if not forms:
         forms.append(orig)
+    if not forms:
+        forms.extend(oov_forms)
     return list(set(forms))


### PR DESCRIPTION
Referring to issue #2096, for some words that are not plural, like "corpus" the old lemmatize function returns "corpu" as lemma which is false! Changing the last two `if` commands resolves the issue!

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.