### PR TITLE
spacy.cli.evaluate: fix TypeError

### DIFF
--- a/spacy/cli/evaluate.py
+++ b/spacy/cli/evaluate.py
@@ -49,9 +49,9 @@ def evaluate(
     end = timer()
     nwords = sum(len(doc_gold[0]) for doc_gold in dev_docs)
     results = {
-        "Time": "%.2f s" % end - begin,
+        "Time": "%.2f s" % (end - begin),
         "Words": nwords,
-        "Words/s": "%.0f" % nwords / (end - begin),
+        "Words/s": "%.0f" % (nwords / (end - begin)),
         "TOK": "%.2f" % scorer.token_acc,
         "POS": "%.2f" % scorer.tags_acc,
         "UAS": "%.2f" % scorer.uas,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

`spacy evaluate` fails on my system with 

```
Traceback (most recent call last):
  File "/Users/fijabakk/.pyenv/versions/3.6.1/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/Users/fijabakk/.pyenv/versions/3.6.1/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/fijabakk/src/spaCy/spacy/__main__.py", line 38, in <module>
    plac.call(commands[command], sys.argv[1:])
  File "/Users/fijabakk/src/spacy-nb/.venv/lib/python3.6/site-packages/plac_core.py", line 328, in call
    cmd, result = parser.consume(arglist)
  File "/Users/fijabakk/src/spacy-nb/.venv/lib/python3.6/site-packages/plac_core.py", line 207, in consume
    return cmd, self.func(*(args + varargs + extraopts), **kwargs)
  File "/Users/fijabakk/src/spaCy/spacy/cli/evaluate.py", line 52, in evaluate
    "Time": "%.2f s" % end - begin,
TypeError: unsupported operand type(s) for -: 'str' and 'float'
```

This PR fixes the problem by adding the missing parentheses.

### Types of change

Bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
