### PR TITLE
Fixed typo

### DIFF
--- a/website/api/doc.jade
+++ b/website/api/doc.jade
@@ -288,7 +288,7 @@ p
     +row
         +cell #[code end]
         +cell int
-        +cell The index of the first character after the span.
+        +cell The index of the last character after the span.
 
     +row
         +cell #[code label]


### PR DESCRIPTION
Changed 'The index of the first character after the span.' to 'The index of the last character after the span' in description of doc.char_span under field 'end'.

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
