### PR TITLE
issue #3012: add test

### DIFF
--- a/.github/contributors/clippered.md
+++ b/.github/contributors/clippered.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI UG (haftungsbeschränkt)](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           | Kenneth Cruz         |
+| Company name (if applicable)   |                      |
+| Title or role (if applicable)  |                      |
+| Date                           | 2018-12-07           |
+| GitHub username                | clippered            |
+| Website (optional)             |                      |

--- a/spacy/tests/regression/test_issue3012.py
+++ b/spacy/tests/regression/test_issue3012.py
@@ -1,0 +1,38 @@
+# coding: utf-8
+import pytest
+from ...attrs import ENT_IOB, ENT_TYPE
+from ...tokens import Doc
+
+
+@pytest.mark.xfail
+@pytest.mark.models('en')
+def test_issue3012(EN):
+    sentence = 'This is 10%.'
+
+    doc = EN(sentence)
+
+    ten = doc[2]  # 10
+    assert (ten.orth_, ten.orth_, ten.tag_, ten.ent_type_) == (10, 'NUM', 'CD', 'PERCENT')
+
+    # now removing '10%' entity
+    assert len(doc.ents) == 1
+    header = [ENT_IOB, ENT_TYPE]
+    ent_array = doc.to_array(header)
+    ent = doc.ents[0]
+    for idx in range(ent.start, ent.end):
+        ent_array[idx, 0] = 0
+        ent_array[idx, 1] = 0
+    doc.from_array(header, ent_array)
+    assert len(doc.ents) == 0
+
+    # still making sure nothing changed on array() calls
+    ten = doc[2]  # 10
+    assert (ten.orth_, ten.orth_, ten.tag_, ten.ent_type_) == (10, 'NUM', 'CD', 'PERCENT')
+
+    # serializing then deserializing
+    bytes = doc.to_bytes()
+    doc2 = Doc(EN.vocab).from_bytes(bytes)
+
+    assert len(doc2.ents) == 0
+    ten2 = doc2[2]  # 10
+    assert (ten2.orth_, ten2.orth_, ten2.tag_, ten2.ent_type_) == (10, 'NUM', 'CD', 'PERCENT')

--- a/spacy/tests/regression/test_issue3012.py
+++ b/spacy/tests/regression/test_issue3012.py
@@ -1,18 +1,23 @@
-# coding: utf-8
+# coding: utf8
+from __future__ import unicode_literals
+
 import pytest
+
 from ...attrs import ENT_IOB, ENT_TYPE
 from ...tokens import Doc
+from ..util import get_doc
 
 
 @pytest.mark.xfail
-@pytest.mark.models('en')
-def test_issue3012(EN):
-    sentence = 'This is 10%.'
+def test_issue3012(en_vocab):
+    words = ["This", "is", "10", "%", "."]
+    tags = ["DT", "VBZ", "CD", "NN", "."]
+    pos = ["DET", "VERB", "NUM", "NOUN", "PUNCT"]
+    ents = [(2, 4, "PERCENT")]
+    doc = get_doc(en_vocab, words=words, tags=tags, pos=pos, ents=ents)
 
-    doc = EN(sentence)
-
-    ten = doc[2]  # 10
-    assert (ten.orth_, ten.orth_, ten.tag_, ten.ent_type_) == (10, 'NUM', 'CD', 'PERCENT')
+    expected = ("10", "NUM", "CD", "PERCENT")
+    assert (doc[2].text, doc[2].pos_, doc[2].tag_, doc[2].ent_type_) == expected
 
     # now removing '10%' entity
     assert len(doc.ents) == 1
@@ -25,14 +30,11 @@ def test_issue3012(EN):
     doc.from_array(header, ent_array)
     assert len(doc.ents) == 0
 
-    # still making sure nothing changed on array() calls
-    ten = doc[2]  # 10
-    assert (ten.orth_, ten.orth_, ten.tag_, ten.ent_type_) == (10, 'NUM', 'CD', 'PERCENT')
+    assert (doc[2].text, doc[2].pos_, doc[2].tag_, doc[2].ent_type_) == expected
 
     # serializing then deserializing
-    bytes = doc.to_bytes()
-    doc2 = Doc(EN.vocab).from_bytes(bytes)
-
+    doc_bytes = doc.to_bytes()
+    doc2 = Doc(en_vocab).from_bytes(doc_bytes)
     assert len(doc2.ents) == 0
-    ten2 = doc2[2]  # 10
-    assert (ten2.orth_, ten2.orth_, ten2.tag_, ten2.ent_type_) == (10, 'NUM', 'CD', 'PERCENT')
+
+    assert (doc[2].text, doc[2].pos_, doc[2].tag_, doc[2].ent_type_) == expected


### PR DESCRIPTION
Add regression test for issue#3012

Sorry, I can't get this test to run on my environment. I'm getting an error:
```
E           _pytest.warning_types.RemovedInPytest4Warning: MarkInfo objects are deprecated as they contain merged marks which are hard to deal with correctly.
E           Please use node.get_closest_marker(name) or node.iter_markers(name).
E           Docs: https://docs.pytest.org/en/latest/mark.html#updating-code
``` 

So please feel free to have a look at it too.
