### PR TITLE
fix issue compiling the latest spacy on MacOS 10.3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,14 @@ if os.environ.get('USE_OPENMP', USE_OPENMP_DEFAULT) == '1':
         COMPILE_OPTIONS['other'].append('-fopenmp')
         LINK_OPTIONS['other'].append('-fopenmp')
 
+if sys.platform == 'darwin':
+    # On Mac, use libc++ because Apple deprecated use of
+    # libstdc
+    COMPILE_OPTIONS['other'].append('-stdlib=libc++')
+    LINK_OPTIONS['other'].append('-lc++')
+    # g++ (used by unix compiler on mac) links to libstdc++ as a default lib.
+    # See: https://stackoverflow.com/questions/1653047/avoid-linking-to-libstdc
+    LINK_OPTIONS['other'].append('-nodefaultlibs')
 
 # By subclassing build_extensions we have the actual compiler that will be used which is really known only after finalize_options
 # http://stackoverflow.com/questions/724664/python-distutils-how-to-get-a-compiler-that-is-going-to-be-used


### PR DESCRIPTION
Installing the latest version of spacy `2.0.17` on my MacOS `10.3.6` computer is failing. It seems Apple deprecated the use of `libstdc` a while back.

## Description

The install fails with an error similar to this:
```
...
  running build_ext
  building 'spacy.parts_of_speech' extension
  creating build/temp.macosx-10.7-x86_64-3.6
  creating build/temp.macosx-10.7-x86_64-3.6/spacy
  gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/anaconda3/include -arch x86_64 -I/anaconda3/include -arch x86_64 -I/anaconda3/include/python3.6m -I/private/var/folders/q3/j42n3r692gb2yl9cp1ncs3q00000gn/T/pip-install-s3qpnk75/spacy/include -I/anaconda3/include/python3.6m -c spacy/parts_of_speech.cpp -o build/temp.macosx-10.7-x86_64-3.6/spacy/parts_of_speech.o -O2 -Wno-strict-prototypes -Wno-unused-function
  warning: include path for stdlibc++ headers not found; pass '-std=libc++' on the command line to use the libc++ standard library instead [-Wstdlibcxx-not-found]
  1 warning generated.
  g++ -bundle -undefined dynamic_lookup -L/anaconda3/lib -arch x86_64 -L/anaconda3/lib -arch x86_64 -arch x86_64 build/temp.macosx-10.7-x86_64-3.6/spacy/parts_of_speech.o -o build/lib.macosx-10.7-x86_64-3.6/spacy/parts_of_speech.cpython-36m-darwin.so -Wl,-rpath,@loader_path/../spacy/platform/darwin/lib
  clang: warning: libstdc++ is deprecated; move to libc++ with a minimum deployment target of OS X 10.9 [-Wdeprecated]
  ld: library not found for -lstdc++
  clang: error: linker command failed with exit code 1 (use -v to see invocation)
  error: command 'g++' failed with exit status 1

  ----------------------------------------
  Failed building wheel for spacy
  Running setup.py clean for spacy
Failed to build spacy
```


### Types of change

This PR changes the spacy setup script to tell the unixcompiler to use `libc++` on Darwin platforms, which allows the install to complete as expected.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
