### PR TITLE
Typo fix

### DIFF
--- a/website/usage/_models/_install.jade
+++ b/website/usage/_models/_install.jade
@@ -100,7 +100,7 @@ p
     |  containing the models for each installation, you can now choose
     |  #[strong how and where you want to keep your data]. For example, you could
     |  download all models manually and put them into a local directory.
-    |  Whenever your spaCy projects need a models, you create a shortcut link to
+    |  Whenever your spaCy projects need a model, you create a shortcut link to
     |  tell spaCy to load it from there. This means you'll never end up with
     |  duplicate data.
 


### PR DESCRIPTION
Typo fix: "models" -> "model"

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Fixes a subject verb agreement error.  Original sentence read, "Whenever your spaCy projects need a models, you create a shortcut link to tell spaCy to load it from there."

"models" is plural.  It should not be preceded by the article "a" as "a" is an article indicating a single item and "models" is plural.  Top Google result for subject verb agreement is [here](https://webapps.towson.edu/ows/moduleSVAGR.htm)

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Change to the documentation

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ ] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
It a one-letter typo fix.  I did none of the above.