### PR TITLE
Correct error in spacy universe docs concerning spacy-lookup

### DIFF
--- a/website/universe/universe.json
+++ b/website/universe/universe.json
@@ -184,7 +184,7 @@
                 "from spacy_lookup import Entity",
                 "",
                 "nlp = spacy.load('en')",
-                "entity = Entity(nlp, keywords_list=['python', 'java platform'])",
+                "entity = Entity(keywords_list=['python', 'java platform'])",
                 "nlp.add_pipe(entity, last=True)",
                 "",
                 "doc = nlp(u\"I am a product manager for a java and python.\")",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
This pull request corrects a small error to the spacy universe docs concerning spacy-lookup.

### Type of changes
Specifically, the error had to do with the instantiation of the Entity object. It only needs the keywords_list argument, but an additional nlp argument was given to the example in the docs. The problem is now solved.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
