### PR TITLE
Fix bug in custom_component_countries_api.py script

### DIFF
--- a/examples/pipeline/custom_component_countries_api.py
+++ b/examples/pipeline/custom_component_countries_api.py
@@ -68,9 +68,9 @@ class RESTCountriesComponent(object):
         # the matches, so we're only setting a default value, not a getter.
         # If no default value is set, it defaults to None.
         Token.set_extension('is_country', default=False)
-        Token.set_extension('country_capital')
-        Token.set_extension('country_latlng')
-        Token.set_extension('country_flag')
+        Token.set_extension('country_capital', default=False)
+        Token.set_extension('country_latlng', default=False)
+        Token.set_extension('country_flag', default=False)
 
         # Register attributes on Doc and Span via a getter that checks if one of
         # the contained tokens is set to is_country == True.


### PR DESCRIPTION
## Description
Fix bug in the custom_component_countries_api.py script.
Set a `default` when setting extension to prevent the following `ValueError`:

```
ValueError: [E083] Error setting extension: only one of `default`, `method`, or `getter` (plus optional `setter`) is allowed. Got: 0
```

### Types of change
Fixes bug in example script.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
