### PR TITLE
Add sent property to token

### DIFF
--- a/spacy/tests/doc/test_token_api.py
+++ b/spacy/tests/doc/test_token_api.py
@@ -56,6 +56,14 @@ def test_doc_token_api_str_builtin(en_tokenizer, text):
     assert str(tokens[0]) == text.split(' ')[0]
     assert str(tokens[1]) == text.split(' ')[1]
 
+@pytest.fixture
+def doc(en_tokenizer):
+    text = "This is a sentence. This is another sentence. And a third."
+    heads = [1, 0, 1, -2, -3, 1, 0, 1, -2, -3, 0, 1, -2, -1]
+    deps = ['nsubj', 'ROOT', 'det', 'attr', 'punct', 'nsubj', 'ROOT', 'det',
+            'attr', 'punct', 'ROOT', 'det', 'npadvmod', 'punct']
+    tokens = en_tokenizer(text)
+    return get_doc(tokens.vocab, [t.text for t in tokens], heads=heads, deps=deps)
 
 def test_doc_token_api_is_properties(en_vocab):
     text = ["Hi", ",", "my", "email", "is", "test@me.com"]
@@ -162,3 +170,11 @@ def test_is_sent_start(en_tokenizer):
     assert doc[5].is_sent_start is True
     doc.is_parsed = True
     assert len(list(doc.sents)) == 2
+
+def test_tokens_sent(doc):
+    """Test token.sent property"""
+    assert len(list(doc.sents)) == 3
+    assert doc[1].sent.text == 'This is a sentence .'
+    assert doc[7].sent.text == 'This is another sentence .'
+    assert doc[1].sent.root.left_edge.text == 'This'
+    assert doc[7].sent.root.left_edge.text == 'This'

--- a/spacy/tokens/token.pyx
+++ b/spacy/tokens/token.pyx
@@ -350,6 +350,22 @@ cdef class Token:
         def __get__(self):
             return self.c.r_kids
 
+    property sent:
+        """RETURNS (Span): The sentence span that the span is a part of."""
+        def __get__(self):
+            if 'sent' in self.doc.user_span_hooks:
+                return self.doc.user_span_hooks['sent'](self)
+            # This should raise if we're not parsed.
+            self.doc.sents
+            cdef int n = 0
+            root = &self.doc.c[self.i]
+            while root.head != 0:
+                root += root.head
+                n += 1
+                if n >= self.doc.length:
+                    raise RuntimeError
+            return self.doc[root.l_edge:root.r_edge + 1]
+
     property sent_start:
         def __get__(self):
             # Raising a deprecation warning causes errors for autocomplete

--- a/spacy/tokens/token.pyx
+++ b/spacy/tokens/token.pyx
@@ -351,20 +351,11 @@ cdef class Token:
             return self.c.r_kids
 
     property sent:
-        """RETURNS (Span): The sentence span that the span is a part of."""
+        """RETURNS (Span): The sentence span that the token is a part of."""
         def __get__(self):
-            if 'sent' in self.doc.user_span_hooks:
-                return self.doc.user_span_hooks['sent'](self)
-            # This should raise if we're not parsed.
-            self.doc.sents
-            cdef int n = 0
-            root = &self.doc.c[self.i]
-            while root.head != 0:
-                root += root.head
-                n += 1
-                if n >= self.doc.length:
-                    raise RuntimeError
-            return self.doc[root.l_edge:root.r_edge + 1]
+            if 'sent' in self.doc.user_token_hooks:
+                return self.doc.user_token_hooks['sent'](self)
+            return self.doc[self.i : self.i+1].sent
 
     property sent_start:
         def __get__(self):


### PR DESCRIPTION
Adds token.sent property to fetch the sentence the the token is part of.

## Description
This fixes #2518

### Types of change
New feature

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
