### PR TITLE
Small fixes to displaCy

### DIFF
--- a/spacy/displacy/__init__.py
+++ b/spacy/displacy/__init__.py
@@ -182,6 +182,5 @@ def set_render_wrapper(func):
     """
     global RENDER_WRAPPER
     if not hasattr(func, "__call__"):
-        msg = "Invalid displaCy render wrapper. Expected callable, got: {obj}"
-        raise ValueError(msg.format(obj=type(func)))
+        raise ValueError(Errors.E110.format(obj=type(func)))
     RENDER_WRAPPER = func

--- a/spacy/displacy/__init__.py
+++ b/spacy/displacy/__init__.py
@@ -59,7 +59,14 @@ def render(
 
 
 def serve(
-    docs, style="dep", page=True, minify=False, options={}, manual=False, port=5000
+    docs,
+    style="dep",
+    page=True,
+    minify=False,
+    options={},
+    manual=False,
+    port=5000,
+    host="0.0.0.0",
 ):
     """Serve displaCy visualisation.
 
@@ -70,13 +77,14 @@ def serve(
     options (dict): Visualiser-specific options, e.g. colors.
     manual (bool): Don't parse `Doc` and instead expect a dict/list of dicts.
     port (int): Port to serve visualisation.
+    host (unicode): Host to serve visualisation.
     """
     from wsgiref import simple_server
 
     render(docs, style=style, page=page, minify=minify, options=options, manual=manual)
-    httpd = simple_server.make_server("0.0.0.0", port, app)
+    httpd = simple_server.make_server(host, port, app)
     print("\nUsing the '{}' visualizer".format(style))
-    print("Serving on port {}...\n".format(port))
+    print("Serving on http://{}:{} ...\n".format(host, port))
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:

--- a/spacy/displacy/__init__.py
+++ b/spacy/displacy/__init__.py
@@ -81,6 +81,9 @@ def serve(
     """
     from wsgiref import simple_server
 
+    if IS_JUPYTER:
+        user_warning(Warnings.W011)
+
     render(docs, style=style, page=page, minify=minify, options=options, manual=manual)
     httpd = simple_server.make_server(host, port, app)
     print("\nUsing the '{}' visualizer".format(style))

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -295,6 +295,7 @@ class Errors(object):
             "thing. For example, use `nlp.create_pipeline('sentencizer')`")
     E109 = ("Model for component '{name}' not initialized. Did you forget to load "
             "a model, or forget to call begin_training()?")
+    E110 = ("Invalid displaCy render wrapper. Expected callable, got: {obj}")
 
 
 @add_codes

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -54,6 +54,12 @@ class Warnings(object):
             "package overwrites built-in factory.")
     W010 = ("As of v2.1.0, the PhraseMatcher doesn't have a phrase length "
             "limit anymore, so the max_length argument is now deprecated.")
+    W011 = ("It looks like you're calling displacy.serve from within a "
+            "Jupyter notebook or a similar environment. This likely means "
+            "you're already running a local web server, so there's no need to "
+            "make displaCy start another one. Instead, you should be able to "
+            "replace displacy.serve with displacy.render to show the "
+            "visualization.")
 
 
 @add_codes

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -362,8 +362,12 @@ def _warn(message, warn_type="user"):
     message (unicode): The message to display.
     category (Warning): The Warning to show.
     """
-    w_id = message.split("[", 1)[1].split("]", 1)[0]  # get ID from string
-    if warn_type in SPACY_WARNING_TYPES and w_id not in SPACY_WARNING_IGNORE:
+    if message.startswith("["):
+        w_id = message.split("[", 1)[1].split("]", 1)[0]  # get ID from string
+    else:
+        w_id = None
+    ignore_warning = w_id and w_id in SPACY_WARNING_IGNORE
+    if warn_type in SPACY_WARNING_TYPES and not ignore_warning:
         category = WARNINGS[warn_type]
         stack = inspect.stack()[-1]
         with warnings.catch_warnings():

--- a/spacy/tests/test_misc.py
+++ b/spacy/tests/test_misc.py
@@ -72,6 +72,20 @@ def test_displacy_spans(en_vocab):
     assert html.startswith("<div")
 
 
+def test_displacy_render_wrapper(en_vocab):
+    """Test that displaCy accepts custom rendering wrapper."""
+
+    def wrapper(html):
+        return "TEST" + html + "TEST"
+
+    displacy.set_render_wrapper(wrapper)
+    doc = get_doc(en_vocab, words=["But", "Google", "is", "starting", "from", "behind"])
+    doc.ents = [Span(doc, 1, 2, label=doc.vocab.strings["ORG"])]
+    html = displacy.render(doc, style="ent")
+    assert html.startswith("TEST<div")
+    assert html.endswith("/div>TEST")
+
+
 def test_displacy_raises_for_wrong_type(en_vocab):
     with pytest.raises(ValueError):
         displacy.render("hello world")

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -236,12 +236,13 @@ def is_in_jupyter():
 
     RETURNS (bool): True if in Jupyter, False if not.
     """
+    # https://stackoverflow.com/a/39662359/6400719
     try:
-        cfg = get_ipython().config
-        if cfg["IPKernelApp"]["parent_appname"] == "ipython-notebook":
-            return True
+        shell = get_ipython().__class__.__name__
+        if shell == "ZMQInteractiveShell":
+            return True  # Jupyter notebook or qtconsole
     except NameError:
-        return False
+        return False  # Probably standard Python interpreter
     return False
 
 

--- a/website/api/_top-level/_displacy.jade
+++ b/website/api/_top-level/_displacy.jade
@@ -68,6 +68,12 @@ p
         +cell Port to serve visualization.
         +cell #[code 5000]
 
+    +row
+        +cell #[code host]
+        +cell unicode
+        +cell Host to serve visualization.
+        +cell #[code '0.0.0.0']
+
 +h(3, "displacy.render") displacy.render
     +tag method
     +tag-new(2)


### PR DESCRIPTION
## Description
- [x] fix auto-detection of Jupyter notebooks (even if `jupyter=True` isn't set)
- [x] add `displacy.set_render_wrapper` method to define a custom function called around the HTML markup generated in all calls to `displacy.render` (can be used to allow custom integrations, callbacks and page formatting)
- [x] add option to customise host for web server
- [x] show warning if `displacy.serve` is called from within Jupyter notebooks
- [x] move error message to `spacy.errors.Errors`.

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
