### PR TITLE
Fix issue 2396

### DIFF
--- a/.github/contributors/alvaroabascar.md
+++ b/.github/contributors/alvaroabascar.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI UG (haftungsbeschränkt)](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           |     Álvaro Abella    |
+| Company name (if applicable)   |         IOMED        |
+| Title or role (if applicable)  |          CSO         |
+| Date                           |       21/12/2018     |
+| GitHub username                |      alvaroabascar   |
+| Website (optional)             |                      |

--- a/spacy/tests/regression/test_issue2396.py
+++ b/spacy/tests/regression/test_issue2396.py
@@ -1,0 +1,18 @@
+# coding: utf-8
+from __future__ import unicode_literals
+import pytest
+
+import numpy as np
+
+def test_issue2396(EN):
+    doc = EN('He created a test for spacy')
+    right_lca_matrix = np.array([
+        [0, 1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1, 1],
+        [1, 1, 2, 3, 3, 3],
+        [1, 1, 3, 3, 3, 3],
+        [1, 1, 3, 3, 4, 4],
+        [1, 1, 3, 3, 4, 5]
+    ], dtype=np.int32)
+    lca_matrix = doc.get_lca_matrix()
+    assert (lca_matrix == right_lca_matrix).all()

--- a/spacy/tests/regression/test_issue2396.py
+++ b/spacy/tests/regression/test_issue2396.py
@@ -1,18 +1,27 @@
 # coding: utf-8
 from __future__ import unicode_literals
+
+from ..util import get_doc
+
 import pytest
+import numpy
 
-import numpy as np
+@pytest.mark.parametrize('sentence,matrix', [
+    (
+        'She created a test for spacy',
+        numpy.array([
+            [0, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1],
+            [1, 1, 2, 3, 3, 3],
+            [1, 1, 3, 3, 3, 3],
+            [1, 1, 3, 3, 4, 4],
+            [1, 1, 3, 3, 4, 5]], dtype=numpy.int32)
+    )
+    ])
+def test_issue2396(EN, sentence, matrix):
+    doc = EN(sentence)
+    span = doc[:]
+    assert (doc.get_lca_matrix() == matrix).all()
+    assert (span.get_lca_matrix() == matrix).all()
 
-def test_issue2396(EN):
-    doc = EN('He created a test for spacy')
-    right_lca_matrix = np.array([
-        [0, 1, 1, 1, 1, 1],
-        [1, 1, 1, 1, 1, 1],
-        [1, 1, 2, 3, 3, 3],
-        [1, 1, 3, 3, 3, 3],
-        [1, 1, 3, 3, 4, 4],
-        [1, 1, 3, 3, 4, 5]
-    ], dtype=np.int32)
-    lca_matrix = doc.get_lca_matrix()
-    assert (lca_matrix == right_lca_matrix).all()
+

--- a/spacy/tokens/doc.pxd
+++ b/spacy/tokens/doc.pxd
@@ -27,6 +27,9 @@ cdef int token_by_end(const TokenC* tokens, int length, int end_char) except -2
 
 cdef int set_children_from_heads(TokenC* tokens, int length) except -1
 
+
+cdef np.ndarray _get_lca_matrix(Doc, int start, int end)
+
 cdef class Doc:
     cdef readonly Pool mem
     cdef readonly Vocab vocab

--- a/spacy/tokens/doc.pxd
+++ b/spacy/tokens/doc.pxd
@@ -28,7 +28,7 @@ cdef int token_by_end(const TokenC* tokens, int length, int end_char) except -2
 cdef int set_children_from_heads(TokenC* tokens, int length) except -1
 
 
-cdef np.ndarray _get_lca_matrix(Doc, int start, int end)
+cdef int [:,:] _get_lca_matrix(Doc, int start, int end)
 
 cdef class Doc:
     cdef readonly Pool mem

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -714,47 +714,9 @@ cdef class Doc:
         """Calculates the lowest common ancestor matrix for a given `Doc`.
         Returns LCA matrix containing the integer index of the ancestor, or -1
         if no common ancestor is found (ex if span excludes a necessary
-        ancestor).
+        ancestor). Internally calls Span.get_lca_matrix().
         """
-        # Efficiency notes:
-        # We can easily improve the performance here by iterating in Cython.
-        # To loop over the tokens in Cython, the easiest way is:
-        # for token in doc.c[:doc.c.length]:
-        #     head = token + token.head
-        # Both token and head will be TokenC* here. The token.head attribute
-        # is an integer offset.
-        def __pairwise_lca(token_j, token_k):
-            if token_j == token_k:
-                return token_j.i
-            elif token_j.head == token_k:
-                return token_k.i
-            elif token_k.head == token_j:
-                return token_j.i
-            
-            token_j_ancestors = set(token_j.ancestors)
-            if token_k in token_j_ancestors:
-                return token_k.i
-            
-            for token_k_ancestor in token_k.ancestors:
-                
-                if token_k_ancestor == token_j:
-                    return token_j.i
-                
-                if token_k_ancestor in token_j_ancestors:
-                    return token_k_ancestor.i
-
-            return -1
-
-        lca_matrix = numpy.empty((len(self), len(self)), dtype=numpy.int32)
-        lca_matrix.fill(-2)
-
-        for j in range(len(self)):
-            token_j = self[j]
-            for k in range(j, len(self)):
-                token_k = self[k]
-                lca_matrix[j][k] = __pairwise_lca(token_j, token_k)
-                lca_matrix[k][j] = lca_matrix[j][k]
-        return lca_matrix
+        return self[:].get_lca_matrix()
 
     def to_disk(self, path, **exclude):
         """Save the current state to a directory.

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -1058,11 +1058,14 @@ cdef int [:,:] _get_lca_matrix(Doc doc, int start, int end):
         # the common ancestor of token and itself is itself:
         lca_matrix[j, j] = j
         for k in range(j + 1, end):
-            lca_matrix[j, k] = _get_tokens_lca(token_j, doc[k])
-            if not start <= lca_matrix[j, k] < end:
+            lca = _get_tokens_lca(token_j, doc[k])
+            # if lca is outside of span, we set it to -1
+            if not start <= lca < end:
                 lca_matrix[j, k] = -1
-            # matrix is symmetric:
-            lca_matrix[k, j] = lca_matrix[j, k]
+                lca_matrix[k, j] = -1
+            else:
+                lca_matrix[j, k] = lca
+                lca_matrix[k, j] = lca
 
     return lca_matrix
 

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -185,12 +185,13 @@ cdef class Span:
     def get_lca_matrix(self):
         """Calculates a matrix of Lowest Common Ancestors (LCA) for a given
         `Span`, where LCA[i, j] is the index of the lowest common ancestor among
-        the tokens ith and jth within the span.
+        the tokens span[i] and span[j]. If they have no common ancestor within
+        the span, LCA[i, j] will be -1.
 
         RETURNS (np.array[ndim=2, dtype=numpy.int32]): LCA matrix with shape
             (n, n), where n = len(self).
         """
-        return _get_lca_matrix(self.doc, self.start, self.end)
+        return numpy.asarray(_get_lca_matrix(self.doc, self.start, self.end))
 
     def similarity(self, other):
         """Make a semantic similarity estimate. The default estimate is cosine


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
This PR fixes issue #2396: `Doc.get_lca_matrix` had a bug in [this line](https://github.com/explosion/spaCy/blob/master/spacy/tokens/doc.pyx#L739) which caused wrong outputs
for some pairs of tokens.

### Types of change
Bug fix

### Explanation of the bug

I borrow the following example from @slavi (#2396):

![He created a test for spacy](https://user-images.githubusercontent.com/7307772/50365998-76916d00-0577-11e9-95d0-271690d0693d.png)

```python3
s = "He created a test for spacy"
doc = nlp(s)
doc.get_lca_matrix()[3][5]
```

- Expected output: 3
- Actual output: 1

The above mentioned line is:

```python3
...
            else:
                lca_index = __pairwise_lca(token_j.head, token_k.head, lca_matrix)
...
```

Here, for tokens 3 ("test") and 5 ("spacy"), we are calling `__pairwise_lca` recursively with their heads ("created" and "for" respectively). But in doing so, we are skiping "test", which is the actual lowest common ancestor.

### Solution

The reimplementation consists on [this simple algorihtm](https://thimbleby.gitlab.io/algorithm-wiki-site/wiki/lowest_common_ancestor/). It works as expected and is 3 times faster.

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
