### PR TITLE
Add example for visualizing word vectors with TensorBoard Projector

### DIFF
--- a/.github/contributors/justindujardin.md
+++ b/.github/contributors/justindujardin.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI UG (haftungsbeschränkt)](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your 
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           | Justin DuJardin      |
+| Company name (if applicable)   | DuJardin Consulting, LLC |
+| Title or role (if applicable)  |                      |
+| Date                           | 2018-03-23           |
+| GitHub username                | justindujardin       |
+| Website (optional)             | https://justindujardin.com |

--- a/examples/vectors_tensorboard.py
+++ b/examples/vectors_tensorboard.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# coding: utf8
+"""Visualize spaCy word vectors in Tensorboard.
+
+Adapted from: https://gist.github.com/BrikerMan/7bd4e4bd0a00ac9076986148afc06507
+"""
+from __future__ import unicode_literals
+
+from os import path
+
+import math
+import numpy
+import plac
+import spacy
+import tensorflow as tf
+import tqdm
+from tensorflow.contrib.tensorboard.plugins.projector import visualize_embeddings, ProjectorConfig
+
+
+@plac.annotations(
+    vectors_loc=("Path to spaCy model that contains vectors", "positional", None, str),
+    out_loc=("Path to output folder for tensorboard session data", "positional", None, str),
+    name=("Human readable name for tsv file and vectors tensor", "positional", None, str),
+)
+def main(vectors_loc, out_loc, name="spaCy_vectors"):
+    meta_file = "{}.tsv".format(name)
+    out_meta_file = path.join(out_loc, meta_file)
+
+    print('Loading spaCy vectors model: {}'.format(vectors_loc))
+    model = spacy.load(vectors_loc)
+    print('Finding lexemes with vectors attached: {}'.format(vectors_loc))
+    strings_stream = tqdm.tqdm(model.vocab.strings, total=len(model.vocab.strings), leave=False)
+    queries = [w for w in strings_stream if model.vocab.has_vector(w)]
+    vector_count = len(queries)
+
+    print('Building Tensorboard Projector metadata for ({}) vectors: {}'.format(vector_count, out_meta_file))
+
+    # Store vector data in a tensorflow variable
+    tf_vectors_variable = numpy.zeros((vector_count, model.vocab.vectors.shape[1]))
+
+    # Write a tab-separated file that contains information about the vectors for visualization
+    #
+    # Reference: https://www.tensorflow.org/programmers_guide/embedding#metadata
+    with open(out_meta_file, 'wb') as file_metadata:
+        # Define columns in the first row
+        file_metadata.write("Text\tFrequency\n".encode('utf-8'))
+        # Write out a row for each vector that we add to the tensorflow variable we created
+        vec_index = 0
+        for text in tqdm.tqdm(queries, total=len(queries), leave=False):
+            # https://github.com/tensorflow/tensorflow/issues/9094
+            text = '<Space>' if text.lstrip() == '' else text
+            lex = model.vocab[text]
+
+            # Store vector data and metadata
+            tf_vectors_variable[vec_index] = model.vocab.get_vector(text)
+            file_metadata.write("{}\t{}\n".format(text, math.exp(lex.prob) * vector_count).encode('utf-8'))
+            vec_index += 1
+
+    print('Running Tensorflow Session...')
+    sess = tf.InteractiveSession()
+    tf.Variable(tf_vectors_variable, trainable=False, name=name)
+    tf.global_variables_initializer().run()
+    saver = tf.train.Saver()
+    writer = tf.summary.FileWriter(out_loc, sess.graph)
+
+    # Link the embeddings into the config
+    config = ProjectorConfig()
+    embed = config.embeddings.add()
+    embed.tensor_name = name
+    embed.metadata_path = meta_file
+
+    # Tell the projector about the configured embeddings and metadata file
+    visualize_embeddings(writer, config)
+
+    # Save session and print run command to the output
+    print('Saving Tensorboard Session...')
+    saver.save(sess, path.join(out_loc, '{}.ckpt'.format(name)))
+    print('Done. Run `tensorboard --logdir={0}` to view in Tensorboard'.format(out_loc))
+
+
+if __name__ == '__main__':
+    plac.call(main)


### PR DESCRIPTION
## Description

Add an example script for visualizing spaCy model word vectors in TensorBoard.

Use on the command line:
```bash
python vectors_tensorboard.py en_core_web_lg ./output_folder spaCy_large
```

### Types of change
Documentation, example script

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
