### PR TITLE
Better support for semi-supervised learning

### DIFF
--- a/spacy/_ml.py
+++ b/spacy/_ml.py
@@ -26,7 +26,6 @@ import thinc.extra.load_nlp
 from .attrs import ID, ORTH, LOWER, NORM, PREFIX, SUFFIX, SHAPE
 from .errors import Errors
 from . import util
-from .tokens.doc import Doc
 
 try:
     import torch.nn
@@ -654,6 +653,8 @@ class _RandomWords(object):
 
 
 def _apply_mask(docs, random_words, mask_prob=0.15):
+    # This needs to be here to avoid circular imports
+    from .tokens.doc import Doc
     N = sum(len(doc) for doc in docs)
     mask = numpy.random.uniform(0.0, 1.0, (N,))
     mask = mask >= mask_prob

--- a/spacy/_ml.py
+++ b/spacy/_ml.py
@@ -26,6 +26,7 @@ import thinc.extra.load_nlp
 from .attrs import ID, ORTH, LOWER, NORM, PREFIX, SUFFIX, SHAPE
 from .errors import Errors
 from . import util
+from .tokens.doc import Doc
 
 try:
     import torch.nn
@@ -678,7 +679,7 @@ def _apply_mask(docs, random_words, mask_prob=0.15):
 
 
 def _replace_word(word, random_words, mask="[MASK]"):
-    roll = random.random()
+    roll = numpy.random.random()
     if roll < 0.8:
         return mask
     elif roll < 0.9:

--- a/spacy/_ml.py
+++ b/spacy/_ml.py
@@ -611,3 +611,79 @@ def concatenate_lists(*layers, **kwargs):  # pragma: no cover
 
     model = wrap(concatenate_lists_fwd, concat)
     return model
+
+
+def masked_language_model(vocab, model, mask_prob=0.15):
+    """Convert a model into a BERT-style masked language model"""
+
+    random_words = _RandomWords(vocab)
+
+    def mlm_forward(docs, drop=0.0):
+        mask, docs = _apply_mask(docs, random_words, mask_prob=mask_prob)
+        mask = model.ops.asarray(mask).reshape((mask.shape[0], 1))
+        output, backprop = model.begin_update(docs, drop=drop)
+
+        def mlm_backward(d_output, sgd=None):
+            d_output *= 1 - mask
+            return backprop(d_output, sgd=sgd)
+
+        return output, mlm_backward
+
+    return wrap(mlm_forward, model)
+
+
+class _RandomWords(object):
+    def __init__(self, vocab):
+        self.words = [lex.text for lex in vocab if lex.prob != 0.0]
+        self.probs = [lex.prob for lex in vocab if lex.prob != 0.0]
+        self.words = self.words[:10000]
+        self.probs = self.probs[:10000]
+        self.probs = numpy.exp(numpy.array(self.probs, dtype="f"))
+        self.probs /= self.probs.sum()
+        self._cache = []
+
+    def next(self):
+        if not self._cache:
+            self._cache.extend(
+                numpy.random.choice(len(self.words), 10000, p=self.probs)
+            )
+        index = self._cache.pop()
+        return self.words[index]
+
+
+
+def _apply_mask(docs, random_words, mask_prob=0.15):
+    N = sum(len(doc) for doc in docs)
+    mask = numpy.random.uniform(0.0, 1.0, (N,))
+    mask = mask >= mask_prob
+    i = 0
+    masked_docs = []
+    for doc in docs:
+        words = []
+        for token in doc:
+            if not mask[i]:
+                word = _replace_word(token.text, random_words)
+            else:
+                word = token.text
+            words.append(word)
+            i += 1
+        spaces = [bool(w.whitespace_) for w in doc]
+        # NB: If you change this implementation to instead modify
+        # the docs in place, take care that the IDs reflect the original
+        # words. Currently we use the original docs to make the vectors
+        # for the target, so we don't lose the original tokens. But if
+        # you modified the docs in place here, you would.
+        masked_docs.append(Doc(doc.vocab, words=words, spaces=spaces))
+    return mask, masked_docs
+
+
+def _replace_word(word, random_words, mask="[MASK]"):
+    roll = random.random()
+    if roll < 0.8:
+        return mask
+    elif roll < 0.9:
+        return random_words.next()
+    else:
+        return word
+
+

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -220,7 +220,7 @@ def train(
             if raw_text:
                 random.shuffle(raw_text)
                 raw_batches = util.minibatch((nlp.make_doc(rt['text'])
-                                              for rt in raw_text), size=32)
+                                              for rt in raw_text), size=8)
             words_seen = 0
             with tqdm.tqdm(total=n_train_words, leave=False) as pbar:
                 losses = {}
@@ -237,7 +237,8 @@ def train(
                     )
                     if raw_text:
                         raw_batch = list(next(raw_batches))
-                        cloze.rehearse(raw_batch, sgd=optimizer, losses=losses)
+                        cloze.rehearse(raw_batch, sgd=optimizer, losses=losses,
+                            drop=0.05)
                     pbar.update(sum(len(doc) for doc in docs))
                     words_seen += sum(len(doc) for doc in docs)
             with nlp.use_params(optimizer.averages):

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -188,7 +188,9 @@ def train(
 
     if raw_text:
         cloze = ClozeMultitask(nlp.vocab)
-        cloze.begin_training([nlp.make_doc('Example doc')], tok2vec=nlp.get_pipe('parser').model.tok2vec)
+        cloze.begin_training(
+            [nlp.make_doc('Example doc')],
+            tok2vec=nlp.get_pipe('parser').model.tok2vec)
 
     nlp._optimizer = None
     optimizer.b1_decay = 0.003
@@ -234,8 +236,8 @@ def train(
                         losses=losses
                     )
                     if raw_text:
-                        raw_batch = next(raw_batches)
-                        cloze.update(raw_batch, None, sgd=optimizer, losses=losses)
+                        raw_batch = list(next(raw_batches))
+                        cloze.rehearse(raw_batch, sgd=optimizer, losses=losses)
                     pbar.update(sum(len(doc) for doc in docs))
                     words_seen += sum(len(doc) for doc in docs)
             with nlp.use_params(optimizer.averages):

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -7,7 +7,7 @@ import weakref
 import functools
 from collections import OrderedDict
 from contextlib import contextmanager
-from copy import copy
+from copy import copy, deepcopy
 from thinc.neural import Model
 import srsly
 
@@ -453,6 +453,60 @@ class Language(object):
             for key, (W, dW) in grads.items():
                 sgd(W, dW, key=key)
 
+    def rehearse(self, docs, sgd=None, losses=None, config=None):
+        """Make a "rehearsal" update to the models in the pipeline, to prevent
+        forgetting. Rehearsal updates run an initial copy of the model over some
+        data, and update the model so its current predictions are more like the
+        initial ones. This is useful for keeping a pre-trained model on-track,
+        even if you're updating it with a smaller set of examples.
+
+        docs (iterable): A batch of `Doc` objects.
+        drop (float): The droput rate.
+        sgd (callable): An optimizer.
+        RETURNS (dict): Results from the update.
+
+        EXAMPLE:
+            >>> raw_text_batches = minibatch(raw_texts)
+            >>> for labelled_batch in minibatch(zip(train_docs, train_golds)):
+            >>>     docs, golds = zip(*train_docs) 
+            >>>     nlp.update(docs, golds)
+            >>>     raw_batch = [nlp.make_doc(text) for text in next(raw_text_batches)]
+            >>>     nlp.rehearse(raw_batch)
+        """
+        if len(docs) == 0:
+            return
+        if sgd is None:
+            if self._optimizer is None:
+                self._optimizer = create_default_optimizer(Model.ops)
+            sgd = self._optimizer
+        docs = list(docs)
+        for i, doc in enumerate(docs):
+            if isinstance(doc, basestring_):
+                docs[i] = self.make_doc(doc)
+        pipes = list(self.pipeline)
+        random.shuffle(pipes)
+        if config is None:
+            config = {}
+        grads = {}
+
+        def get_grads(W, dW, key=None):
+            grads[key] = (W, dW)
+
+        get_grads.alpha = sgd.alpha
+        get_grads.b1 = sgd.b1
+        get_grads.b2 = sgd.b2
+
+        for name, proc in pipes:
+            if not hasattr(proc, "rehearse"):
+                continue
+            grads = {}
+            proc.rehearse(docs, sgd=get_grads, losses=losses,
+                          **config.get(name, {}))
+            for key, (W, dW) in grads.items():
+                sgd(W, dW, key=key)
+
+        return losses
+
     def preprocess_gold(self, docs_golds):
         """Can be called before training to pre-process gold data. By default,
         it handles nonprojectivity and adds missing tags to the tag map.
@@ -497,6 +551,30 @@ class Language(object):
                 proc.begin_training(
                     get_gold_tuples, pipeline=self.pipeline, sgd=self._optimizer, **cfg
                 )
+        return self._optimizer
+
+    def resume_training(self, sgd=None, **cfg):
+        """Continue training a pre-trained model.
+        
+        Create and return an optimizer, and initialize "rehearsal" for any pipeline
+        component that has a .rehearse() method. Rehearsal is used to prevent
+        models from "forgetting" their initialised "knowledge". To perform
+        rehearsal, collect samples of text you want the models to retain performance
+        on, and call nlp.rehearse() with a batch of Doc objects.
+        """
+        if cfg.get("device", -1) >= 0:
+            util.use_gpu(cfg["device"])
+            if self.vocab.vectors.data.shape[1] >= 1:
+                self.vocab.vectors.data = Model.ops.asarray(self.vocab.vectors.data)
+        link_vectors_to_models(self.vocab)
+        if self.vocab.vectors.data.shape[1]:
+            cfg["pretrained_vectors"] = self.vocab.vectors.name
+        if sgd is None:
+            sgd = create_default_optimizer(Model.ops)
+        self._optimizer = sgd
+        for name, proc in self.pipeline:
+            if hasattr(proc, "rehearse"):
+                proc._rehearsal_model = deepcopy(proc.model)
         return self._optimizer
 
     def evaluate(self, docs_golds, verbose=False):

--- a/spacy/pipeline.pyx
+++ b/spacy/pipeline.pyx
@@ -989,7 +989,7 @@ class MultitaskObjective(Tagger):
         return sent_tags[target]
 
 
-class ClozeMultitask(Tagger):
+class ClozeMultitask(Pipe):
     @classmethod
     def Model(cls, vocab, tok2vec, **cfg):
         output_size = vocab.vectors.data.shape[1]
@@ -1011,8 +1011,8 @@ class ClozeMultitask(Tagger):
     def set_annotations(self, docs, dep_ids, tensors=None):
         pass
 
-    def begin_training(self, docs=[], pipeline=None, tok2vec=None,
-                       sgd=None, **kwargs):
+    def begin_training(self, get_gold_tuples=lambda: [], pipeline=None,
+                        tok2vec=None, sgd=None, **kwargs):
         link_vectors_to_models(self.vocab)
         if self.model is True:
             self.model = self.Model(self.vocab, tok2vec)
@@ -1225,8 +1225,12 @@ cdef class DependencyParser(Parser):
         return [nonproj.deprojectivize]
 
     def add_multitask_objective(self, target):
-        labeller = MultitaskObjective(self.vocab, target=target)
-        self._multitasks.append(labeller)
+        if target == 'cloze':
+            cloze = ClozeMultitask(self.vocab)
+            self._multitasks.append(cloze)
+        else:
+            labeller = MultitaskObjective(self.vocab, target=target)
+            self._multitasks.append(labeller)
 
     def init_multitask_objectives(self, get_gold_tuples, pipeline, sgd=None, **cfg):
         for labeller in self._multitasks:
@@ -1246,8 +1250,12 @@ cdef class EntityRecognizer(Parser):
     nr_feature = 6
 
     def add_multitask_objective(self, target):
-        labeller = MultitaskObjective(self.vocab, target=target)
-        self._multitasks.append(labeller)
+        if target == 'cloze':
+            cloze = ClozeMultitask(self.vocab)
+            self._multitasks.append(cloze)
+        else:
+            labeller = MultitaskObjective(self.vocab, target=target)
+            self._multitasks.append(labeller)
 
     def init_multitask_objectives(self, get_gold_tuples, pipeline, sgd=None, **cfg):
         for labeller in self._multitasks:

--- a/spacy/pipeline.pyx
+++ b/spacy/pipeline.pyx
@@ -326,6 +326,9 @@ class Pipe(object):
         """
         raise NotImplementedError
 
+    def rehearse(self, docs, sgd=None, losses=None, **config):
+        pass
+
     def get_loss(self, docs, golds, scores):
         """Find the loss and gradient of loss for the batch of
         documents and their predicted scores."""

--- a/spacy/pipeline.pyx
+++ b/spacy/pipeline.pyx
@@ -1033,7 +1033,7 @@ class ClozeMultitask(Tagger):
         # and look them up all at once. This prevents data copying.
         ids = self.model.ops.flatten([doc.to_array(ID).ravel() for doc in docs])
         target = vectors[ids]
-        gradient = (prediction - target) / target.shape[0]
+        gradient = (prediction - target) / prediction.shape[0]
         loss = (gradient**2).sum()
         return float(loss), gradient
  

--- a/spacy/syntax/ner.pyx
+++ b/spacy/syntax/ner.pyx
@@ -319,10 +319,10 @@ cdef class In:
             return False
         # TODO: Is this quite right? I think it's supposed to be ensuring the
         # gazetteer matches are maintained
-        elif st.B_(1).ent_iob != preset_ent_iob:
+        elif st.B(1) != -1 and st.B_(1).ent_iob != preset_ent_iob:
             return False
         # Don't allow entities to extend across sentence boundaries
-        elif st.B_(1).sent_start == 1:
+        elif st.B(1) != -1 and st.B_(1).sent_start == 1:
             return False
         return st.entity_is_open() and label != 0 and st.E_(0).ent_type == label
 
@@ -370,9 +370,6 @@ cdef class Last:
     @staticmethod
     cdef bint is_valid(const StateC* st, attr_t label) nogil:
         if st.B_(1).ent_iob == 1:
-            return False
-        # Don't allow entities to end on whitespace
-        elif Lexeme.get_struct_attr(st.B_(0).lex, IS_SPACE):
             return False
         return st.entity_is_open() and label != 0 and st.E_(0).ent_type == label
 

--- a/spacy/syntax/ner.pyx
+++ b/spacy/syntax/ner.pyx
@@ -207,15 +207,16 @@ cdef class BiluoPushDown(TransitionSystem):
         else:
             label_id = label_name
         if action == OUT and label_id != 0:
-            return
+            return None
         if action == MISSING or action == ISNT:
-            return
+            return None
         # Check we're not creating a move we already have, so that this is
         # idempotent
         for trans in self.c[:self.n_moves]:
             if trans.move == action and trans.label == label_id:
                 return 0
         if self.n_moves >= self._size:
+            self._size = self.n_moves
             self._size *= 2
             self.c = <Transition*>self.mem.realloc(self.c, self._size * sizeof(self.c[0]))
         self.c[self.n_moves] = self.init_transition(self.n_moves, action, label_id)

--- a/spacy/syntax/nn_parser.pxd
+++ b/spacy/syntax/nn_parser.pxd
@@ -12,6 +12,7 @@ from ._parser_model cimport WeightsC, ActivationsC, SizesC
 cdef class Parser:
     cdef readonly Vocab vocab
     cdef public object model
+    cdef public object _rehearsal_model
     cdef readonly TransitionSystem moves
     cdef readonly object cfg
     cdef public object _multitasks
@@ -21,4 +22,3 @@ cdef class Parser:
  
     cdef void c_transition_batch(self, StateC** states, const float* scores,
             int nr_class, int batch_size) nogil
- 

--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -72,6 +72,7 @@ cdef class Parser:
                           pretrained_vectors=pretrained_vectors,
                           bilstm_depth=bilstm_depth)
         tok2vec = chain(tok2vec, flatten)
+        tok2vec.nO = token_vector_width
         lower = PrecomputableAffine(hidden_width,
                     nF=cls.nr_feature, nI=token_vector_width,
                     nP=parser_maxout_pieces)

--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -78,7 +78,8 @@ cdef class Parser:
         lower.nP = parser_maxout_pieces
 
         with Model.use_device('cpu'):
-            upper = zero_init(Affine(nr_class, hidden_width, drop_factor=0.0))
+            upper = Affine(nr_class, hidden_width, drop_factor=0.0)
+        upper.W *= 0
 
         cfg = {
             'nr_class': nr_class,
@@ -121,6 +122,7 @@ cdef class Parser:
         self.cfg = cfg
         self.model = model
         self._multitasks = []
+        self._rehearsal_model = None
 
     def __reduce__(self):
         return (Parser, (self.vocab, self.moves, self.model), None, None)
@@ -404,6 +406,39 @@ cdef class Parser:
         finish_update(golds, sgd=sgd)
         return losses
 
+    def rehearse(self, docs, sgd=None, losses=None, **cfg):
+        """Perform a "rehearsal" update, to prevent catastrophic forgetting."""
+        if isinstance(docs, Doc):
+            docs = [docs]
+        if losses is None:
+            losses = {}
+        assert self._rehearsal_model.upper.W.shape == self.model.upper.W.shape
+        losses.setdefault(self.name, 0.)
+        # Prepare the stepwise model, and get the callback for finishing the batch
+        tutor = self._rehearsal_model(docs)
+        model, finish_update = self.model.begin_update(docs, drop=0.0)
+        states = self.moves.init_batch(docs)
+        n_scores = 0.
+        loss = 0.
+        non_zeroed_classes = self._rehearsal_model.upper.W.any(axis=1)
+        while states: 
+            targets, _ = tutor.begin_update(states)
+            guesses, backprop = model.begin_update(states)
+            d_scores = (targets - guesses) / targets.shape[0]
+            d_scores *= non_zeroed_classes
+            # If all weights for an output are 0 in the original model, don't
+            # supervise that output. This allows us to add classes.
+            loss += (d_scores**2).sum()
+            backprop(d_scores, sgd=sgd)
+            # Follow the predicted action
+            self.transition_states(states, guesses)
+            states = [state for state in states if not state.is_final()]
+            n_scores += d_scores.size
+        # Do the backprop
+        finish_update(docs, sgd=sgd)
+        losses[self.name] += loss / n_scores
+        return losses
+
     def update_beam(self, docs, golds, width, drop=0., sgd=None, losses=None,
                     beam_density=0.0):
         lengths = [len(d) for d in docs]
@@ -416,7 +451,7 @@ cdef class Parser:
             model.vec2scores, width, drop=drop, losses=losses,
             beam_density=beam_density)
         for i, d_scores in enumerate(states_d_scores):
-            losses[self.name] += (d_scores**2).sum()
+            losses[self.name] += (d_scores**2).mean()
             ids, bp_vectors, bp_scores = backprops[i]
             d_vector = bp_scores(d_scores, sgd=sgd)
             if isinstance(model.ops, CupyOps) \

--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -412,7 +412,11 @@ cdef class Parser:
             docs = [docs]
         if losses is None:
             losses = {}
-        assert self._rehearsal_model.upper.W.shape == self.model.upper.W.shape
+        for multitask in self._multitasks:
+            if hasattr(multitask, 'rehearse'):
+                multitask.rehearse(docs, losses=losses, sgd=sgd)
+        if self._rehearsal_model is None:
+            return None
         losses.setdefault(self.name, 0.)
         # Prepare the stepwise model, and get the callback for finishing the batch
         tutor = self._rehearsal_model(docs)


### PR DESCRIPTION
The new `spacy pretrain` command implemented BERT/ULMFit/etc-like transfer learning, using our Language Modelling with Approximate Outputs version of BERT's cloze task. Pretraining is convenient, but in some ways it's a bit of a strange solution. All we're doing is initialising the weights. At the same time, we're putting a lot of work into our optimisation so that it's less sensitive to initial conditions, and more likely to find good optima. I discuss this a bit in the pseudo-rehearsal blog post: https://explosion.ai/blog/pseudo-rehearsal-catastrophic-forgetting

## Support semi-supervised learning in `spacy train`

One obvious way to improve these pretraining methods is to do multi-task learning, instead of just transfer learning. This has been shown to work very well: https://arxiv.org/pdf/1809.08370.pdf . This patch makes it easy to do this sort of thing.

* Add a new argument to `spacy train`, `--raw-text`. This takes a jsonl file with unlabelled data that can be used in arbitrary ways to do semi-supervised learning.

* Add a new method to the `Language` class and to pipeline components, `.rehearse()`. This is like `.update()`, but doesn't expect `GoldParse` objects. It takes a batch of `Doc` objects, and performs an update on some semi-supervised objective.

* Move the BERT-LMAO objective out from `spacy/cli/pretrain.py` into `spacy/_ml.py`, so we can create a new pipeline component, `ClozeMultitask`. This can be specified as a parser or NER multitask in the `spacy train` command. Example usage:

```
python -m spacy train en ./tmp ~/data/en-core-web/train/nw.json ~/data/en-core-web/dev/nw.json --pipeline parser --raw-textt ~/data/unlabelled/reddit-100k.jsonl --vectors en_vectors_web_lg --parser-multitasks cloze
```

## Implement rehearsal methods for pipeline components

The new `--raw-text` argument and `nlp.rehearse()` method also gives us a good place to implement the the idea in the pseudo-rehearsal blog post in the parser. This works as follows:

* Add a new `nlp.resume_training()` method. This allocates copies of pre-trained models in the pipeline, setting things up for the rehearsal updates. It also returns an optimizer object. This also greatly reduces confusion around the `nlp.begin_training()` method, which randomises the weights, making it not suitable for adding new labels or otherwise fine-tuning a pre-trained model. 

* Implement rehearsal updates on the Parser class, making it available for the dependency parser and NER. During rehearsal, the initial model is used to supervise the model being trained. The current model is asked to match the predictions of the initial model on some data. This minimises catastrophic forgetting, by keeping the model's predictions close to the original. See the blog post for details.

## Still to do

* [ ] Implement rehearsal for the text categorizer
* [ ] Implement rehearsal for the tagger.
* [ ] Evaluate rehearsal when adding a new label to the NER
* [ ] Update the docs

