### PR TITLE
Remove u-strings from example on website index

### DIFF
--- a/website/index.jade
+++ b/website/index.jade
@@ -63,13 +63,13 @@ include _includes/_mixins
                 nlp = spacy.load('en_core_web_sm')
 
                 # Process whole documents
-                text = (u"When Sebastian Thrun started working on self-driving cars at "
-                        u"Google in 2007, few people outside of the company took him "
-                        u"seriously. “I can tell you very senior CEOs of major American "
-                        u"car companies would shake my hand and turn away because I wasn’t "
-                        u"worth talking to,” said Thrun, now the co-founder and CEO of "
-                        u"online higher education startup Udacity, in an interview with "
-                        u"Recode earlier this week.")
+                text = ("When Sebastian Thrun started working on self-driving cars at "
+                        "Google in 2007, few people outside of the company took him "
+                        "seriously. “I can tell you very senior CEOs of major American "
+                        "car companies would shake my hand and turn away because I wasn’t "
+                        "worth talking to,” said Thrun, now the co-founder and CEO of "
+                        "online higher education startup Udacity, in an interview with "
+                        "Recode earlier this week.")
                 doc = nlp(text)
 
                 # Find named entities, phrases and concepts
@@ -77,8 +77,8 @@ include _includes/_mixins
                     print(entity.text, entity.label_)
 
                 # Determine semantic similarities
-                doc1 = nlp(u"my fries were super gross")
-                doc2 = nlp(u"such disgusting fries")
+                doc1 = nlp("my fries were super gross")
+                doc2 = nlp("such disgusting fries")
                 similarity = doc1.similarity(doc2)
                 print(doc1.text, doc2.text, similarity)
 


### PR DESCRIPTION
## Description

u-strings are Python 2 syntax that no-op in Python 3 and Binder runs the example on Python 3.

### Types of change

documentation/bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement. - #2906
- [n/a] I ran the tests, and all new and existing tests passed.
- [n/a] My changes don't require a change to the documentation, or if they do, I've added all required information.
