### PR TITLE
💫 Fix token.ent_iob after doc.merge(), and ensure consistency in doc.ents

### DIFF
--- a/spacy/tests/doc/test_add_entities.py
+++ b/spacy/tests/doc/test_add_entities.py
@@ -18,7 +18,7 @@ def test_doc_add_entities_set_ents_iob(en_vocab):
     assert [w.ent_iob_ for w in doc] == (['O'] * len(doc))
 
     doc.ents = [(doc.vocab.strings['ANIMAL'], 3, 4)]
-    assert [w.ent_iob_ for w in doc] == ['O', 'O', 'O', 'B']
+    assert [w.ent_iob_ for w in doc] == ['', '', '', 'B']
 
     doc.ents = [(doc.vocab.strings['WORD'], 0, 2)]
-    assert [w.ent_iob_ for w in doc] == ['B', 'I', 'O', 'O']
+    assert [w.ent_iob_ for w in doc] == ['B', 'I', '', '']

--- a/spacy/tests/doc/test_span_merge.py
+++ b/spacy/tests/doc/test_span_merge.py
@@ -2,6 +2,8 @@
 from __future__ import unicode_literals
 
 from ..util import get_doc
+from ...vocab import Vocab
+from ...tokens import Doc
 
 import pytest
 
@@ -93,6 +95,21 @@ def test_spans_entity_merge(en_tokenizer):
         ent.merge(label=label, lemma=lemma, ent_type=type_)
     # check looping is ok
     assert len(doc) == 15
+
+
+def test_spans_entity_merge_iob():
+    # Test entity IOB stays consistent after merging
+    words = ["a", "b", "c", "d", "e"]
+    doc = Doc(Vocab(), words=words)
+    doc.ents = [(doc.vocab.strings.add('ent-abc'), 0, 3),
+                (doc.vocab.strings.add('ent-d'), 3, 4)]
+    assert doc[0].ent_iob_ == "B"
+    assert doc[1].ent_iob_ == "I"
+    assert doc[2].ent_iob_ == "I"
+    assert doc[3].ent_iob_ == "B"
+    doc[0:1].merge()
+    assert doc[0].ent_iob_ == "B"
+    assert doc[1].ent_iob_ == "I"
 
 
 def test_spans_sentence_update_after_merge(en_tokenizer):

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -421,7 +421,12 @@ cdef class Doc:
             for i in range(self.length):
                 token = &self.c[i]
                 if token.ent_iob == 1:
-                    assert start != -1
+                    if start == -1:
+                        seq = ['%s|%s' % (t.text, t.ent_iob_) for t in self[i-5:i+5]]
+                        raise ValueError(
+                            "token.ent_iob values make invalid sequence: "
+                            "I without B\n"
+                            "{seq}".format(seq=' '.join(seq)))
                 elif token.ent_iob == 2 or token.ent_iob == 0:
                     if start != -1:
                         output.append(Span(self, start, i, label=label))

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -949,6 +949,13 @@ cdef class Doc:
                 self.vocab.morphology.assign_tag(token, attr_value)
             else:
                 Token.set_struct_attr(token, attr_name, attr_value)
+        # Make sure ent_iob remains consistent
+        if self.c[end].ent_iob == 1 and token.ent_iob in (0, 2):
+            if token.ent_type == self.c[end].ent_type:
+                token.ent_iob = 3
+            else:
+                # If they're not the same entity type, let them be two entities
+                self.c[end].ent_iob = 3
         # Begin by setting all the head indices to absolute token positions
         # This is easier to work with for now than the offsets
         # Before thinking of something simpler, beware the case where a

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -451,10 +451,7 @@ cdef class Doc:
             cdef int i
             for i in range(self.length):
                 self.c[i].ent_type = 0
-                # At this point we don't know whether the NER has run over the
-                # Doc. If the ent_iob is missing, leave it missing.
-                if self.c[i].ent_iob != 0:
-                    self.c[i].ent_iob = 2  # Means O. Non-O are set from ents.
+                self.c[i].ent_iob = 0  # Means missing.
             cdef attr_t ent_type
             cdef int start, end
             for ent_info in ents:


### PR DESCRIPTION
Previously the `token.ent_iob` sequence could end up in an inconsistent state, both after `doc.merge()` and after setting `doc.ents`. This patch resolves the problem and improves the error message if we do end up in an inconsistent state.

This should address #1554 , and one of the problems behind #1752 

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
