### PR TITLE
Improve entry points and allow custom language classes via entry points

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -28,7 +28,7 @@ from .lang.punctuation import TOKENIZER_INFIXES
 from .lang.tokenizer_exceptions import TOKEN_MATCH
 from .lang.tag_map import TAG_MAP
 from .lang.lex_attrs import LEX_ATTRS, is_stop
-from .errors import Errors, Warnings, user_warning
+from .errors import Errors
 from . import util
 from . import about
 
@@ -146,9 +146,6 @@ class Language(object):
         RETURNS (Language): The newly constructed object.
         """
         user_factories = util.get_entry_points("spacy_factories")
-        for factory in user_factories.keys():
-            if factory in self.factories:
-                user_warning(Warnings.W009.format(name=factory))
         self.factories.update(user_factories)
         self._meta = dict(meta)
         self._path = None

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -230,6 +230,19 @@ def get_entry_points(key):
     return result
 
 
+def get_entry_point(key, value):
+    """Check if registered entry point is available for a given name and
+    load it. Otherwise, return None.
+
+    key (unicode): Entry point name.
+    value (unicode): Name of entry point to load.
+    RETURNS: The loaded entry point or None.
+    """
+    for entry_point in pkg_resources.iter_entry_points(key):
+        if entry_point.name == value:
+            return entry_point.load()
+
+
 def is_in_jupyter():
     """Check if user is running spaCy from a Jupyter notebook by detecting the
     IPython kernel. Mainly used for the displaCy visualizer.

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -43,6 +43,11 @@ def get_lang_class(lang):
     RETURNS (Language): Language class.
     """
     global LANGUAGES
+    # Check if an entry point is exposed for the language code
+    entry_point = get_entry_point("spacy_languages", lang)
+    if entry_point is not None:
+        LANGUAGES[lang] = entry_point
+        return entry_point
     if lang not in LANGUAGES:
         try:
             module = importlib.import_module(".lang.%s" % lang, "spacy")


### PR DESCRIPTION
Related PR with more details: #2348
Resolves #1816.

## Description

This PR introduces the option to add custom `Language` classes via entry points. This allows users to add their own languages without modifying the core library.

To stay with the theme of #2348, the following is now possible:

```python
# snek.py in a user package
from spacy.language import Language
from spacy.attrs import LANG

class SnekDefaults(Language.Defaults):
    lex_attr_getters = dict(Language.Defaults.lex_attr_getters)
    lex_attr_getters[LANG] = lambda text: "sk"


class SnekLanguage(Language):
    lang = "sk"
    Defaults = SnekDefaults
```

```python
# setup.py in a user package
from setuptools import setup

setup(
    name="snek",
    entry_points={
        "spacy_languages": ["sk = snek:SnekLanguage"],
    },
)
```

In spaCy, you can then load the custom `sk` language:

```python
from spacy.util import get_lang_class

SnekLanguage = get_lang_class("sk")
nlp = SnekLanguage()
```

This is especially relevant for model packages, which could then specify `"lang": "sk"` in their `meta.json` without spaCy raising an error because the language is not available in the core library.

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.