### PR TITLE
Swedish: Exceptions for single letter words ending sentence

### DIFF
--- a/spacy/lang/sv/tokenizer_exceptions.py
+++ b/spacy/lang/sv/tokenizer_exceptions.py
@@ -1,7 +1,7 @@
 # coding: utf8
 from __future__ import unicode_literals
 
-from ...symbols import ORTH, LEMMA, TAG, NORM, PRON_LEMMA
+from ...symbols import ORTH, LEMMA, TAG, NORM, PRON_LEMMA, PUNCT
 
 
 _exc = {}
@@ -78,5 +78,11 @@ for orth in [
     "s.k.", "st.", "s:t", "t.ex.", "t.o.m.", "ung.", "äv.", "övers."]:
     _exc[orth] = [{ORTH: orth}]
 
+# Sentences ending in "i." (as in "... peka i."), "m." (as in "...än 2000 m."),
+# should be tokenized as two separate tokens.
+for orth in ["i", "m"]:
+    _exc[orth + "."] = [
+        {ORTH: orth, LEMMA: orth, NORM: orth},
+        {ORTH: ".", TAG: PUNCT}]
 
 TOKENIZER_EXCEPTIONS = _exc

--- a/spacy/tests/lang/sv/test_tokenizer.py
+++ b/spacy/tests/lang/sv/test_tokenizer.py
@@ -6,7 +6,8 @@ import pytest
 
 SV_TOKEN_EXCEPTION_TESTS = [
     ('Smörsåsen används bl.a. till fisk', ['Smörsåsen', 'används', 'bl.a.', 'till', 'fisk']),
-    ('Jag kommer först kl. 13 p.g.a. diverse förseningar', ['Jag', 'kommer', 'först', 'kl.', '13', 'p.g.a.', 'diverse', 'förseningar'])
+    ('Jag kommer först kl. 13 p.g.a. diverse förseningar', ['Jag', 'kommer', 'först', 'kl.', '13', 'p.g.a.', 'diverse', 'förseningar']),
+    ('Anders I. tycker om ord med i i.', ["Anders", "I.", "tycker", "om", "ord", "med", "i", "i", "."])
 ]
 
 


### PR DESCRIPTION
This is part of #2608.

## Description
Sentences ending in "i." (as in "... peka i."), "m." (as in "...än 2000 m."), should be tokenized as two separate tokens, not one.

In the corpus there is a single case of "let's call that variable e."; that gets incorrectly tokenized into "e.". But this variable name could be anything, so to fix it in the general case, I'd have to remove all single letter exceptions. There are two ways to do this:

1) In the language specific code, I could override the single letter versions, to make sure they are two different tokens again. This runs into the problem that "s." is an abbreviation in Swedish, which should be one unit. So one option would be "removing everything except s". Doesn't feel like "clean code" to me...

2) I also tried removing the single letter exceptions from BASE_EXCEPTIONS. Problem is, "s." is still an abbreviation, and if Swedish has one of them, so does probably other languages... So removing the BASE_EXCEPTIONS means going through all supported languages and make sure to add single letter abbreviations where needed. That's too big of a task for me.

Since none of those two options feel good, I've opted for just adding "i." and "m." as exceptions. This is what this PR does. Feel free to suggest I should go with either 1) or 2) instead.

### Types of change
Bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement (As part of #2613)
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
