### PR TITLE
1480 - Implement Fast-Text vectors with subword features

### DIFF
--- a/spacy/tests/vectors/test_vectors.py
+++ b/spacy/tests/vectors/test_vectors.py
@@ -23,6 +23,18 @@ def vectors():
         ('juice', [5, 5, 10]),
         ('pie', [7, 6.3, 8.9])]
 
+@pytest.fixture
+def ngrams_vectors():
+    return [
+        ("apple", [1, 2, 3]),
+        ("app", [-0.1, -0.2, -0.3]),
+        ('ppl', [-0.2, -0.3, -0.4]),
+        ('pl', [0.7, 0.8, 0.9])
+    ]
+@pytest.fixture()
+def ngrams_vocab(en_vocab, ngrams_vectors):
+    add_vecs_to_vocab(en_vocab, ngrams_vectors)
+    return en_vocab
 
 @pytest.fixture
 def data():
@@ -104,6 +116,18 @@ def test_vectors_token_vector(tokenizer_v, vectors, text):
     assert vectors[0] == (doc[0].text, list(doc[0].vector))
     assert vectors[1] == (doc[2].text, list(doc[2].vector))
 
+
+@pytest.mark.parametrize('text', ["apple"])
+def test_vectors__ngrams_word(ngrams_vocab, text):
+    assert list(ngrams_vocab.get_vector(text)) == list(ngrams_vectors()[0][1])
+
+@pytest.mark.parametrize('text', ["applpie"])
+def test_vectors__ngrams_subword(ngrams_vocab, text):
+    truth = list(ngrams_vocab.get_vector(text,1,6))
+    test = list([(ngrams_vectors()[1][1][i] + ngrams_vectors()[2][1][i] + ngrams_vectors()[3][1][i])/3 for i in range(len(ngrams_vectors()[1][1]))])
+    eps = [abs(truth[i] - test[i]) for i in range(len(truth))]
+    for i in eps:
+        assert i<1e-6
 
 @pytest.mark.parametrize('text', ["apple", "orange"])
 def test_vectors_lexeme_vector(vocab, text):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->
Implement Fast-Text vectors with subword features #1480 

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
This commit incorporates subword information to get embeddings for words using fasttext.
For words found in the input vocab model, the vector is returned as it is. For out of vocab words, average of all the subword vectors are computed and returned.
ngram range can be given as optional params. If no range is specified, no subwords are used and the word is used as it is. 
This enables simple and easy integration of subword information and is agnostic of the vocab model supplied.

Usage:
```vocab.get_vector(text,minn,maxn)```
### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
