### PR TITLE
cli.convert: fix typo in converter arguments

### DIFF
--- a/spacy/cli/convert.py
+++ b/spacy/cli/convert.py
@@ -69,7 +69,7 @@ def convert(
     # Use converter function to convert data
     func = CONVERTERS[converter]
     input_data = input_path.open("r", encoding="utf-8").read()
-    data = func(input_data, nsents=n_sents, use_morphology=morphology, lang=lang)
+    data = func(input_data, n_sents=n_sents, use_morphology=morphology, lang=lang)
     if output_dir != "-":
         # Export data to a file
         suffix = ".{}".format(file_type)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

The keyword argument `n_sents` to the converter functions was misspelled as `nsents`. 
Running `spacy convert -n [...]` resulted in `TypeError: conllu2json() got an unexpected keyword argument 'nsents'`

### Types of change
Bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
