### PR TITLE
💫 Support pipeline component factories via entry points (with detailed examples)

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -46,6 +46,8 @@ class Warnings(object):
             "use context-sensitive tensors. You can always add your own word "
             "vectors, or use one of the larger models instead if available.")
     W008 = ("Evaluating {obj}.similarity based on empty vectors.")
+    W009 = ("Custom factory '{name}' provided by entry points of another "
+            "package overwrites built-in factory.")
 
 
 @add_codes

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -28,7 +28,7 @@ from .lang.punctuation import TOKENIZER_INFIXES
 from .lang.tokenizer_exceptions import TOKEN_MATCH
 from .lang.tag_map import TAG_MAP
 from .lang.lex_attrs import LEX_ATTRS, is_stop
-from .errors import Errors
+from .errors import Errors, Warnings, user_warning
 from . import util
 from . import about
 
@@ -139,6 +139,11 @@ class Language(object):
             100,000 characters in one text.
         RETURNS (Language): The newly constructed object.
         """
+        user_factories = util.get_entry_points('spacy_factories')
+        for factory in user_factories.keys():
+            if factory in self.factories:
+                user_warning(Warnings.W009.format(name=factory))
+        self.factories.update(user_factories)
         self._meta = dict(meta)
         self._path = None
         if vocab is True:

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -220,6 +220,19 @@ def get_package_path(name):
     return Path(pkg.__file__).parent
 
 
+def get_entry_points(key):
+    """Get registered entry points from other packages for a given key, e.g.
+    'spacy_factories' and return them as a dictionary, keyed by name.
+
+    key (unicode): Entry point name.
+    RETURNS (dict): Entry points, keyed by name.
+    """
+    result = {}
+    for entry_point in pkg_resources.iter_entry_points(key):
+        result[entry_point.name] = entry_point.load()
+    return result
+
+
 def is_in_jupyter():
     """Check if user is running spaCy from a Jupyter notebook by detecting the
     IPython kernel. Mainly used for the displaCy visualizer.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

This PR introduces a new mechanism for registering custom pipeline components and their factories and making it easy to define them in a custom model's pipeline.

When you load a model, spaCy will generally use the model's `meta.json` to set up the language class and construct the pipeline. The pipeline is specified as a list of strings, e.g. `"pipeline": ["tagger", "paser", "ner"]`. For each of those strings, spaCy will call `nlp.create_pipe` and look up the name in the [built-in factories](https://github.com/explosion/spaCy/blob/1a4682dd0bdf4d8b7b4c3dd23c3829b1333f2fa5/spacy/language.py#L101). If your model wanted to specify its own custom components, you previously had to write to `Language.factories` *before* loading the model.

```python
pipe = nlp.create_pipe('custom_component')  # fails 😞

Language.factories['custom_component'] = CustomComponentFactory
pipe = nlp.create_pipe('custom_component')  # works 😃
```

This was inconvenient and usually required shipping a bunch of component initialisation code with the model. Using entry points, model packages and extension packages can now define their own `'spacy_factories'`, which will be added to the built-in factories when the `Language` class is initialised. If a package in the same environment exposes spaCy entry points, all of this happens automatically and no further user action is required.

### Details and Example

For a quick and fun intro to entry points in Python, I recommend [this blog post](https://amir.rachum.com/blog/2017/07/28/python-entry-points/). To stick with the theme of the post, consider the following custom spaCy extension which is initialised with the shared `nlp` object and will print a snake when it's called as a pipeline component.

#### `snek.py`
```python
snek = """\
    --..,_                     _,.--.
       `'.'.                .'`__ o  `;__.
          '.'.            .'.'`  '---'`  `
            '.`'--....--'`.'
              `'--....--'`
"""

class SnekFactory(object):
    def __init__(self, nlp, **cfg):
        self.nlp = nlp

    def __call__(self, doc):
        print(snek)
        return doc
```

Since it's a very complex and sophisticated module, you want to split it off into its own package so you can version it and upload it to PyPi. You also want your custom model to be able to define `"pipeline": ["snek"]` in its `meta.json`. For that, you need to be able to tell spaCy where to find the factory for `"snek"`. If you don't do this, spaCy will raise an error when you try to load the model because there's no built-in `"snek"` factory. To add an entry to the factories, you can now expose it in your `setup.py` via the `entry_points` dictionary:

#### `setup.py`
```python
from setuptools import setup

setup(
    name='snek',
    entry_points={
        'spacy_factories': [
            'snek = snek:SnekFactory'        
         ]
    }
)
```

The entry point definition tells spaCy that the name `snek` can be found in the module `snek` (i.e. `snek.py`) as `SnekFactory`. The same package can expose multiple entry points.  To make them available to spaCy, all you need to do is install the package:

```bash
python setup.py develop
```

spaCy is now able to create the pipeline component `'snek'`:

```bash
>>> from spacy.lang.en import English

>>> nlp = English()
>>> snek = nlp.create_pipe('snek')  # this now works! 🐍🎉
>>> nlp.add_pipe(snek)
>>> doc = nlp(u"I am snek")
    --..,_                     _,.--.
       `'.'.                .'`__ o  `;__.
          '.'.            .'.'`  '---'`  `
            '.`'--....--'`.'
              `'--....--'`
```

Arguably, this gets even more exciting when you train your `en_core_snek_sm` model. To make sure `snek` is installed with the model, you can add it to the model's `setup.py`. You can then tell spaCy to construct the model pipeline with the `snek` component:

#### `meta.json`
```json
{
  "lang": "en",
  "name": "core_snek_sm",
  "version": "1.0.0",
  "pipeline": ["snek"]
}
```

In theory, the entry point mechanism also lets you overwrite built-in factories – including the tokenizer. By default, spaCy will output a warning in these cases, to prevent accidental overwrites and unintended results.

### Advanced usage

The `**cfg` keyword arguments that the factory receives are passed down all the way from `spacy.load`. This means that the factory can respond to custom settings defined when loading the model –  for example, the style of the snek to load:

```python
nlp = spacy.load('en_core_snek_sm', snek_style='cute')
```

```python
SNEKS = {'basic': snek, 'cute': cute_snek}  # collection of sneks

class SnekFactory(object):
    def __init__(self, nlp, **cfg):
        self.nlp = nlp
        self.snek_style = cfg.get('snek_style', 'basic')
        self.snek = SNEKS[self.snek_style]

    def __call__(self, doc):
        print(self.snek)
        return doc
```

The factory can also implement other [`Pipe` methods](https://spacy.io/api/pipe) like `to_disk` and `from_disk` for serialization, or even `update` to make the component trainable. If a component exposes a `from_disk` method and is included in a model's pipeline, spaCy will call it on load. This lets you ship custom data with your model. When you save out a model using `nlp.to_disk` and the component exposes a `to_disk` method, it will be called with the disk path.

```python
def to_disk(self, path):
    snek_path = path / 'snek.txt'
    with snek_path.open('w', encoding='utf8') as snek_file:
        snek_file.write(self.snek)

def from_disk(self, path, **cfg):
    snek_path = path / 'snek.txt'
    with snek_path.open('r', encoding='utf8') as snek_file:
        self.snek = snek_file.read()
    return self
```

The above example will serialize the current snek in a `snek.txt` in the model data directory. When a model using the `snek` component is loaded, it will open the `snek.txt` and make it available to the component.

### Future plans

I might write up a more detailed blog post on this topic that goes beyond snek. For example, a custom gazetteer component that pre-labels named entities based on word lists that can be serialized with a model.

If this approach works well, we can also implement something similar for custom `Language` classes via the `spacy_language` entry point (to address situations like #1816).

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
