### PR TITLE
Allow input text of length up to max_length, inclusive

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -334,7 +334,7 @@ class Language(object):
             >>> tokens[0].text, tokens[0].head.tag_
             ('An', 'NN')
         """
-        if len(text) >= self.max_length:
+        if len(text) > self.max_length:
             raise ValueError(Errors.E088.format(length=len(text),
                                                 max_length=self.max_length))
         doc = self.make_doc(text)


### PR DESCRIPTION
## Description
The name `max_length` implies that input of exactly that length is still valid, so this should be the case.
I encountered this problem when I saw the error message and tried to do `text = text[:nlp.max_length]` to resolve it, but of course it was still too long.

### Types of change
Minor bug fix.

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
