### PR TITLE
Guidance to handle binary files in git in Windows

### DIFF
--- a/website/usage/_install/_troubleshooting.jade
+++ b/website/usage/_install/_troubleshooting.jade
@@ -177,3 +177,23 @@ p
     |  your updates. You can also do this by running spaCy over some text,
     |  extracting a bunch of entities the model previously recognised correctly,
     |  and adding them to your training examples.
+
++h(3, "unhashable-list") Unhashable type: 'list'
+
++code(false, "text").
+    TypeError: unhashable type: 'list'
+
+p
+    |  If you're training models, writing them to disk, and versioning them with
+    |  git, you might encounter this error when trying to load them in a Windows
+    |  environment. This happens because a default install of Git for Windows is
+    |  configured to automatically convert Unix-style end-of-line characters
+    |  (LF) to Windows-style ones (CRLF) during file checkout (and the reverse
+    |  when commiting). While that's mostly fine for text files, a trained model
+    |  written to disk has some binary files that should not go through this
+    |  conversion. When they do, you get the error above. You can fix it by
+    |  either changing your #[+a("https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration", true) "core.autocrlf"]
+    |  setting to "false", or by commiting a #[+a("https://git-scm.com/docs/gitattributes", true) ".gitattributes file"]
+    |  to your repository to tell git on which files or folders it shouldn't do
+    |  LF-to-CRLF conversion, with an entry like "path/to/your/trained/spacy/model/** -text".
+    |  After you've done either of these, clone your repository again.


### PR DESCRIPTION
## Description
Adds guidance on what to do if users encounter the error described in [1634](https://github.com/explosion/spaCy/issues/1634), which probably only happens in Windows environments.

### Types of change
Change to documentation.

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

Since this is purely a documentation change I didn't run the project tests.