### PR TITLE
💫 Raise better error when using uninitialized pipeline component

### DIFF
--- a/spacy/cli/package.py
+++ b/spacy/cli/package.py
@@ -70,7 +70,7 @@ def package(input_dir, output_dir, meta_path=None, create_meta=False, force=Fals
             )
     Path.mkdir(package_path, parents=True)
     shutil.copytree(path2str(input_path), path2str(package_path / model_name_v))
-    create_file(main_path / "meta.json", srsly.json_dumps(meta))
+    create_file(main_path / "meta.json", srsly.json_dumps(meta, indent=2))
     create_file(main_path / "setup.py", TEMPLATE_SETUP)
     create_file(main_path / "MANIFEST.in", TEMPLATE_MANIFEST)
     create_file(package_path / "__init__.py", TEMPLATE_INIT)

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -287,6 +287,8 @@ class Errors(object):
     E108 = ("As of spaCy v2.1, the pipe name `sbd` has been deprecated "
             "in favor of the pipe name `sentencizer`, which does the same "
             "thing. For example, use `nlp.create_pipeline('sentencizer')`")
+    E109 = ("Model for component {name} not initialized. Did you forget to load "
+            "a model, or forget to call begin_training()?")
 
 
 @add_codes

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -287,7 +287,7 @@ class Errors(object):
     E108 = ("As of spaCy v2.1, the pipe name `sbd` has been deprecated "
             "in favor of the pipe name `sentencizer`, which does the same "
             "thing. For example, use `nlp.create_pipeline('sentencizer')`")
-    E109 = ("Model for component {name} not initialized. Did you forget to load "
+    E109 = ("Model for component '{name}' not initialized. Did you forget to load "
             "a model, or forget to call begin_training()?")
 
 

--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -226,6 +226,11 @@ cdef class Parser:
                 self.set_annotations(subbatch, parse_states, tensors=None)
             for doc in batch_in_order:
                 yield doc
+                
+    def require_model(self):
+        """Raise an error if the component's model is not initialized."""
+        if getattr(self, 'model', None) in (None, True, False):
+            raise ValueError(Errors.E109.format(name=self.name))
 
     def predict(self, docs, beam_width=1, beam_density=0.0, drop=0.):
         self.require_model()

--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -228,6 +228,7 @@ cdef class Parser:
                 yield doc
 
     def predict(self, docs, beam_width=1, beam_density=0.0, drop=0.):
+        self.require_model()
         if isinstance(docs, Doc):
             docs = [docs]
         if not any(len(doc) for doc in docs):
@@ -375,6 +376,7 @@ cdef class Parser:
         return [b for b in beams if not b.is_done]
 
     def update(self, docs, golds, drop=0., sgd=None, losses=None):
+        self.require_model()
         if isinstance(docs, Doc) and isinstance(golds, GoldParse):
             docs = [docs]
             golds = [golds]


### PR DESCRIPTION
After creating a component, the `.model` attribute is left with the value `True`, to indicate it should be created later during `from_disk()`, `from_bytes()` or `begin_training()`. This had led to confusing errors if you try to use the component without initializing the model.

To fix this, we add a method `require_model()` to the `Pipe` base class. The `require_model()` method needs to be called at the start of the `.predict()` and `.update()` methods of the components. It raises a `ValueError` if the model is not initialized. An error message has been added to `spacy.errors`.