### PR TITLE
fixes symbolic link on py3 and windows

### DIFF
--- a/.github/contributors/cicorias.md
+++ b/.github/contributors/cicorias.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI UG (haftungsbeschränkt)](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [X] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           |  Shawn Cicoria                     |
+| Company name (if applicable)   |   Microsoft                   |
+| Title or role (if applicable)  |   Principal Software Engineer                   |
+| Date                           |   November  20, 2018                  |
+| GitHub username                |     cicorias                 |
+| Website (optional)             |      www.cicoria.com                |

--- a/spacy/compat.py
+++ b/spacy/compat.py
@@ -80,7 +80,7 @@ def getattr_(obj, name, *default):
 
 
 def symlink_to(orig, dest):
-    if is_python2 and is_windows:
+    if (is_python2 or is_python3) and is_windows:
         import subprocess
         subprocess.call(['mklink', '/d', path2str(orig), path2str(dest)], shell=True)
     else:

--- a/spacy/compat.py
+++ b/spacy/compat.py
@@ -1,6 +1,7 @@
 # coding: utf8
 from __future__ import unicode_literals
 
+import os
 import sys
 import ujson
 import itertools
@@ -80,12 +81,18 @@ def getattr_(obj, name, *default):
 
 
 def symlink_to(orig, dest):
-    if (is_python2 or is_python3) and is_windows:
+    if is_windows:
         import subprocess
         subprocess.call(['mklink', '/d', path2str(orig), path2str(dest)], shell=True)
     else:
         orig.symlink_to(dest)
 
+def symlink_remove(link):
+    # https://stackoverflow.com/questions/26554135/cant-delete-unlink-a-symlink-to-directory-in-python-windows
+    if( os.path.isdir(path2str(link)) and is_windows ): # this should only be on Py2.7 and windows
+        os.rmdir(path2str(link))
+    else:
+        os.unlink(path2str(link))
 
 def is_config(python2=None, python3=None, windows=None, linux=None, osx=None):
     return (python2 in (None, is_python2) and

--- a/spacy/tests/test_symlink_windows.py
+++ b/spacy/tests/test_symlink_windows.py
@@ -1,0 +1,36 @@
+import os
+from pathlib import Path
+
+from ..compat import symlink_to, symlink_remove, path2str
+
+import pytest
+
+def target_local_path():
+  return './foo-target'
+
+def link_local_path():
+  return './foo-symlink'
+
+
+@pytest.fixture(scope='function')
+def setup_target(request):
+  target = Path(target_local_path())
+  if not target.exists():
+    os.mkdir( path2str(target) )
+
+  # yield -- need to cleanup even if assertion fails
+  # https://github.com/pytest-dev/pytest/issues/2508#issuecomment-309934240
+  def cleanup():  
+    symlink_remove( Path(link_local_path() ) )
+    os.rmdir( target_local_path()  )
+
+  request.addfinalizer(cleanup)
+
+
+def test_create_symlink_windows(setup_target):
+  target = Path(target_local_path())
+  link = Path(link_local_path())
+  assert target.exists()
+
+  symlink_to(link, target)
+  assert link.exists()


### PR DESCRIPTION
during setup of spacy using command
python -m spacy link en_core_web_sm en
closes #2948

<!--- Provide a general summary of your changes in the title. -->

## Description
fixes the issues address in #2948 - where the symbolic link isn't being created and the error message indicates permissions, while it is not permissions.

### Types of change
Bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [X] I have submitted the spaCy Contributor Agreement.
- [X] I ran the tests, and all new and existing tests passed.
- [X] My changes don't require a change to the documentation, or if they do, I've added all required information.
