### PR TITLE
Build metadata modernization - pyproject.toml and python_requires

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include include *.h
 include LICENSE
 include README.rst
+include pyproject.toml
 include bin/spacy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools",
+            "wheel>0.32.0.<0.33.0",
+            "Cython",
+            "cymem>=2.0.2,<2.1.0",
+            "preshed>=2.0.1,<2.1.0",
+            "murmurhash>=0.28.0,<1.1.0",
+            "thinc>=6.12.1,<6.13.0",
+            ]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -220,6 +220,7 @@ def setup_package():
                 'cuda100': ['cupy-cuda100>=4.0', 'thinc_gpu_ops>=0.0.3,<0.1.0'],
                 'ja': ['mecab-python3==0.7']
             },
+            python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
             classifiers=[
                 'Development Status :: 5 - Production/Stable',
                 'Environment :: Console',

--- a/setup.py
+++ b/setup.py
@@ -237,6 +237,7 @@ def setup_package():
                 'Programming Language :: Python :: 3.4',
                 'Programming Language :: Python :: 3.5',
                 'Programming Language :: Python :: 3.6',
+                'Programming Language :: Python :: 3.7',
                 'Topic :: Scientific/Engineering'],
             cmdclass = {
                 'build_ext': build_ext_subclass},


### PR DESCRIPTION
## Description
The current way you have configured your build system does not comply with PEP 517 or PEP 518, which are very helpful when you have build system dependencies. It is recommended that you add a `pyproject.toml` with `build-system` to describe your build system dependencies, which will allow `pip install .` to "just work" out of the box (I have tested this and it works). Note that I also added it to the `MANIFEST.in` because [it is not currently included by default](https://github.com/pypa/setuptools/pull/1634) with even the latest setuptools.

While I was there, I noticed that you didn't have a `python_requires` in your `setup.py` and added one. This bit of metadata describes exactly which versions of Python are required to run your software. When you drop support for Python 3.4, add `!=3.4.*` to the `python_requires` line and users on Python 3.4 who invoke `pip install spaCy` will get the last version of spaCy that supports Python 3.4. It is likely to become very important when you want to drop Python 2.

**It is imperative that you use twine to upload spaCy to PyPI from now on!** Perhaps you already are (I could not find anything in the repo about how uploads are done), but `python setup.py upload` is deprecated and will be removed soon. The preferred way to upload packages is with [`twine`](https://pypi.org/project/twine/). Unless you are using the absolute latest version of setuptools, there is a serious bug in the metadata upload that can cause problems with `python_requires`. If your upload workflow *requires* that you use `setup.py` upload, you should enforce that `setuptools >= 40.6.3` is used *in your setup.py*, though I'll stress that even the latest version of `setuptools` is likely to be much buggier than `twine`.

I believe that these changes constitute purely factual information and there is no element of "art" to them (there's really no other way to do this), so I do not believe I have a copyright interest in the content of this PR. I cannot sign the contributor agreement, though. If that is a problem, consider this PR to be an "issue" and feel free to "re-implement" it as desired (though again, there's really no other way to convey this purely factual information).

### Types of change
Build metadata enhancement

## Checklist
- [ ] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [X] My changes don't require a change to the documentation, or if they do, I've added all required information.
