### PR TITLE
Fix bug in CLI iob and ner converter

### DIFF
--- a/.github/contributors/mpszumowski.md
+++ b/.github/contributors/mpszumowski.md
@@ -87,7 +87,7 @@ U.S. Federal law. Any choice of law rules will not apply.
 7. Please place an “x” on one of the applicable statement below. Please do NOT
 mark both statements:
 
-    * [ ] I am signing on behalf of myself as an individual and no other person
+    * [x] I am signing on behalf of myself as an individual and no other person
     or entity, including my employer, has or will have rights with respect to my
     contributions.
 

--- a/.github/contributors/mpszumowski.md
+++ b/.github/contributors/mpszumowski.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI UG (haftungsbeschränkt)](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [ ] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           | Maciej Szumowski     |
+| Company name (if applicable)   |                      |
+| Title or role (if applicable)  |                      |
+| Date                           | 30.05.2018           |
+| GitHub username                | mpszumowski          |
+| Website (optional)             |                      |

--- a/spacy/gold.pyx
+++ b/spacy/gold.pyx
@@ -353,12 +353,14 @@ def _consume_os(tags):
 def _consume_ent(tags):
     if not tags:
         return []
-    target = tags.pop(0).replace('B', 'I')
+    tag = tags.pop(0)
+    target_in = 'I' + tag[1:]
+    target_last = 'L' + tag[1:]
     length = 1
-    while tags and tags[0] == target:
+    while tags and tags[0] in {target_in, target_last}:
         length += 1
         tags.pop(0)
-    label = target[2:]
+    label = tag[2:]
     if length == 1:
         return ['U-' + label]
     else:

--- a/spacy/tests/regression/test_issue2385.py
+++ b/spacy/tests/regression/test_issue2385.py
@@ -7,11 +7,17 @@ from ...gold import iob_to_biluo
 @pytest.mark.xfail
 @pytest.mark.parametrize('tags', [('B-ORG', 'L-ORG'),
                                   ('B-PERSON', 'I-PERSON', 'L-PERSON'),
-                                  ('B-BRAWLER', 'I-BRAWLER', 'L-BRAWLER'),
                                   ('U-BRAWLER', 'U-BRAWLER')])
 def test_issue2385_biluo(tags):
     """already biluo format"""
     assert iob_to_biluo(tags) == list(tags)
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize('tags', [('B-BRAWLER', 'I-BRAWLER', 'I-BRAWLER')])
+def test_issue2385_iob_bcharacter(tags):
+    """fix bug in labels with a 'b' character"""
+    assert iob_to_biluo(tags) == ['B-BRAWLER', 'I-BRAWLER', 'L-BRAWLER']
 
 
 @pytest.mark.xfail

--- a/spacy/tests/regression/test_issue2385.py
+++ b/spacy/tests/regression/test_issue2385.py
@@ -1,0 +1,28 @@
+# coding: utf-8
+import pytest
+
+from ...gold import iob_to_biluo
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize('tags', [('B-ORG', 'L-ORG'),
+                                  ('B-PERSON', 'I-PERSON', 'L-PERSON'),
+                                  ('B-BRAWLER', 'I-BRAWLER', 'L-BRAWLER'),
+                                  ('U-BRAWLER', 'U-BRAWLER')])
+def test_issue2385_biluo(tags):
+    """already biluo format"""
+    assert iob_to_biluo(tags) == list(tags)
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize('tags', [('I-ORG', 'I-ORG', 'B-ORG')])
+def test_issue2385_iob1(tags):
+    """maintain support for iob1 format"""
+    assert iob_to_biluo(tags) == ['B-ORG', 'L-ORG', 'U-ORG']
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize('tags', [('B-PERSON', 'I-PERSON', 'B-PERSON')])
+def test_issue2385_iob2(tags):
+    """maintain support for iob2 format"""
+    assert iob_to_biluo(tags) == ['B-PERSON', 'L-PERSON', 'U-PERSON']


### PR DESCRIPTION
Fix a bug in iob_to_biluo function in case of labels with a 'b' character and modify _consume_ent for cli.converter to handle tags already in biluo format.

## Description
https://github.com/explosion/spaCy/issues/2385

If tags in BILUO format are passed to the CLI converter, the L-flag goes unprocessed and n-word tokens are read as (n-1)-word tokens. This is because the CLI iob and ner 2json converters both presuppose that NER tags are passed in IOB1/2 format and convert them to BILUO in gold.iob_to_biluo. 

This may not always be the case - especially the conll_ner2json converter is not self-evident to accept specifically IOB format. What is more, the currently suggested workflow of preparing the dataset for the isolated NER pipeline component is to convert any offset NER tags into BILUO using biluo_tags_from_offsets, write a script converting the docs into .iob or .conll format and then use the CLI converter on the BILUO-tagged docs to obtain the json file accepted by CLI train.

This shows that a general-purpose writer that will also convert offset tags straight into json would be handy. Before it's ready I have modified the iob_to_biluo function to accept both IOB and BILUO formats. In the process I have also fixed a bug that would corrupt labels with a 'B' character due to the str.replace('B', 'I') method.

### Types of change
Bug fix
