### PR TITLE
raise error when setting overlapping entities as doc.ents to close  #2550

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -250,7 +250,9 @@ class Errors(object):
     E096 = ("Invalid object passed to displaCy: Can only visualize Doc or "
              "Span objects, or dicts if set to manual=True.")
     E097 = ("Can't merge non-disjoint spans. '{token}' is already part of tokens to merge")
-
+    E098 = ("Trying to set conflicting doc.ents: '{span1}' and '{span2}'. A token"
+            " can only be part of one entity, so make sure the entities you're "
+            "setting don't overlap.")
 
 @add_codes
 class TempErrors(object):

--- a/spacy/tests/doc/test_add_entities.py
+++ b/spacy/tests/doc/test_add_entities.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from ...pipeline import EntityRecognizer
 from ..util import get_doc
+from ...tokens import Span
 
 import pytest
 
@@ -22,3 +23,13 @@ def test_doc_add_entities_set_ents_iob(en_vocab):
 
     doc.ents = [(doc.vocab.strings['WORD'], 0, 2)]
     assert [w.ent_iob_ for w in doc] == ['B', 'I', '', '']
+
+def test_add_overlapping_entities(en_vocab):
+    text = ["Louisiana", "Office", "of", "Conservation"]
+    doc = get_doc(en_vocab, text)
+    entity = Span(doc, 0, 4, label=391)
+    doc.ents = [entity]
+
+    new_entity = Span(doc, 0, 1, label=392)
+    with pytest.raises(ValueError):
+        doc.ents = list(doc.ents) + [new_entity]

--- a/spacy/tests/regression/test_issue242.py
+++ b/spacy/tests/regression/test_issue242.py
@@ -17,9 +17,10 @@ def test_issue242(en_tokenizer):
     matcher.add('FOOD', None, *patterns)
 
     matches = [(ent_type, start, end) for ent_type, start, end in matcher(doc)]
-    doc.ents += tuple(matches)
     match1, match2 = matches
     assert match1[1] == 3
     assert match1[2] == 5
     assert match2[1] == 4
     assert match2[2] == 6
+
+    doc.ents += tuple([match2])


### PR DESCRIPTION
Just added detection of overlapping entities and erroring on setting doc.ents, as described in issue 2550

## Description
I also added a unit test, but I had to adapt the unit test for issue 242 which was allowing overlapping entities. I hope this was the desired behavior. I can also change it to something else, if it is preferred.

### Types of change
It's a bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed
I had to adapt the test for issue 242, so that it passes
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
