### PR TITLE
WIP: linear regexes and tokeniser optimisations

### DIFF
--- a/spacy/lang/punctuation.py
+++ b/spacy/lang/punctuation.py
@@ -12,12 +12,12 @@ _prefixes = (['§', '%', '=', r'\+'] + LIST_PUNCT + LIST_ELLIPSES + LIST_QUOTES 
 
 _suffixes = (LIST_PUNCT + LIST_ELLIPSES + LIST_QUOTES + LIST_ICONS +
              ["'s", "'S", "’s", "’S"] +
-             [r'(?<=[0-9])\+',
-              r'(?<=°[FfCcKk])\.',
-              r'(?<=[0-9])(?:{})'.format(CURRENCY),
-              r'(?<=[0-9])(?:{})'.format(UNITS),
-              r'(?<=[0-9{}{}(?:{})])\.'.format(ALPHA_LOWER, r'%²\-\)\]\+', QUOTES),
-              r'(?<=[{a}][{a}])\.'.format(a=ALPHA_UPPER)])
+             [r'(?:[0-9])(\+)',
+              r'(?:°[FfCcKk])(\.)',
+              r'(?:[0-9])({})'.format(CURRENCY),
+              r'(?:[0-9])({})'.format(UNITS),
+              r'(?:[0-9{}{}(?:{})])(\.)'.format(ALPHA_LOWER, r'%²\-\)\]\+', QUOTES),
+              r'(?:[{a}][{a}])(\.)'.format(a=ALPHA_UPPER)])
 
 
 _infixes = (LIST_ELLIPSES + LIST_ICONS +


### PR DESCRIPTION
**WIP**: fix #1642 . I'm going to start work fully on this tomorrow but wanted to open a PR straight away to help capture some of the ideas we had around optimising tokeniser performance and provide some guidance towards the final cleanup...since I'm not great at Python.

Target: 500.000 WPS tokenisation...ideally scaling parallel

Changes I'm planning to make:
- [ ] transform postive lookaheads and lookbehinds to make use of capture groups (which are O(n))
- [ ] transform negative lookaheads and lookbhinds to make use of a combination of linearisation techniques I came up with for my go-tokenizer.
- [ ] settle on a schema for defining regexes where we explicitly define the capture group we're looking for. I remember there were 1 or 2 regexes that were hard to transform because they relied on capturing "multiple parts" in between lookaheads/behinds. Also wrapping the existing API/functions so they make use of a capturing groups transparently. https://github.com/explosion/spaCy/blob/15eb54feccfb8dac50f7635ee9802280d8a56354/spacy/tokenizer.pyx#L408
- [ ] use the re2 regex library
- [ ] add some performance tests? --- i might need some help with this?
- [ ] see if I can port my parallelisation and other optimisations to the tokenisers. Might have to rethink some of it since it's written in Go but should be doable.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ ] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
