### PR TITLE
Fix code sample for span.set_extension

### DIFF
--- a/website/api/span.jade
+++ b/website/api/span.jade
@@ -127,7 +127,7 @@ p
 
 +aside-code("Example").
     from spacy.tokens import Span
-    city_getter = lambda span: span.text in ('New York', 'Paris', 'Berlin')
+    city_getter = lambda span: any(city in span.text for city in ('New York', 'Paris', 'Berlin'))
     Span.set_extension('has_city', getter=city_getter)
     doc = nlp(u'I like New York in Autumn')
     assert doc[1:4]._.has_city


### PR DESCRIPTION
## Description
Same fix as [PR 2282](https://github.com/explosion/spaCy/pull/2282) but for `Span._set_extension` this time, didn't notice that this one had the same bug. And I checked that `Token.set_extension` doesn't need a fix :).

### Types of change
This is a bug fix to sample code **in the documentation**.

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
