### PR TITLE
💫 Add .similarity warnings for no vectors and option to exclude warnings

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -38,6 +38,13 @@ class Warnings(object):
             "surprising to you, make sure the Doc was processed using a model "
             "that supports named entity recognition, and check the `doc.ents` "
             "property manually if necessary.")
+    W007 = ("The model you're using has no word vectors loaded, so the result "
+            "of the {obj}.similarity method will be based on the tagger, "
+            "parser and NER, which may not give useful similarity judgements. "
+            "This may happen if you're using one of the small models, e.g. "
+            "`en_core_web_sm`, which don't ship with word vectors and only "
+            "use context-sensitive tensors. You can always add your own word "
+            "vectors, or use one of the larger models instead if available.")
     W008 = ("Evaluating {obj}.similarity based on empty vectors.")
 
 

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -38,6 +38,7 @@ class Warnings(object):
             "surprising to you, make sure the Doc was processed using a model "
             "that supports named entity recognition, and check the `doc.ents` "
             "property manually if necessary.")
+    W008 = ("Evaluating {obj}.similarity based on empty vectors.")
 
 
 @add_codes

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -283,8 +283,15 @@ def _get_warn_types(arg):
             if w_type.strip() in WARNINGS]
 
 
+def _get_warn_excl(arg):
+    if not arg:
+        return []
+    return [w_id.strip() for w_id in arg.split(',')]
+
+
 SPACY_WARNING_FILTER = os.environ.get('SPACY_WARNING_FILTER', 'always')
 SPACY_WARNING_TYPES = _get_warn_types(os.environ.get('SPACY_WARNING_TYPES'))
+SPACY_WARNING_EXCLUDE = _get_warn_excl(os.environ.get('SPACY_WARNING_EXCLUDE'))
 
 
 def user_warning(message):
@@ -304,7 +311,8 @@ def _warn(message, warn_type='user'):
     message (unicode): The message to display.
     category (Warning): The Warning to show.
     """
-    if warn_type in SPACY_WARNING_TYPES:
+    w_id = message.split('[', 1)[1].split(']', 1)[0]  # get ID from string
+    if warn_type in SPACY_WARNING_TYPES and w_id not in SPACY_WARNING_EXCLUDE:
         category = WARNINGS[warn_type]
         stack = inspect.stack()[-1]
         with warnings.catch_warnings():

--- a/spacy/lexeme.pyx
+++ b/spacy/lexeme.pyx
@@ -15,7 +15,7 @@ from .attrs cimport IS_TITLE, IS_UPPER, LIKE_URL, LIKE_NUM, LIKE_EMAIL, IS_STOP
 from .attrs cimport IS_BRACKET, IS_QUOTE, IS_LEFT_PUNCT, IS_RIGHT_PUNCT, IS_CURRENCY, IS_OOV
 from .attrs cimport PROB
 from .attrs import intify_attrs
-from .errors import Errors
+from .errors import Errors, Warnings, user_warning
 
 
 memset(&EMPTY_LEXEME, 0, sizeof(LexemeC))
@@ -122,6 +122,7 @@ cdef class Lexeme:
             if self.c.orth == other[0].orth:
                 return 1.0
         if self.vector_norm == 0 or other.vector_norm == 0:
+            user_warning(Warnings.W008.format(obj='Lexeme'))
             return 0.0
         return (numpy.dot(self.vector, other.vector) /
                 (self.vector_norm * other.vector_norm))

--- a/spacy/tests/doc/test_doc_api.py
+++ b/spacy/tests/doc/test_doc_api.py
@@ -220,11 +220,13 @@ def test_doc_api_has_vector():
 
 def test_doc_api_similarity_match():
     doc = Doc(Vocab(), words=['a'])
-    assert doc.similarity(doc[0]) == 1.0
-    assert doc.similarity(doc.vocab['a']) == 1.0
+    with pytest.warns(None):
+        assert doc.similarity(doc[0]) == 1.0
+        assert doc.similarity(doc.vocab['a']) == 1.0
     doc2 = Doc(doc.vocab, words=['a', 'b', 'c'])
-    assert doc.similarity(doc2[:1]) == 1.0
-    assert doc.similarity(doc2) == 0.0
+    with pytest.warns(None):
+        assert doc.similarity(doc2[:1]) == 1.0
+        assert doc.similarity(doc2) == 0.0
 
 
 def test_lowest_common_ancestor(en_tokenizer):

--- a/spacy/tests/doc/test_span.py
+++ b/spacy/tests/doc/test_span.py
@@ -72,9 +72,10 @@ def test_span_similarity_match():
     doc = Doc(Vocab(), words=['a', 'b', 'a', 'b'])
     span1 = doc[:2]
     span2 = doc[2:]
-    assert span1.similarity(span2) == 1.0
-    assert span1.similarity(doc) == 0.0
-    assert span1[:1].similarity(doc.vocab['a']) == 1.0
+    with pytest.warns(None):
+        assert span1.similarity(span2) == 1.0
+        assert span1.similarity(doc) == 0.0
+        assert span1[:1].similarity(doc.vocab['a']) == 1.0
 
 
 def test_spans_default_sentiment(en_tokenizer):

--- a/spacy/tests/vectors/test_similarity.py
+++ b/spacy/tests/vectors/test_similarity.py
@@ -45,7 +45,8 @@ def test_vectors_similarity_TT(vocab, vectors):
 def test_vectors_similarity_TD(vocab, vectors):
     [(word1, vec1), (word2, vec2)] = vectors
     doc = get_doc(vocab, words=[word1, word2])
-    assert doc.similarity(doc[0]) == doc[0].similarity(doc)
+    with pytest.warns(None):
+        assert doc.similarity(doc[0]) == doc[0].similarity(doc)
 
 
 def test_vectors_similarity_DS(vocab, vectors):
@@ -57,4 +58,5 @@ def test_vectors_similarity_DS(vocab, vectors):
 def test_vectors_similarity_TS(vocab, vectors):
     [(word1, vec1), (word2, vec2)] = vectors
     doc = get_doc(vocab, words=[word1, word2])
-    assert doc[:2].similarity(doc[0]) == doc[0].similarity(doc[:2])
+    with pytest.warns(None):
+        assert doc[:2].similarity(doc[0]) == doc[0].similarity(doc[:2])

--- a/spacy/tests/vectors/test_vectors.py
+++ b/spacy/tests/vectors/test_vectors.py
@@ -182,15 +182,17 @@ def test_vectors_lexeme_doc_similarity(vocab, text):
 @pytest.mark.parametrize('text', [["apple", "orange", "juice"]])
 def test_vectors_span_span_similarity(vocab, text):
     doc = get_doc(vocab, text)
-    assert doc[0:2].similarity(doc[1:3]) == doc[1:3].similarity(doc[0:2])
-    assert -1. < doc[0:2].similarity(doc[1:3]) < 1.0
+    with pytest.warns(None):
+        assert doc[0:2].similarity(doc[1:3]) == doc[1:3].similarity(doc[0:2])
+        assert -1. < doc[0:2].similarity(doc[1:3]) < 1.0
 
 
 @pytest.mark.parametrize('text', [["apple", "orange", "juice"]])
 def test_vectors_span_doc_similarity(vocab, text):
     doc = get_doc(vocab, text)
-    assert doc[0:2].similarity(doc) == doc.similarity(doc[0:2])
-    assert -1. < doc[0:2].similarity(doc) < 1.0
+    with pytest.warns(None):
+        assert doc[0:2].similarity(doc) == doc.similarity(doc[0:2])
+        assert -1. < doc[0:2].similarity(doc) < 1.0
 
 
 @pytest.mark.parametrize('text1,text2', [

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -313,7 +313,8 @@ cdef class Doc:
                         break
                 else:
                     return 1.0
-
+        if self.vocab.vectors.n_keys == 0:
+            models_warning(Warnings.W007.format(obj='Doc'))
         if self.vector_norm == 0 or other.vector_norm == 0:
             user_warning(Warnings.W008.format(obj='Doc'))
             return 0.0

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -31,7 +31,8 @@ from ..attrs cimport ENT_TYPE, SENT_START
 from ..parts_of_speech cimport CCONJ, PUNCT, NOUN, univ_pos_t
 from ..util import normalize_slice
 from ..compat import is_config, copy_reg, pickle, basestring_
-from ..errors import Errors, Warnings, deprecation_warning
+from ..errors import deprecation_warning, models_warning, user_warning
+from ..errors import Errors, Warnings
 from .. import util
 from .underscore import Underscore, get_ext_args
 from ._retokenize import Retokenizer
@@ -314,6 +315,7 @@ cdef class Doc:
                     return 1.0
 
         if self.vector_norm == 0 or other.vector_norm == 0:
+            user_warning(Warnings.W008.format(obj='Doc'))
             return 0.0
         return numpy.dot(self.vector, other.vector) / (self.vector_norm * other.vector_norm)
 

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -194,6 +194,8 @@ cdef class Span:
                     break
             else:
                 return 1.0
+        if self.vocab.vectors.n_keys == 0:
+            models_warning(Warnings.W007.format(obj='Span'))
         if self.vector_norm == 0.0 or other.vector_norm == 0.0:
             user_warning(Warnings.W008.format(obj='Span'))
             return 0.0

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -16,7 +16,7 @@ from ..util import normalize_slice
 from ..attrs cimport IS_PUNCT, IS_SPACE
 from ..lexeme cimport Lexeme
 from ..compat import is_config
-from ..errors import Errors, TempErrors
+from ..errors import Errors, TempErrors, Warnings, user_warning, models_warning
 from .underscore import Underscore, get_ext_args
 
 
@@ -195,6 +195,7 @@ cdef class Span:
             else:
                 return 1.0
         if self.vector_norm == 0.0 or other.vector_norm == 0.0:
+            user_warning(Warnings.W008.format(obj='Span'))
             return 0.0
         return numpy.dot(self.vector, other.vector) / (self.vector_norm * other.vector_norm)
 

--- a/spacy/tokens/token.pyx
+++ b/spacy/tokens/token.pyx
@@ -155,6 +155,8 @@ cdef class Token:
         elif hasattr(other, 'orth'):
             if self.c.lex.orth == other.orth:
                 return 1.0
+        if self.vocab.vectors.n_keys == 0:
+            models_warning(Warnings.W007.format(obj='Token'))
         if self.vector_norm == 0 or other.vector_norm == 0:
             user_warning(Warnings.W008.format(obj='Token'))
             return 0.0

--- a/spacy/tokens/token.pyx
+++ b/spacy/tokens/token.pyx
@@ -19,7 +19,7 @@ from ..attrs cimport IS_OOV, IS_TITLE, IS_UPPER, IS_CURRENCY, LIKE_URL, LIKE_NUM
 from ..attrs cimport IS_STOP, ID, ORTH, NORM, LOWER, SHAPE, PREFIX, SUFFIX
 from ..attrs cimport LENGTH, CLUSTER, LEMMA, POS, TAG, DEP
 from ..compat import is_config
-from ..errors import Errors
+from ..errors import Errors, Warnings, user_warning, models_warning
 from .. import util
 from .underscore import Underscore, get_ext_args
 
@@ -156,6 +156,7 @@ cdef class Token:
             if self.c.lex.orth == other.orth:
                 return 1.0
         if self.vector_norm == 0 or other.vector_norm == 0:
+            user_warning(Warnings.W008.format(obj='Token'))
             return 0.0
         return (numpy.dot(self.vector, other.vector) /
                 (self.vector_norm * other.vector_norm))


### PR DESCRIPTION
See #2164 ([comment](https://github.com/explosion/spaCy/issues/2164#issuecomment-379727077)).

## Description

This PR introduces a few updates to the new warnings:

* If `Doc.similarity`, `Span.similarity` or `Token.similarity` is called and the model has no vectors (e.g. if it's a small model that only uses tensors), a warning is shown that explains this, including why the returned scores might not be very accurate. There's been a lot of confusion around this in the past, so I hope that this helps.
* If two empty vectors are evaluated using the `similarity` methods, spaCy will also show a warning.
* Make sure the respective warnings are captured in our `pytest` test suite.
* Specific warning codes can now be excluded via the environment variable `SPACY_WARNING_EXCLUDE` (similar to how linters etc. let you include and exclude specific errors by code). Warnings like the ones added in this PR are a good example for this – they're useful if you're not aware of the problem, but if you are and don't want to keep seeing them, you can tell spaCy to ignore them explicitly:

```bash
export SPACY_WARNING_EXCLUDE=W007,W008
```

(Maybe the variable should be called `SPACY_WARNING_IGNORE`? We also need to find the right place to document the new environment variables and settings for warnings. Since they're all enabled by default, I don't think it needs to be part of the "Getting started" guide. But maybe a new section on "Debugging with spaCy"? I've always wanted to have a docs section like that – I'm just not sure we have enough content yet.)

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
