### PR TITLE
💫 Make span.as_doc() return a copy, not a view. Closes #1537

### DIFF
--- a/spacy/tests/doc/test_span.py
+++ b/spacy/tests/doc/test_span.py
@@ -152,6 +152,9 @@ def test_span_as_doc(doc):
     span = doc[4:10]
     span_doc = span.as_doc()
     assert span.text == span_doc.text.strip()
+    assert isinstance(span_doc, doc.__class__)
+    assert span_doc is not doc
+    assert span_doc[0].idx == 0
 
 
 def test_span_string_label(doc):

--- a/website/api/span.jade
+++ b/website/api/span.jade
@@ -377,8 +377,8 @@ p
 +h(2, "as_doc") Span.as_doc
 
 p
-    |  Create a #[code Doc] object view of the #[code Span]'s data. Mostly
-    |  useful for C-typed interfaces.
+    |  Create a new #[code Doc] object corresponding to the #[code Span], with
+    |  a copy of the data.
 
 +aside-code("Example").
     doc = nlp(u'I like New York in Autumn.')


### PR DESCRIPTION
Initially `span.as_doc()` was designed to return a view of the span's contents, as a `Doc` object. This was a nice idea, but it fails due to the `token.idx` property, which refers to the character offset within the string. In a span, the idx of the first token might not be 0. Because this data is different, we can't have a view --- it'll be inconsistent.

This patch changes `span.as_doc()` to instead return a copy. The docs are updated accordingly. Closes #1537