### PR TITLE
[2032] - Changed python set to cpp stl set

### DIFF
--- a/.github/CONTRIBUTOR_AGREEMENT.md
+++ b/.github/CONTRIBUTOR_AGREEMENT.md
@@ -91,16 +91,16 @@ mark both statements:
     or entity, including my employer, has or will have rights with respect to my
     contributions.
 
-    * [x] I am signing on behalf of my employer or a legal entity and I have the
+    * [] I am signing on behalf of my employer or a legal entity and I have the
     actual authority to contractually bind that entity.
 
 ## Contributor Details
 
 | Field                          | Entry                |
 |------------------------------- | -------------------- |
-| Name                           |                      |
+| Name                           | Suraj Rajan          |
 | Company name (if applicable)   |                      |
 | Title or role (if applicable)  |                      |
-| Date                           |                      |
-| GitHub username                |                      |
+| Date                           | 31/Mar/2018          |
+| GitHub username                | skrcode              |
 | Website (optional)             |                      |

--- a/spacy/tests/vectors/test_vectors.py
+++ b/spacy/tests/vectors/test_vectors.py
@@ -28,12 +28,38 @@ def vectors():
 def data():
     return numpy.asarray([[0.0, 1.0, 2.0], [3.0, -2.0, 4.0]], dtype='f')
 
+@pytest.fixture
+def resize_data():
+    return numpy.asarray([[0.0, 1.0], [2.0, 3.0]], dtype='f')
 
 @pytest.fixture()
 def vocab(en_vocab, vectors):
     add_vecs_to_vocab(en_vocab, vectors)
     return en_vocab
 
+def test_init_vectors_with_resize_shape(strings,resize_data):
+    v = Vectors(shape=(len(strings), 3))
+    v.resize(shape=resize_data.shape)
+    assert v.shape == resize_data.shape
+    assert v.shape != (len(strings), 3)
+
+def test_init_vectors_with_resize_data(data,resize_data):
+    v = Vectors(data=data)
+    v.resize(shape=resize_data.shape)
+    assert v.shape == resize_data.shape
+    assert v.shape != data.shape
+
+def test_get_vector_resize(strings, data,resize_data):
+    v = Vectors(data=data)
+    v.resize(shape=resize_data.shape)
+    strings = [hash_string(s) for s in strings]
+    for i, string in enumerate(strings):
+        v.add(string, row=i)
+
+    assert list(v[strings[0]]) == list(resize_data[0])
+    assert list(v[strings[0]]) != list(resize_data[1])
+    assert list(v[strings[1]]) != list(resize_data[0])
+    assert list(v[strings[1]]) == list(resize_data[1])
 
 def test_init_vectors_with_data(strings, data):
     v = Vectors(data=data)

--- a/spacy/vectors.pyx
+++ b/spacy/vectors.pyx
@@ -52,7 +52,7 @@ cdef class Vectors:
     cdef public object name
     cdef public object data
     cdef public object key2row
-    cdef cppset[int] _unset
+    cdef public cppset[int] _unset
 
     def __init__(self, *, shape=None, data=None, keys=None, name=None):
         """Create a new vector store.

--- a/spacy/vectors.pyx
+++ b/spacy/vectors.pyx
@@ -52,7 +52,7 @@ cdef class Vectors:
     cdef public object name
     cdef public object data
     cdef public object key2row
-    cdef public cppset[int] _unset
+    cdef cppset[int] _unset
 
     def __init__(self, *, shape=None, data=None, keys=None, name=None):
         """Create a new vector store.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->
Changed python set to cpp stl set #2032 
## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Changed python set to cpp stl set. CPP stl set works better due to the logarithmic run time of its methods. Finding minimum in the cpp set is done in constant time as opposed to the worst case linear runtime of python set. Operations such as find,count,insert,delete are also done in either constant and logarithmic time thus making cpp set a better option to manage vectors.
Reference : http://www.cplusplus.com/reference/set/set/
### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Enhancement for `Vectors` for faster initialising of word vectors(fasttext)
## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
