### PR TITLE
💫 Prevent parser from predicting unseen classes

### DIFF
--- a/spacy/about.py
+++ b/spacy/about.py
@@ -4,13 +4,13 @@
 # fmt: off
 
 __title__ = "spacy-nightly"
-__version__ = "2.1.0a4"
+__version__ = "2.1.0a5.dev0"
 __summary__ = "Industrial-strength Natural Language Processing (NLP) with Python and Cython"
 __uri__ = "https://spacy.io"
 __author__ = "Explosion AI"
 __email__ = "contact@explosion.ai"
 __license__ = "MIT"
-__release__ = True
+__release__ = False
 
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"

--- a/spacy/about.py
+++ b/spacy/about.py
@@ -4,13 +4,13 @@
 # fmt: off
 
 __title__ = "spacy-nightly"
-__version__ = "2.1.0a5.dev0"
+__version__ = "2.1.0a4"
 __summary__ = "Industrial-strength Natural Language Processing (NLP) with Python and Cython"
 __uri__ = "https://spacy.io"
 __author__ = "Explosion AI"
 __email__ = "contact@explosion.ai"
 __license__ = "MIT"
-__release__ = False
+__release__ = True
 
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -221,7 +221,7 @@ def train(
                     (nlp.make_doc(rt["text"]) for rt in raw_text), size=8
                 )
             words_seen = 0
-            with _create_progress_bar(n_train_words) as pbar:
+            with tqdm.tqdm(total=n_train_words, leave=False) as pbar:
                 losses = {}
                 for batch in util.minibatch_by_words(train_docs, size=batch_sizes):
                     if not batch:

--- a/spacy/syntax/_parser_model.pyx
+++ b/spacy/syntax/_parser_model.pyx
@@ -205,7 +205,9 @@ class ParserModel(Model):
             return
         smaller = self.upper
         larger = Affine(new_output, smaller.nI)
-        larger.W *= 0
+        # Set nan as value for unseen classes, to prevent prediction.
+        larger.W.fill(self.ops.xp.nan)
+        larger.b.fill(self.ops.xp.nan)
         # It seems very unhappy if I pass these as smaller.W?
         # Seems to segfault. Maybe it's a descriptor protocol thing?
         smaller_W = smaller.W
@@ -254,6 +256,13 @@ class ParserStepModel(Model):
         if mask is not None:
             vector *= mask
         scores, get_d_vector = self.vec2scores.begin_update(vector, drop=drop)
+        # We can have nans from unseen classes.
+        # For backprop purposes, we want to treat unseen classes as having the
+        # lowest score.
+        # numpy's nan_to_num function doesn't take a value, and nan is replaced
+        # by 0...-inf is replaced by minimum, so we go via that. Ugly to the max.
+        scores[self.ops.xp.isnan(scores)] = -self.ops.xp.inf
+        self.ops.xp.nan_to_num(scores, copy=False)
 
         def backprop_parser_step(d_scores, sgd=None):
             d_vector = get_d_vector(d_scores, sgd=sgd)
@@ -400,6 +409,8 @@ cdef class precompute_hiddens:
             state_vector, mask = self.ops.maxout(state_vector)
 
         def backprop_nonlinearity(d_best, sgd=None):
+            # Fix nans (which can occur from unseen classes.)
+            d_best[self.ops.xp.isnan(d_best)] = 0.
             if self.nP == 1:
                 d_best *= mask
                 d_best = d_best.reshape((d_best.shape + (1,)))

--- a/spacy/syntax/_parser_model.pyx
+++ b/spacy/syntax/_parser_model.pyx
@@ -102,6 +102,8 @@ cdef void predict_states(ActivationsC* A, StateC** states,
             index = i * n.hiddens * n.pieces + j * n.pieces
             which = Vec.arg_max(&A.unmaxed[index], n.pieces)
             A.hiddens[i*n.hiddens + j] = A.unmaxed[index + which]
+            if A.hiddens[i*n.hiddens + j] < 0:
+                A.hiddens[i*n.hiddens + j] = 0
     memset(A.scores, 0, n.states * n.classes * sizeof(float))
     cdef double one = 1.0
     # Compute hidden-to-output
@@ -394,16 +396,18 @@ cdef class precompute_hiddens:
     def _nonlinearity(self, state_vector):
         if self.nP == 1:
             state_vector = state_vector.reshape(state_vector.shape[:-1])
-            mask = state_vector >= 0.
-            state_vector *= mask
         else:
-            state_vector, mask = self.ops.maxout(state_vector)
+            state_vector, which = self.ops.maxout(state_vector)
+        # Apply a relu filter, so that classes that don't occur get zero prob.
+        mask = state_vector >= 0.
+        state_vector *= mask
 
         def backprop_nonlinearity(d_best, sgd=None):
+            d_best *= mask
             if self.nP == 1:
-                d_best *= mask
                 d_best = d_best.reshape((d_best.shape + (1,)))
                 return d_best
             else:
-                return self.ops.backprop_maxout(d_best, mask, self.nP)
+                d_state_vector = self.ops.backprop_maxout(d_best, which, self.nP)
+                return d_state_vector
         return state_vector, backprop_nonlinearity


### PR DESCRIPTION
Resolves #1585.

Previously when we added a new label, the parser might output non-zero
predictions for the new class. This could occur if the output of the
previous layer had non-zero values within it, as zero wouldn't be the
lowest number.

~To fix this, we add a ReLu filter to the output of the parser's maxout
layer, before we apply the output weights. This way, we know that if a
class has zeroed weights, the parser must predict zero probability for
it.~

~This change requires retraining the models, unfortunately.~

Nope, the ReLu idea doesn't work! We still can end up with negative scores,
and very often do, because the output layer may have negative bias.

After thinking some more, I came up with a solution that doesn't require 
retraining the models :tada:. We set nan values for the new weights, so they
can't come out on top. During backprop, we replace the nans with the lowest
score, so we can still learn.