### PR TITLE
German lemmatizer additions

### DIFF
--- a/spacy/tests/lang/de/test_lemma.py
+++ b/spacy/tests/lang/de/test_lemma.py
@@ -7,7 +7,9 @@ import pytest
 @pytest.mark.parametrize('string,lemma', [('Abgehängten', 'Abgehängte'),
                                           ('engagierte', 'engagieren'),
                                           ('schließt', 'schließen'),
-                                          ('vorgebenden', 'vorgebend')])
+                                          ('vorgebenden', 'vorgebend'),
+                                          ('die', 'der'),
+                                          ('Die', 'der')])
 def test_lemmatizer_lookup_assigns(de_tokenizer, string, lemma):
     tokens = de_tokenizer(string)
     assert tokens[0].lemma_ == lemma


### PR DESCRIPTION
##  Quick fix to German lemmatizer capitals issue

I made a quick fix to the issue at #2486 . In this fix I included capitalized versions of the words belonging to the  classes that are likely to occur at the beginning of a sentence. I added capital versions of the words that are risk free i.e. has only one possible lemma. Here are the classes:

Personal pronouns
Relative pronouns
Demonstratives
Indefinite articles
Definite articles
Particles
Auxiliary verbs
Modal verbs

Members of these classes usually have only one possible lemma anyway.


### Types of change
Additions are word-lemma pairs, for instance:

Die:der
Das:der
Welche:welch


- I was very careful not to override any word-lemma pairs that already exists.
- New behavior is as follows: When one of these words is in capital, lemma is the small version i.e. "Die" -> "der". Please see the tests.
- I made a list of the word -lemma pairs, sorted by word categories: https://github.com/DuyguA/spaCy/tree/german_lemmatizer_additions  . Again in the case if a word existed as a key in existing lemmatizer file, old version is not overriden. I tried to disturb the existing word-lemma pairs as less as possible.
- In the case of interrogative sentences,  verbs can come to the beginning of the sentence as well. I'll make a separate PR for a verbs list.

## Checklist

- [x ] I have submitted the spaCy Contributor Agreement.
- [ x] I ran the tests, and all new and existing tests passed.
- [ x] My changes don't require a change to the documentation, or if they do, I've added all required information.
