### PR TITLE
replace janome with mecab in the documentation and the test

### DIFF
--- a/.github/contributors/himkt.md
+++ b/.github/contributors/himkt.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI UG (haftungsbeschränkt)](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [ x ] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ x ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                   |
+|------------------------------- | ----------------------- |
+| Name                           | himkt                   |
+| Company name (if applicable)   | University of Tsukuba   |
+| Title or role (if applicable)  |                         |
+| Date                           | 2018-06-07              |
+| GitHub username                | himkt                   |
+| Website (optional)             | https://himkt.github.io |

--- a/examples/information_extraction/phrase_matcher.py
+++ b/examples/information_extraction/phrase_matcher.py
@@ -34,6 +34,10 @@ formatted in jsonl as a sequence of entries like this:
 {"text":"Appalachia"}
 {"text":"Argentina"}
 
+Reddit comments corpus:
+* https://files.pushshift.io/reddit/
+* https://archive.org/details/2015_reddit_comments_corpus
+
 Compatible with: spaCy v2.0.0+
 """
 from __future__ import print_function, unicode_literals, division

--- a/spacy/tests/conftest.py
+++ b/spacy/tests/conftest.py
@@ -141,7 +141,7 @@ def da_tokenizer():
 
 @pytest.fixture
 def ja_tokenizer():
-    janome = pytest.importorskip("MeCab")
+    mecab = pytest.importorskip("MeCab")
     return util.get_lang_class('ja').Defaults.create_tokenizer()
 
 @pytest.fixture

--- a/website/usage/_models/_languages.jade
+++ b/website/usage/_models/_languages.jade
@@ -44,7 +44,7 @@ p
 
     +list.o-no-block
         +item #[strong Chinese]: #[+a("https://github.com/fxsjy/jieba") Jieba]
-        +item #[strong Japanese]: #[+a("https://github.com/mocobeta/janome") Janome]
+        +item #[strong Japanese]: #[+a("https://github.com/taku910/mecab") MeCab]
         +item #[strong Thai]: #[+a("https://github.com/wannaphongcom/pythainlp") pythainlp]
         +item #[strong Vietnamese]: #[+a("https://github.com/trungtv/pyvi") Pyvi]
         +item #[strong Russian]: #[+a("https://github.com/kmike/pymorphy2") pymorphy2]


### PR DESCRIPTION
This PR is simple document fix.

## Description

In my glance, spaCy now uses MeCab for Japanese Tokenizer.
But the documentation still refers Janome, which is confusing for me.

## __NOTION__
This PR only changes the documentation.
So I create this PR although unittest fails in my environment.
I will further investigate about unittest failing.

### Types of change
change to the documentation

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
