### PR TITLE
Batch UD evaluation script 

### DIFF
--- a/spacy/cli/ud/conll17_ud_eval.py
+++ b/spacy/cli/ud/conll17_ud_eval.py
@@ -286,17 +286,51 @@ def evaluate(gold_ud, system_ud, deprel_weights=None, check_parse=True):
             return text.decode("utf-8").lower()
         return text.lower()
 
-    def spans_score(gold_spans, system_spans):
+    def spans_score(gold_spans, system_spans, to_print=False):
         correct, gi, si = 0, 0, 0
+        si_start_earlier, gi_start_earlier, end_si_earlier, end_gi_earlier = 0, 0, 0, 0
         while gi < len(gold_spans) and si < len(system_spans):
+            previous_si = system_spans[si-1] if si > 0 else None
+            previous_gi = gold_spans[gi-1] if gi > 0 else None
+            next_si = system_spans[si+1] if si+1 < len(system_spans) else None
+            next_gi = gold_spans[gi+1] if gi+1 < len(gold_spans) else None
             if system_spans[si].start < gold_spans[gi].start:
+                si_start_earlier += 1
+                if to_print:
+                    print("syst start earlier", "SI_" + str(si), previous_si, system_spans[si], next_si, system_spans[si].start, system_spans[si].end)
+                    print("gold              ", "GI_" + str(gi), previous_gi, gold_spans[gi], next_gi, gold_spans[gi].start, gold_spans[gi].end)
+                    print()
                 si += 1
             elif gold_spans[gi].start < system_spans[si].start:
+                gi_start_earlier += 1
+                if to_print:
+                    print("gold start earlier", "GI_" + str(gi), previous_gi, gold_spans[gi], next_gi, gold_spans[gi].start, gold_spans[gi].end)
+                    print("syst              ", "SI_" + str(si), previous_si, system_spans[si], next_si, system_spans[si].start,
+                          system_spans[si].end)
+                    print()
                 gi += 1
             else:
                 correct += gold_spans[gi].end == system_spans[si].end
+                if gold_spans[gi].end < system_spans[si].end:
+                    end_gi_earlier += 1
+                    if to_print:
+                        print("gold end earlier", "GI_" + str(gi), previous_gi, gold_spans[gi], next_gi, gold_spans[gi].start, gold_spans[gi].end)
+                        print("syst            ", "SI_" + str(si), previous_si, system_spans[si], next_si, system_spans[si].start, system_spans[si].end)
+                        print()
+                elif gold_spans[gi].end > system_spans[si].end:
+                    end_si_earlier += 1
+                    if to_print:
+                        print("syst end earlier", "SI_" + str(si), previous_si, system_spans[si], next_si, system_spans[si].start, system_spans[si].end)
+                        print("gold            ", "GI_" + str(gi), previous_gi, gold_spans[gi], next_gi, gold_spans[gi].start, gold_spans[gi].end)
+                        print()
                 si += 1
                 gi += 1
+
+        if to_print:
+            print("si_start_earlier", si_start_earlier)
+            print("gi_start_earlier", gi_start_earlier)
+            print("end_si_earlier", end_si_earlier)
+            print("end_gi_earlier", end_gi_earlier)
 
         return Score(len(gold_spans), len(system_spans), correct)
 
@@ -429,7 +463,7 @@ def evaluate(gold_ud, system_ud, deprel_weights=None, check_parse=True):
     # Compute the F1-scores
     if check_parse:
         result = {
-            "Tokens": spans_score(gold_ud.tokens, system_ud.tokens),
+            "Tokens": spans_score(gold_ud.tokens, system_ud.tokens, to_print=True),
             "Sentences": spans_score(gold_ud.sentences, system_ud.sentences),
             "Words": alignment_score(alignment, None),
             "UPOS": alignment_score(alignment, lambda w, parent: w.columns[UPOS]),
@@ -442,7 +476,7 @@ def evaluate(gold_ud, system_ud, deprel_weights=None, check_parse=True):
         }
     else:
         result = {
-            "Tokens": spans_score(gold_ud.tokens, system_ud.tokens),
+            "Tokens": spans_score(gold_ud.tokens, system_ud.tokens, to_print=True),
             "Sentences": spans_score(gold_ud.sentences, system_ud.sentences),
             "Words": alignment_score(alignment, None),
             "Feats": alignment_score(alignment, lambda w, parent: w.columns[FEATS]),

--- a/spacy/cli/ud/conll17_ud_eval.py
+++ b/spacy/cli/ud/conll17_ud_eval.py
@@ -51,7 +51,7 @@
 #   - evaluate the given gold and system CoNLL-U files (loaded with load_conllu)
 #   - raises UDError if the concatenated tokens of gold and system file do not match
 #   - returns a dictionary with the metrics described above, each metrics having
-#     three fields: precision, recall and f1
+#     four fields: precision, recall, f1 and aligned_accuracy
 
 # Description of token matching
 # -----------------------------

--- a/spacy/cli/ud/conll17_ud_eval.py
+++ b/spacy/cli/ud/conll17_ud_eval.py
@@ -302,22 +302,22 @@ def evaluate(gold_ud, system_ud, deprel_weights=None, check_parse=True):
                 # avoid counting the same mistake twice
                 if not previous_end_si_earlier:
                     combo += 1
-                    oversegmented.append(previous_gi)
+                    oversegmented.append(str(previous_gi).strip())
                 si += 1
             elif gold_spans[gi].start < system_spans[si].start:
                 # avoid counting the same mistake twice
                 if not previous_end_gi_earlier:
                     combo += 1
-                    undersegmented.append(previous_si)
+                    undersegmented.append(str(previous_si).strip())
                 gi += 1
             else:
                 correct += gold_spans[gi].end == system_spans[si].end
                 if gold_spans[gi].end < system_spans[si].end:
-                    undersegmented.append(system_spans[si])
+                    undersegmented.append(str(system_spans[si]).strip())
                     previous_end_gi_earlier = True
                     previous_end_si_earlier = False
                 elif gold_spans[gi].end > system_spans[si].end:
-                    oversegmented.append(gold_spans[gi])
+                    oversegmented.append(str(gold_spans[gi]).strip())
                     previous_end_si_earlier = True
                     previous_end_gi_earlier = False
                 else:

--- a/spacy/cli/ud/conll17_ud_eval.py
+++ b/spacy/cli/ud/conll17_ud_eval.py
@@ -258,6 +258,8 @@ def evaluate(gold_ud, system_ud, deprel_weights=None, check_parse=True):
             self.aligned_accuracy = correct / aligned_total if aligned_total else aligned_total
             self.undersegmented = undersegmented
             self.oversegmented = oversegmented
+            self.under_perc = len(undersegmented) / gold_total if gold_total and undersegmented else 0.0
+            self.over_perc = len(oversegmented) / gold_total if gold_total and oversegmented else 0.0
     class AlignmentWord:
         def __init__(self, gold_word, system_word):
             self.gold_word = gold_word

--- a/spacy/cli/ud/conll17_ud_eval.py
+++ b/spacy/cli/ud/conll17_ud_eval.py
@@ -251,11 +251,13 @@ def load_conllu(file, check_parse=True):
 # Evaluate the gold and system treebanks (loaded using load_conllu).
 def evaluate(gold_ud, system_ud, deprel_weights=None, check_parse=True):
     class Score:
-        def __init__(self, gold_total, system_total, correct, aligned_total=None):
+        def __init__(self, gold_total, system_total, correct, aligned_total=None, undersegmented=None, oversegmented=None):
             self.precision = correct / system_total if system_total else 0.0
             self.recall = correct / gold_total if gold_total else 0.0
             self.f1 = 2 * correct / (system_total + gold_total) if system_total + gold_total else 0.0
             self.aligned_accuracy = correct / aligned_total if aligned_total else aligned_total
+            self.undersegmented = undersegmented
+            self.oversegmented = oversegmented
     class AlignmentWord:
         def __init__(self, gold_word, system_word):
             self.gold_word = gold_word
@@ -286,58 +288,45 @@ def evaluate(gold_ud, system_ud, deprel_weights=None, check_parse=True):
             return text.decode("utf-8").lower()
         return text.lower()
 
-    def spans_score(gold_spans, system_spans, to_print=False):
+    def spans_score(gold_spans, system_spans):
         correct, gi, si = 0, 0, 0
-        undersegment, oversegment, combo = 0, 0, 0
+        undersegmented = list()
+        oversegmented = list()
+        combo = 0
         previous_end_si_earlier = False
         previous_end_gi_earlier = False
         while gi < len(gold_spans) and si < len(system_spans):
             previous_si = system_spans[si-1] if si > 0 else None
             previous_gi = gold_spans[gi-1] if gi > 0 else None
-            next_si = system_spans[si+1] if si+1 < len(system_spans) else None
-            next_gi = gold_spans[gi+1] if gi+1 < len(gold_spans) else None
             if system_spans[si].start < gold_spans[gi].start:
-                if to_print and not previous_end_si_earlier:
+                # avoid counting the same mistake twice
+                if not previous_end_si_earlier:
                     combo += 1
-                    oversegment += 1
-                    print("oversegment: system --> gold: ", previous_si, system_spans[si], next_si, '-->', previous_gi, gold_spans[gi], next_gi)
-                    print("combo")
+                    oversegmented.append(previous_gi)
                 si += 1
             elif gold_spans[gi].start < system_spans[si].start:
-                if to_print and not previous_end_gi_earlier:
+                # avoid counting the same mistake twice
+                if not previous_end_gi_earlier:
                     combo += 1
-                    undersegment += 1
-                    print("undersegment: system --> gold: ", previous_si, system_spans[si], next_si, '-->', previous_gi, gold_spans[gi], next_gi)
-                    print("combo")
+                    undersegmented.append(previous_si)
                 gi += 1
             else:
                 correct += gold_spans[gi].end == system_spans[si].end
                 if gold_spans[gi].end < system_spans[si].end:
-                    undersegment += 1
+                    undersegmented.append(system_spans[si])
                     previous_end_gi_earlier = True
                     previous_end_si_earlier = False
-                    if to_print:
-                        print("undersegment: system --> gold: ", previous_si, system_spans[si], next_si, '-->', previous_gi, gold_spans[gi], next_gi)
                 elif gold_spans[gi].end > system_spans[si].end:
-                    oversegment += 1
+                    oversegmented.append(gold_spans[gi])
                     previous_end_si_earlier = True
                     previous_end_gi_earlier = False
-                    if to_print:
-                        print("oversegment: system --> gold: ", previous_si, system_spans[si], next_si, '-->', previous_gi, gold_spans[gi], next_gi)
                 else:
                     previous_end_gi_earlier = False
                     previous_end_si_earlier = False
                 si += 1
                 gi += 1
 
-        if to_print:
-            print()
-            print("oversegment", oversegment)
-            print("undersegment", undersegment)
-            print("combo", combo)
-            print()
-
-        return Score(len(gold_spans), len(system_spans), correct)
+        return Score(len(gold_spans), len(system_spans), correct, None, undersegmented, oversegmented)
 
     def alignment_score(alignment, key_fn, weight_fn=lambda w: 1):
         gold, system, aligned, correct = 0, 0, 0, 0
@@ -468,7 +457,7 @@ def evaluate(gold_ud, system_ud, deprel_weights=None, check_parse=True):
     # Compute the F1-scores
     if check_parse:
         result = {
-            "Tokens": spans_score(gold_ud.tokens, system_ud.tokens, to_print=True),
+            "Tokens": spans_score(gold_ud.tokens, system_ud.tokens),
             "Sentences": spans_score(gold_ud.sentences, system_ud.sentences),
             "Words": alignment_score(alignment, None),
             "UPOS": alignment_score(alignment, lambda w, parent: w.columns[UPOS]),
@@ -481,7 +470,7 @@ def evaluate(gold_ud, system_ud, deprel_weights=None, check_parse=True):
         }
     else:
         result = {
-            "Tokens": spans_score(gold_ud.tokens, system_ud.tokens, to_print=True),
+            "Tokens": spans_score(gold_ud.tokens, system_ud.tokens),
             "Sentences": spans_score(gold_ud.sentences, system_ud.sentences),
             "Words": alignment_score(alignment, None),
             "Feats": alignment_score(alignment, lambda w, parent: w.columns[FEATS]),

--- a/spacy/cli/ud/conll17_ud_eval.py
+++ b/spacy/cli/ud/conll17_ud_eval.py
@@ -51,7 +51,8 @@
 #   - evaluate the given gold and system CoNLL-U files (loaded with load_conllu)
 #   - raises UDError if the concatenated tokens of gold and system file do not match
 #   - returns a dictionary with the metrics described above, each metrics having
-#     four fields: precision, recall, f1 and aligned_accuracy
+#     four fields: precision, recall, f1 and aligned_accuracy (when using aligned
+#     words, otherwise this is None)
 
 # Description of token matching
 # -----------------------------

--- a/spacy/cli/ud/run_eval.py
+++ b/spacy/cli/ud/run_eval.py
@@ -3,6 +3,7 @@ import spacy
 import time
 import re
 import operator
+import datetime
 
 from spacy.cli.ud import conll17_ud_eval
 from spacy.cli.ud.ud_train import write_conllu
@@ -11,8 +12,8 @@ from spacy.lang.lex_attrs import word_shape
 # TODO: remove hardcoded path
 ud_location = os.path.join('C:', os.sep, 'Users', 'Sofie', 'Documents', 'data', 'UD_2_3', 'ud-treebanks-v2.3')
 ud_version = '2.3'
-ud_folder = 'UD_French-'
-ud_lang = 'fr_'
+ud_folder = 'UD_English-'
+ud_lang = 'en_'
 
 space_re = re.compile("\s+")
 
@@ -50,12 +51,12 @@ def split_text(text):
     return [space_re.sub(" ", par.strip()) for par in text.split("\n\n")]
 
 
-def get_freq_dict(my_list):
+def get_freq_tuples(my_list, print_total_threshold):
     d = {}
     for token in my_list:
         d.setdefault(token, 0)
         d[token] += 1
-    return d
+    return sorted(d.items(), key=operator.itemgetter(1), reverse=True)[:print_total_threshold]
 
 
 def run_single_eval(nlp, model_print_name, train_path, gold_ud, tmp_output_path):
@@ -72,8 +73,8 @@ def run_single_eval(nlp, model_print_name, train_path, gold_ud, tmp_output_path)
     # STEP 3: record stats and timings
     tokens_per_s = int(len(gold_ud.tokens) / tokenization_time)
 
-    print_header_1 = ['train_path', 'gold_tokens', 'model', 'loading_time', 'tokenization_time', 'tokens_per_s']
-    print_string_1 = [os.path.basename(train_path) + ' ' + ud_version, len(gold_ud.tokens), model_print_name,
+    print_header_1 = ['date', 'train_path', 'gold_tokens', 'model', 'loading_time', 'tokenization_time', 'tokens_per_s']
+    print_string_1 = [str(datetime.date.today()), os.path.basename(train_path) + ' ' + ud_version, len(gold_ud.tokens), model_print_name,
                       "%.2f" % loading_time, "%.2f" % tokenization_time, tokens_per_s]
 
     # STEP 4: evaluate predicted tokens and features
@@ -104,26 +105,22 @@ def run_single_eval(nlp, model_print_name, train_path, gold_ud, tmp_output_path)
             print_header_1.extend([score_name + '_word_under_ex', score_name + '_shape_under_ex',
                                    score_name + '_word_over_ex', score_name + '_shape_over_ex'])
 
-            d_under_words = get_freq_dict(score.undersegmented)
-            d_under_shapes = get_freq_dict([word_shape(x) for x in score.undersegmented])
-            d_over_words = get_freq_dict(score.oversegmented)
-            d_over_shapes = get_freq_dict([word_shape(x) for x in score.oversegmented])
+            d_under_words = get_freq_tuples(score.undersegmented, print_total_threshold)
+            d_under_shapes = get_freq_tuples([word_shape(x) for x in score.undersegmented], print_total_threshold)
+            d_over_words = get_freq_tuples(score.oversegmented, print_total_threshold)
+            d_over_shapes = get_freq_tuples([word_shape(x) for x in score.oversegmented], print_total_threshold)
 
-            print_string_1.append(str(sorted(d_under_words.items(), key=operator.itemgetter(1), reverse=True)[:print_total_threshold]))
-            print_string_1.append(str(sorted(d_under_shapes.items(), key=operator.itemgetter(1), reverse=True)[:print_total_threshold]))
-            print_string_1.append(str(sorted(d_over_words.items(), key=operator.itemgetter(1), reverse=True)[:print_total_threshold]))
-            print_string_1.append(str(sorted(d_over_shapes.items(), key=operator.itemgetter(1), reverse=True)[:print_total_threshold]))
+            print_string_1.append(str({k: v for k, v in d_under_words if v > print_freq_threshold}).replace(";", "*SEMICOLON*"))
+            print_string_1.append(str({k: v for k, v in d_under_shapes if v > print_freq_threshold}).replace(";", "*SEMICOLON*"))
+            print_string_1.append(str({k: v for k, v in d_over_words if v > print_freq_threshold}).replace(";", "*SEMICOLON*"))
+            print_string_1.append(str({k: v for k, v in d_over_shapes if v > print_freq_threshold}).replace(";", "*SEMICOLON*"))
 
     # STEP 5: print the results
-    print()
-    print(" Loading model took {} seconds: {}".format(loading_time, my_model))
-    print(" Tokenizing text took {} seconds".format(tokenization_time))
-    print(" Tokens per second: {}".format(tokens_per_s))
-    print()
+    fname = os.path.join(os.path.dirname(__file__), 'output.csv')
+    with open(fname, 'w') as file:       # , 'a'
+        file.write(';'.join(map(str, print_header_1)) + '\n')
+        file.write(';'.join(map(str, print_string_1)) + '\n')
 
-    print(';'.join(map(str, print_header_1)))
-    print(';'.join(map(str, print_string_1)))
-    print()
 
 
 def main(nlp_list, ud_folder, treebank_list):
@@ -136,25 +133,25 @@ if __name__ == "__main__":
     # my_model = 'en_core_web_sm'
     # my_model = 'en_core_web_md'
     # my_model = 'en_core_web_lg'
-    # my_model = 'English'
-    my_model = 'French'
+    my_model = 'English'
+    # my_model = 'French'
 
     check_parse = False
-    print_freq_threshold = 0  # minimum frequency an error should have to be printed
+    print_freq_threshold = 5  # minimum frequency an error should have to be printed
     print_total_threshold = 10  # maximum number of errors printed per category
 
     # STEP 0 : loading raw text
     # English treebanks: ESL, EWT, GUM, LinES, ParTUT, PUD
     # ESL does not contain the actual texts, PUD does not contain a train/dev portion
     # EWT is the biggest one, ParTUT is the only one with fusion tokens
-    my_treebank = "GSD"
+    my_treebank = "EWT"
     my_train_path = get_training_path(my_treebank, conllu=False)
 
     # STEP 1: load model
     start = time.time()
     # my_nlp = load_model(modelname=my_model)
-    # my_nlp = load_english_model()
-    my_nlp = load_french_model()
+    my_nlp = load_english_model()
+    # my_nlp = load_french_model()
     end = time.time()
     loading_time = end - start
 

--- a/spacy/cli/ud/run_eval.py
+++ b/spacy/cli/ud/run_eval.py
@@ -97,7 +97,11 @@ if __name__ == "__main__":
                                  "%.2f" % score.recall,
                                  "%.2f" % score.f1])
             print_string.append("-" if score.aligned_accuracy is None else "%.2f" % score.aligned_accuracy)
-            print_header.extend([score_name + '_p', score_name + '_r', score_name + '_F', score_name + '_acc'])
+            print_string.append("-" if score.undersegmented is None else len(score.undersegmented))
+            print_string.append("-" if score.oversegmented is None else len(score.oversegmented))
+
+            print_header.extend([score_name + '_p', score_name + '_r', score_name + '_F', score_name + '_acc',
+                                 'undersegmented', 'oversegmented'])
 
     # STEP 5: print the results
     print(" Loading model took {} seconds: {}".format(loading_time, nlp))

--- a/spacy/cli/ud/run_eval.py
+++ b/spacy/cli/ud/run_eval.py
@@ -50,14 +50,15 @@ def split_text(text):
 
 
 if __name__ == "__main__":
+    run_eval = False
 
     # STEP 0 : loading raw text
     flat_text = read_english_training(conllu=False, get_file=False)
 
     # STEP 1: load model
     start = time.time()
-    nlp = load_model(modelname='en_core_web_sm')
-    # load_english_model()
+    # nlp = load_model(modelname='en_core_web_sm')
+    nlp = load_english_model()
     end_loading = time.time()
     loading_time = end_loading - start
 
@@ -68,26 +69,31 @@ if __name__ == "__main__":
     tokenization_time = end_tokenization - end_loading
 
     # STEP 3: write and evaluate predicted tokenization
-    output_path = os.path.join(os.path.dirname(__file__), 'nlp_output.conllu')
-    with open(output_path, "w", encoding="utf8") as out_file:
-        write_conllu(docs, out_file)
-    gold_file = read_english_training(conllu=True, get_file=True)
-    gold_ud = conll17_ud_eval.load_conllu(gold_file)
-    with open(output_path, "r", encoding="utf8") as sys_file:
-        sys_ud = conll17_ud_eval.load_conllu(sys_file)
-    scores = conll17_ud_eval.evaluate(gold_ud, sys_ud)
+    if run_eval:
+        output_path = os.path.join(os.path.dirname(__file__), 'nlp_output_english.conllu')
+        with open(output_path, "w", encoding="utf8") as out_file:
+            write_conllu(docs, out_file)
+        gold_file = read_english_training(conllu=True, get_file=True)
+        gold_ud = conll17_ud_eval.load_conllu(gold_file)
+        with open(output_path, "r", encoding="utf8") as sys_file:
+            sys_ud = conll17_ud_eval.load_conllu(sys_file)
+        scores = conll17_ud_eval.evaluate(gold_ud, sys_ud)
 
-    for score_name, score in scores.items():
-        print(score_name)
-        print(" p", score.precision)
-        print(" r", score.recall)
-        print(" F", score.f1)
-        print(" acc", score.aligned_accuracy)
+        for score_name, score in scores.items():
+            print(score_name)
+            print(" p", score.precision)
+            print(" r", score.recall)
+            print(" F", score.f1)
+            print(" acc", score.aligned_accuracy)
+            print()
+
+        print("word number in gold:", len(gold_ud.words))
+        print("token number in gold:", len(gold_ud.tokens))
         print()
 
-    print("word number in gold:", len(gold_ud.words))
-    print("token number in gold:", len(gold_ud.tokens))
-    print()
     print("Loading model took {} seconds: {}".format(loading_time, nlp))
     print("Tokenizing text took {} seconds: {}".format(tokenization_time, nlp))
-    print(" which is {} tokens per second".format(len(gold_ud.tokens) / tokenization_time))
+
+    if run_eval:
+        print(" which is {} tokens per second".format(len(gold_ud.tokens) / tokenization_time))
+

--- a/spacy/cli/ud/run_eval.py
+++ b/spacy/cli/ud/run_eval.py
@@ -1,0 +1,85 @@
+import os
+import spacy
+import time
+import re
+
+from spacy.cli.ud import conll17_ud_eval
+from spacy.cli.ud.ud_train import write_conllu
+
+# TODO: remove hardcoded path
+ud_location = os.path.join('C:', os.sep, 'Users', 'Sofie', 'Documents', 'data', 'UD_2_3', 'ud-treebanks-v2.3')
+
+space_re = re.compile("\s+")
+
+
+def read_english_training(conllu=False, get_file=False):
+    ud_eng = 'UD_English-ESL'
+    ud_eng_path = os.path.join(ud_location, ud_eng)
+    train_file = os.path.join(ud_eng_path, 'en_esl-ud-train.txt')
+    if conllu:
+        train_file = os.path.join(ud_eng_path, 'en_esl-ud-train.conllu')
+
+    if get_file:
+        return open(train_file, 'r', encoding='utf-8')
+
+    with open(train_file, 'r', encoding='utf-8') as fin:
+        data = fin.read()
+
+    return data
+
+
+def time_load_model(modelname):
+    """ Load and time a specific model """
+    start = time.time()
+    model = spacy.load(modelname)
+    end = time.time()
+    return end - start, model
+
+
+def get_english_model():
+    """ Load and time a generic English model """
+    start = time.time()
+    from spacy.lang.en import English
+    nlp = English()
+    nlp.add_pipe(nlp.create_pipe('sentencizer'))
+    end = time.time()
+    return end - start, nlp
+
+
+def split_text(text):
+    return [space_re.sub(" ", par.strip()) for par in text.split("\n\n")]
+
+
+def eval(nlp, text, gold_file, sys_loc):
+    texts = split_text(text)
+    docs = list(nlp.pipe(texts))
+    with open(sys_loc, "w", encoding="utf8") as out_file:
+        write_conllu(docs, out_file)
+    gold_ud = conll17_ud_eval.load_conllu(gold_file)
+    with open(sys_loc, "r", encoding="utf8") as sys_file:
+        sys_ud = conll17_ud_eval.load_conllu(sys_file)
+    scores = conll17_ud_eval.evaluate(gold_ud, sys_ud)
+    return docs, scores
+
+
+if __name__ == "__main__":
+    time_diff, nlp = time_load_model(modelname='en_core_web_sm')
+    # time_diff, nlp = get_english_model()
+
+    print(" --> Loading model name {} took {} seconds: {}".format("en_core_web_sm", time_diff, nlp))
+
+    output_path = os.path.join(os.path.dirname(__file__), 'nlp_output.conllu')
+
+    docs, myscores = eval(nlp,
+                          read_english_training(conllu=False, get_file=False),
+                          read_english_training(conllu=True, get_file=True),
+                          output_path)
+
+    # print("docs", docs)
+    for score_name, score in myscores.items():
+        print(score_name)
+        print(" p", score.precision)
+        print(" r", score.recall)
+        print(" F", score.f1)
+        print(" acc", score.aligned_accuracy)
+        print()

--- a/spacy/cli/ud/run_eval.py
+++ b/spacy/cli/ud/run_eval.py
@@ -11,8 +11,8 @@ from spacy.lang.lex_attrs import word_shape
 # TODO: remove hardcoded path
 ud_location = os.path.join('C:', os.sep, 'Users', 'Sofie', 'Documents', 'data', 'UD_2_3', 'ud-treebanks-v2.3')
 ud_version = '2.3'
-ud_folder = 'UD_English-'
-ud_lang = 'en_'
+ud_folder = 'UD_French-'
+ud_lang = 'fr_'
 
 space_re = re.compile("\s+")
 
@@ -38,19 +38,96 @@ def load_english_model():
     return nlp
 
 
+def load_french_model():
+    """ Load a generic French model """
+    from spacy.lang.fr import French
+    nlp = French()
+    nlp.add_pipe(nlp.create_pipe('sentencizer'))
+    return nlp
+
+
 def split_text(text):
     return [space_re.sub(" ", par.strip()) for par in text.split("\n\n")]
 
 
-def print_high_freq(my_list, threshold):
+def get_freq_dict(my_list):
     d = {}
     for token in my_list:
         d.setdefault(token, 0)
         d[token] += 1
-    for token, count in sorted(d.items(), key=operator.itemgetter(1), reverse=True):
-        if count >= threshold:
-            print(token, '\t', count)
+    return d
+
+
+def run_single_eval(nlp, model_print_name, train_path, gold_ud, tmp_output_path):
+    with open(train_path, 'r', encoding='utf-8') as fin:
+        flat_text = fin.read()
+
+    # STEP 2: tokenize text
+    tokenization_start = time.time()
+    texts = split_text(flat_text)
+    docs = list(nlp.pipe(texts))
+    tokenization_end = time.time()
+    tokenization_time = tokenization_end - tokenization_start
+
+    # STEP 3: record stats and timings
+    tokens_per_s = int(len(gold_ud.tokens) / tokenization_time)
+
+    print_header_1 = ['train_path', 'gold_tokens', 'model', 'loading_time', 'tokenization_time', 'tokens_per_s']
+    print_string_1 = [os.path.basename(train_path) + ' ' + ud_version, len(gold_ud.tokens), model_print_name,
+                      "%.2f" % loading_time, "%.2f" % tokenization_time, tokens_per_s]
+
+    # STEP 4: evaluate predicted tokens and features
+    # TODO Sofie: do we need a tmp file ?!
+    with open(tmp_output_path, "w", encoding="utf8") as out_file:
+        write_conllu(docs, out_file)
+    with open(tmp_output_path, "r", encoding="utf8") as sys_file:
+        sys_ud = conll17_ud_eval.load_conllu(sys_file, check_parse=check_parse)
+    scores = conll17_ud_eval.evaluate(gold_ud, sys_ud, check_parse=check_parse)
+
+    # fixed order for normalized printing. don't print the last few columns if we don't have a parse
+    eval_headers = ['Tokens', 'Words', 'Lemmas', 'Sentences', 'Feats', 'UPOS', 'XPOS', 'AllTags', 'UAS', 'LAS']
+    if not check_parse:
+        eval_headers = ['Tokens', 'Words', 'Lemmas', 'Sentences', 'Feats']
+    for score_name in eval_headers:
+        score = scores[score_name]
+        print_string_1.extend(["%.2f" % score.precision,
+                               "%.2f" % score.recall,
+                               "%.2f" % score.f1])
+        print_string_1.append("-" if score.aligned_accuracy is None else "%.2f" % score.aligned_accuracy)
+        print_string_1.append("-" if score.undersegmented is None else len(score.undersegmented))
+        print_string_1.append("-" if score.oversegmented is None else len(score.oversegmented))
+
+        print_header_1.extend([score_name + '_p', score_name + '_r', score_name + '_F', score_name + '_acc',
+                               score_name + '_under', score_name + '_over'])
+
+        if score_name == "Tokens":
+            print_header_1.extend([score_name + '_word_under_ex', score_name + '_shape_under_ex',
+                                   score_name + '_word_over_ex', score_name + '_shape_over_ex'])
+
+            d_under_words = get_freq_dict(score.undersegmented)
+            d_under_shapes = get_freq_dict([word_shape(x) for x in score.undersegmented])
+            d_over_words = get_freq_dict(score.oversegmented)
+            d_over_shapes = get_freq_dict([word_shape(x) for x in score.oversegmented])
+
+            print_string_1.append(str(sorted(d_under_words.items(), key=operator.itemgetter(1), reverse=True)[:print_total_threshold]))
+            print_string_1.append(str(sorted(d_under_shapes.items(), key=operator.itemgetter(1), reverse=True)[:print_total_threshold]))
+            print_string_1.append(str(sorted(d_over_words.items(), key=operator.itemgetter(1), reverse=True)[:print_total_threshold]))
+            print_string_1.append(str(sorted(d_over_shapes.items(), key=operator.itemgetter(1), reverse=True)[:print_total_threshold]))
+
+    # STEP 5: print the results
     print()
+    print(" Loading model took {} seconds: {}".format(loading_time, my_model))
+    print(" Tokenizing text took {} seconds".format(tokenization_time))
+    print(" Tokens per second: {}".format(tokens_per_s))
+    print()
+
+    print(';'.join(map(str, print_header_1)))
+    print(';'.join(map(str, print_string_1)))
+    print()
+
+
+def main(nlp_list, ud_folder, treebank_list):
+    pass
 
 
 if __name__ == "__main__":
@@ -59,88 +136,33 @@ if __name__ == "__main__":
     # my_model = 'en_core_web_sm'
     # my_model = 'en_core_web_md'
     # my_model = 'en_core_web_lg'
-    # my_model = 'en_vectors_web_lg'
-    my_model = 'English'
+    # my_model = 'English'
+    my_model = 'French'
 
     check_parse = False
-    print_threshold = 10  # set high (eg 1000) not to print anything
+    print_freq_threshold = 0  # minimum frequency an error should have to be printed
+    print_total_threshold = 10  # maximum number of errors printed per category
 
     # STEP 0 : loading raw text
     # English treebanks: ESL, EWT, GUM, LinES, ParTUT, PUD
     # ESL does not contain the actual texts, PUD does not contain a train/dev portion
     # EWT is the biggest one, ParTUT is the only one with fusion tokens
-    my_treebank = "EWT"
-    train_path = get_training_path(my_treebank, conllu=False)
-    with open(train_path, 'r', encoding='utf-8') as fin:
-        flat_text = fin.read()
+    my_treebank = "GSD"
+    my_train_path = get_training_path(my_treebank, conllu=False)
 
     # STEP 1: load model
     start = time.time()
-    # nlp = load_model(modelname=my_model)
-    nlp = load_english_model()
-    end_loading = time.time()
-    loading_time = end_loading - start
+    # my_nlp = load_model(modelname=my_model)
+    # my_nlp = load_english_model()
+    my_nlp = load_french_model()
+    end = time.time()
+    loading_time = end - start
 
-    # STEP 2: tokenize text
-    texts = split_text(flat_text)
-    docs = list(nlp.pipe(texts))
-    end_tokenization = time.time()
-    tokenization_time = end_tokenization - end_loading
-
-    # STEP 3: record stats and timings
     gold_file = open(get_training_path(my_treebank, conllu=True), 'r', encoding='utf-8')
-    gold_ud = conll17_ud_eval.load_conllu(gold_file)
-    tokens_per_s = int(len(gold_ud.tokens) / tokenization_time)
+    my_gold_ud = conll17_ud_eval.load_conllu(gold_file)
 
-    print_header_1 = ['train_path', 'gold_tokens', 'model', 'loading_time', 'tokenization_time', 'tokens_per_s']
-    print_string_1 = [os.path.basename(train_path) + ' ' + ud_version, len(gold_ud.tokens), my_model,
-                    "%.2f" % loading_time, "%.2f" % tokenization_time, tokens_per_s]
+    my_tmp_output_path = os.path.join(os.path.dirname(__file__), 'nlp_output_english.conllu')
 
-    # STEP 4: evaluate predicted tokens and features
-    if run_eval:
-        output_path = os.path.join(os.path.dirname(__file__), 'nlp_output_english.conllu')
-        with open(output_path, "w", encoding="utf8") as out_file:
-            write_conllu(docs, out_file)
-        with open(output_path, "r", encoding="utf8") as sys_file:
-            sys_ud = conll17_ud_eval.load_conllu(sys_file, check_parse=check_parse)
-        scores = conll17_ud_eval.evaluate(gold_ud, sys_ud, check_parse=check_parse)
-
-        # fixed order for normalized printing. don't print the last few columns if we don't have a parse
-        eval_headers = ['Tokens', 'Words', 'Lemmas', 'Sentences', 'Feats', 'UPOS', 'XPOS', 'AllTags', 'UAS', 'LAS']
-        if not check_parse:
-            eval_headers = ['Tokens', 'Words', 'Lemmas', 'Sentences', 'Feats']
-        for score_name in eval_headers:
-            score = scores[score_name]
-            print_string_1.extend(["%.2f" % score.precision,
-                                 "%.2f" % score.recall,
-                                 "%.2f" % score.f1])
-            print_string_1.append("-" if score.aligned_accuracy is None else "%.2f" % score.aligned_accuracy)
-            print_string_1.append("-" if score.undersegmented is None else len(score.undersegmented))
-            print_string_1.append("-" if score.oversegmented is None else len(score.oversegmented))
-
-            print_header_1.extend([score_name + '_p', score_name + '_r', score_name + '_F', score_name + '_acc',
-                                 'undersegmented', 'oversegmented'])
-
-            if score_name == "Tokens":
-                print()
-                print(score_name, "undersegmented:")
-                print_high_freq(score.undersegmented, print_threshold)
-                print_high_freq([word_shape(x) for x in score.undersegmented], print_threshold)
-
-                print(score_name, "oversegmented:")
-                print_high_freq(score.oversegmented, print_threshold)
-                print_high_freq([word_shape(x) for x in score.oversegmented], print_threshold)
-
-
-    # STEP 5: print the results
-    print()
-    print(" Loading model took {} seconds: {}".format(loading_time, nlp))
-    print(" Tokenizing text took {} seconds".format(tokenization_time))
-    print(" Tokens per second: {}".format(tokens_per_s))
-    print()
-
-    print(';'.join(map(str, print_header_1)))
-    print(';'.join(map(str, print_string_1)))
-    print()
+    run_single_eval(my_nlp, my_model, my_train_path, my_gold_ud, my_tmp_output_path)
 
 

--- a/spacy/cli/ud/run_eval.py
+++ b/spacy/cli/ud/run_eval.py
@@ -13,11 +13,15 @@ space_re = re.compile("\s+")
 
 
 def read_english_training(conllu=False, get_file=False):
-    ud_eng = 'UD_English-ESL'
-    ud_eng_path = os.path.join(ud_location, ud_eng)
-    train_file = os.path.join(ud_eng_path, 'en_esl-ud-train.txt')
+    # English treebanks: ESL, EWT, GUM, LinES, ParTUT, PUD
+    # ESL does not contain the actual texts, PUD does not contain a train/dev portion
+    # EWT is the biggest one, ParTUT is the only one with fusion tokens
+    english_treebank = "EWT"
+
+    ud_eng_path = os.path.join(ud_location, 'UD_English-' + english_treebank)
+    train_file = os.path.join(ud_eng_path, 'en_' + english_treebank.lower() + '-ud-train.txt')
     if conllu:
-        train_file = os.path.join(ud_eng_path, 'en_esl-ud-train.conllu')
+        train_file = train_file.replace('.txt', '.conllu')
 
     if get_file:
         return open(train_file, 'r', encoding='utf-8')
@@ -28,58 +32,62 @@ def read_english_training(conllu=False, get_file=False):
     return data
 
 
-def time_load_model(modelname):
-    """ Load and time a specific model """
-    start = time.time()
-    model = spacy.load(modelname)
-    end = time.time()
-    return end - start, model
+def load_model(modelname):
+    """ Load a specific model """
+    return spacy.load(modelname)
 
 
-def get_english_model():
-    """ Load and time a generic English model """
-    start = time.time()
+def load_english_model():
+    """ Load a generic English model """
     from spacy.lang.en import English
     nlp = English()
     nlp.add_pipe(nlp.create_pipe('sentencizer'))
-    end = time.time()
-    return end - start, nlp
+    return nlp
 
 
 def split_text(text):
     return [space_re.sub(" ", par.strip()) for par in text.split("\n\n")]
 
 
-def eval(nlp, text, gold_file, sys_loc):
-    texts = split_text(text)
+if __name__ == "__main__":
+
+    # STEP 0 : loading raw text
+    flat_text = read_english_training(conllu=False, get_file=False)
+
+    # STEP 1: load model
+    start = time.time()
+    nlp = load_model(modelname='en_core_web_sm')
+    # load_english_model()
+    end_loading = time.time()
+    loading_time = end_loading - start
+
+    # STEP 2: tokenize text
+    texts = split_text(flat_text)
     docs = list(nlp.pipe(texts))
-    with open(sys_loc, "w", encoding="utf8") as out_file:
+    end_tokenization = time.time()
+    tokenization_time = end_tokenization - end_loading
+
+    # STEP 3: write and evaluate predicted tokenization
+    output_path = os.path.join(os.path.dirname(__file__), 'nlp_output.conllu')
+    with open(output_path, "w", encoding="utf8") as out_file:
         write_conllu(docs, out_file)
+    gold_file = read_english_training(conllu=True, get_file=True)
     gold_ud = conll17_ud_eval.load_conllu(gold_file)
-    with open(sys_loc, "r", encoding="utf8") as sys_file:
+    with open(output_path, "r", encoding="utf8") as sys_file:
         sys_ud = conll17_ud_eval.load_conllu(sys_file)
     scores = conll17_ud_eval.evaluate(gold_ud, sys_ud)
-    return docs, scores
 
-
-if __name__ == "__main__":
-    time_diff, nlp = time_load_model(modelname='en_core_web_sm')
-    # time_diff, nlp = get_english_model()
-
-    print(" --> Loading model name {} took {} seconds: {}".format("en_core_web_sm", time_diff, nlp))
-
-    output_path = os.path.join(os.path.dirname(__file__), 'nlp_output.conllu')
-
-    docs, myscores = eval(nlp,
-                          read_english_training(conllu=False, get_file=False),
-                          read_english_training(conllu=True, get_file=True),
-                          output_path)
-
-    # print("docs", docs)
-    for score_name, score in myscores.items():
+    for score_name, score in scores.items():
         print(score_name)
         print(" p", score.precision)
         print(" r", score.recall)
         print(" F", score.f1)
         print(" acc", score.aligned_accuracy)
         print()
+
+    print("word number in gold:", len(gold_ud.words))
+    print("token number in gold:", len(gold_ud.tokens))
+    print()
+    print("Loading model took {} seconds: {}".format(loading_time, nlp))
+    print("Tokenizing text took {} seconds: {}".format(tokenization_time, nlp))
+    print(" which is {} tokens per second".format(len(gold_ud.tokens) / tokenization_time))

--- a/spacy/cli/ud/run_eval.py
+++ b/spacy/cli/ud/run_eval.py
@@ -8,38 +8,48 @@ import datetime
 from spacy.cli.ud import conll17_ud_eval
 from spacy.cli.ud.ud_train import write_conllu
 from spacy.lang.lex_attrs import word_shape
+from spacy.util import get_lang_class
 
-ud_version = '2.3'
+# Non-parsing tasks that will be evaluated (works for default models)
+EVAL_NO_PARSE = ['Tokens', 'Words', 'Lemmas', 'Sentences', 'Feats']
 
-check_parse = False
-print_freq_threshold = 5  # minimum frequency an error should have to be printed
-print_total_threshold = 10  # maximum number of errors printed per category
+# Tasks that will be evaluated if check_parse=True and there are no default models in the list
+EVAL_PARSE = ['Tokens', 'Words', 'Lemmas', 'Sentences', 'Feats', 'UPOS', 'XPOS', 'AllTags', 'UAS', 'LAS']
+
+# Tasks for which to print high-freq error cases. Includes verbose output!
+PRINT_ERROR_EXAMPLES = []  # ['Tokens']
+
+# Minimum frequency an error should have to be printed
+PRINT_FREQ = 5
+
+# Maximum number of errors printed per category
+PRINT_TOTAL = 10
 
 space_re = re.compile("\s+")
 
 
 def load_model(modelname):
-    """ Load a specific model """
-    return spacy.load(modelname)
+    """ Load a specific spaCy model """
+    loading_start = time.time()
+    nlp = spacy.load(modelname)
+    loading_end = time.time()
+    loading_time = loading_end - loading_start
+    return nlp, loading_time, modelname
 
 
-def load_english_model():
-    """ Load a generic English model """
-    from spacy.lang.en import English
-    nlp = English()
+def load_default_model_sentencizer(lang):
+    """ Load a generic spaCy model and add the sentencizer for sentence tokenization"""
+    loading_start = time.time()
+    lang_class = get_lang_class(lang)
+    nlp = lang_class()
     nlp.add_pipe(nlp.create_pipe('sentencizer'))
-    return nlp
-
-
-def load_french_model():
-    """ Load a generic French model """
-    from spacy.lang.fr import French
-    nlp = French()
-    nlp.add_pipe(nlp.create_pipe('sentencizer'))
-    return nlp
+    loading_end = time.time()
+    loading_time = loading_end - loading_start
+    return nlp, loading_time, lang + "_default_" + 'sentencizer'
 
 
 def get_long_lang(lang):
+    """" Helper method to compile the UD path for a certain treebank """
     if lang == 'en':
         return "English"
     if lang == 'fr':
@@ -47,12 +57,12 @@ def get_long_lang(lang):
     return "Unknown"
 
 
-# TODO: remove this ?
 def split_text(text):
     return [space_re.sub(" ", par.strip()) for par in text.split("\n\n")]
 
 
 def get_freq_tuples(my_list, print_total_threshold):
+    """ Turn a list of errors into frequency-sorted tuples thresholded by a certain total number """
     d = {}
     for token in my_list:
         d.setdefault(token, 0)
@@ -60,37 +70,38 @@ def get_freq_tuples(my_list, print_total_threshold):
     return sorted(d.items(), key=operator.itemgetter(1), reverse=True)[:print_total_threshold]
 
 
-def run_single_eval(nlp, model_print_name, train_path, gold_ud, tmp_output_path, file, print_header):
+def run_single_eval(nlp, loading_time, print_name, train_path, gold_ud, tmp_output_path, file, print_header):
+    """" Run an evaluation of a model nlp on a certain specified treebank """
     with open(train_path, 'r', encoding='utf-8') as fin:
         flat_text = fin.read()
 
-    # STEP 2: tokenize text
+    # STEP 1: tokenize text
     tokenization_start = time.time()
     texts = split_text(flat_text)
     docs = list(nlp.pipe(texts))
     tokenization_end = time.time()
     tokenization_time = tokenization_end - tokenization_start
 
-    # STEP 3: record stats and timings
+    # STEP 2: record stats and timings
     tokens_per_s = int(len(gold_ud.tokens) / tokenization_time)
 
-    print_header_1 = ['date', 'train_path', 'gold_tokens', 'model', 'tokenization_time', 'tokens_per_s']
-    print_string_1 = [str(datetime.date.today()), os.path.basename(train_path) + ' ' + ud_version, len(gold_ud.tokens),
-                      model_print_name,
-                      "%.2f" % tokenization_time, tokens_per_s]
+    print_header_1 = ['date', 'train_path', 'gold_tokens', 'model', 'loading_time', 'tokenization_time', 'tokens_per_s']
+    print_string_1 = [str(datetime.date.today()), os.path.basename(train_path), len(gold_ud.tokens),
+                      print_name, "%.2f" % loading_time, "%.2f" % tokenization_time, tokens_per_s]
 
-    # STEP 4: evaluate predicted tokens and features
-    # TODO Sofie: do we need a tmp file ?!
+    # STEP 3: evaluate predicted tokens and features
     with open(tmp_output_path, "w", encoding="utf8") as out_file:
         write_conllu(docs, out_file)
     with open(tmp_output_path, "r", encoding="utf8") as sys_file:
         sys_ud = conll17_ud_eval.load_conllu(sys_file, check_parse=check_parse)
+    os.remove(tmp_output_path)
     scores = conll17_ud_eval.evaluate(gold_ud, sys_ud, check_parse=check_parse)
 
-    # fixed order for normalized printing. don't print the last few columns if we don't have a parse
-    eval_headers = ['Tokens', 'Words', 'Lemmas', 'Sentences', 'Feats', 'UPOS', 'XPOS', 'AllTags', 'UAS', 'LAS']
+    # STEP 4: format the scoring results
+    eval_headers = EVAL_PARSE
     if not check_parse:
-        eval_headers = ['Tokens', 'Words', 'Lemmas', 'Sentences', 'Feats']
+        eval_headers = EVAL_NO_PARSE
+
     for score_name in eval_headers:
         score = scores[score_name]
         print_string_1.extend(["%.2f" % score.precision,
@@ -103,35 +114,38 @@ def run_single_eval(nlp, model_print_name, train_path, gold_ud, tmp_output_path,
         print_header_1.extend([score_name + '_p', score_name + '_r', score_name + '_F', score_name + '_acc',
                                score_name + '_under', score_name + '_over'])
 
-        if score_name == "Tokens":
+        if score_name in PRINT_ERROR_EXAMPLES:
             print_header_1.extend([score_name + '_word_under_ex', score_name + '_shape_under_ex',
                                    score_name + '_word_over_ex', score_name + '_shape_over_ex'])
 
-            d_under_words = get_freq_tuples(score.undersegmented, print_total_threshold)
-            d_under_shapes = get_freq_tuples([word_shape(x) for x in score.undersegmented], print_total_threshold)
-            d_over_words = get_freq_tuples(score.oversegmented, print_total_threshold)
-            d_over_shapes = get_freq_tuples([word_shape(x) for x in score.oversegmented], print_total_threshold)
+            d_under_words = get_freq_tuples(score.undersegmented, PRINT_TOTAL)
+            d_under_shapes = get_freq_tuples([word_shape(x) for x in score.undersegmented], PRINT_TOTAL)
+            d_over_words = get_freq_tuples(score.oversegmented, PRINT_TOTAL)
+            d_over_shapes = get_freq_tuples([word_shape(x) for x in score.oversegmented], PRINT_TOTAL)
 
+            # saving to CSV with ; seperator so blinding ; in the example output
             print_string_1.append(
-                str({k: v for k, v in d_under_words if v > print_freq_threshold}).replace(";", "*SEMICOLON*"))
+                str({k: v for k, v in d_under_words if v > PRINT_FREQ}).replace(";", "*SEMICOLON*"))
             print_string_1.append(
-                str({k: v for k, v in d_under_shapes if v > print_freq_threshold}).replace(";", "*SEMICOLON*"))
+                str({k: v for k, v in d_under_shapes if v > PRINT_FREQ}).replace(";", "*SEMICOLON*"))
             print_string_1.append(
-                str({k: v for k, v in d_over_words if v > print_freq_threshold}).replace(";", "*SEMICOLON*"))
+                str({k: v for k, v in d_over_words if v > PRINT_FREQ}).replace(";", "*SEMICOLON*"))
             print_string_1.append(
-                str({k: v for k, v in d_over_shapes if v > print_freq_threshold}).replace(";", "*SEMICOLON*"))
+                str({k: v for k, v in d_over_shapes if v > PRINT_FREQ}).replace(";", "*SEMICOLON*"))
 
-    # STEP 5: print the results
+    # STEP 5: print the formatted results to CSV
     if print_header:
         file.write(';'.join(map(str, print_header_1)) + '\n')
     file.write(';'.join(map(str, print_string_1)) + '\n')
 
 
 def main(models, treebanks, file):
-    my_tmp_output_path = os.path.join(os.path.dirname(__file__), 'nlp_output_english.conllu')
+    """" Run an evaluation for each language with its specified models and treebanks """
+    my_tmp_output_path = os.path.join(os.path.dirname(__file__), 'tmp_nlp_output.conllu')
     print_header = True
 
     for tb_lang, treebank_list in treebanks.items():
+        print()
         print("Language", tb_lang)
         for treebank in treebank_list:
             ud_path = os.path.join(my_ud_folder, 'UD_' + get_long_lang(tb_lang) + '-' + treebank)
@@ -141,37 +155,46 @@ def main(models, treebanks, file):
             gold_path = train_path.replace('.txt', '.conllu')
             print("  Gold data from ", gold_path)
 
-            with open(gold_path, 'r', encoding='utf-8') as gold_file:
-                gold_ud = conll17_ud_eval.load_conllu(gold_file)
+            try:
+                with open(gold_path, 'r', encoding='utf-8') as gold_file:
+                    gold_ud = conll17_ud_eval.load_conllu(gold_file)
 
-            for nlp, nlp_name in models[tb_lang]:
-                print("   Benchmarking", nlp_name)
-                try:
-                    run_single_eval(nlp, nlp_name, train_path, gold_ud, my_tmp_output_path, file, print_header)
+                for nlp, nlp_loading_time, nlp_name in models[tb_lang]:
+                    print("   Benchmarking", nlp_name)
+
+                    run_single_eval(nlp, nlp_loading_time, nlp_name, train_path, gold_ud, my_tmp_output_path, file,
+                                    print_header)
                     print_header = False
-                except Exception as e:
-                    print("    Ran into trouble: ", str(e))
+            except Exception as e:
+                print("   Ran into trouble: ", str(e))
 
 
 if __name__ == "__main__":
+    """" Hardcoded setting for a quick batch run """
     my_ud_folder = os.path.join('C:', os.sep, 'Users', 'Sofie', 'Documents', 'data', 'UD_2_3', 'ud-treebanks-v2.3')
 
-    treebanks = dict()
-    treebanks['en'] = ['ESL', 'EWT', 'GUM', 'LinES', 'ParTUT', 'PUD']
-    treebanks['fr'] = ['FTB', 'GSD', 'ParTUT', 'PUD', 'Sequoia', 'Spoken']
+    my_treebanks = dict()
+    # Note: 'PUD' doesn't have training data
+    # Note: 'FTB' and 'ESL' have blinded text
+    my_treebanks['en'] = ['EWT', 'GUM', 'LinES', 'ParTUT']  # 'ESL', 'PUD'
+    my_treebanks['fr'] = ['GSD', 'ParTUT', 'Sequoia', 'Spoken']  # 'FTB', 'PUD'
 
+    # When set to True, remove the default models from the list as they don't have parsing functionality
+    check_parse = False
+
+    print("Loading all models")
     my_models = dict()
     my_models['en'] = [
-        (load_english_model(), 'English + sentencizer'),
-        (load_model('en_core_web_sm'), 'en_core_web_sm'),
-        (load_model('en_core_web_md'), 'en_core_web_md'),
-        (load_model('en_core_web_lg'), 'en_core_web_lg')]
+        load_default_model_sentencizer('en'),
+        load_model('en_core_web_sm')]  # ,
+    # (load_model('en_core_web_md'), 'en_core_web_md'),
+    # (load_model('en_core_web_lg'), 'en_core_web_lg')]
 
     my_models['fr'] = [
-        (load_french_model(), 'French + sentencizer'),
-        (load_model('fr_core_news_sm'), 'fr_core_news_sm'),
-        (load_model('fr_core_news_md'), 'fr_core_news_md')]
+        load_default_model_sentencizer('fr')]  # ,
+    # (load_model('fr_core_news_sm'), 'fr_core_news_sm'),
+    # (load_model('fr_core_news_md'), 'fr_core_news_md')]
 
     fname = os.path.join(os.path.dirname(__file__), 'output.csv')
-    with open(fname, 'w') as my_file:  # , 'a'
-        main(my_models, treebanks, my_file)
+    with open(fname, 'w', encoding='utf-8') as my_file:  # , 'a'
+        main(my_models, my_treebanks, my_file)

--- a/spacy/cli/ud/run_eval.py
+++ b/spacy/cli/ud/run_eval.py
@@ -43,8 +43,8 @@ def split_text(text):
 if __name__ == "__main__":
     # RUN PARAMETERS
     run_eval = True
-    my_model = 'en_core_web_sm'
-    # my_model = 'English'
+    # my_model = 'en_core_web_sm'
+    my_model = 'English'
     check_parse = False
 
     # STEP 0 : loading raw text
@@ -58,8 +58,8 @@ if __name__ == "__main__":
 
     # STEP 1: load model
     start = time.time()
-    nlp = load_model(modelname=my_model)
-    # nlp = load_english_model()
+    # nlp = load_model(modelname=my_model)
+    nlp = load_english_model()
     end_loading = time.time()
     loading_time = end_loading - start
 

--- a/spacy/cli/ud/run_eval.py
+++ b/spacy/cli/ud/run_eval.py
@@ -8,28 +8,19 @@ from spacy.cli.ud.ud_train import write_conllu
 
 # TODO: remove hardcoded path
 ud_location = os.path.join('C:', os.sep, 'Users', 'Sofie', 'Documents', 'data', 'UD_2_3', 'ud-treebanks-v2.3')
+ud_version = '2.3'
+ud_folder = 'UD_English-'
+ud_lang = 'en_'
 
 space_re = re.compile("\s+")
 
 
-def read_english_training(conllu=False, get_file=False):
-    # English treebanks: ESL, EWT, GUM, LinES, ParTUT, PUD
-    # ESL does not contain the actual texts, PUD does not contain a train/dev portion
-    # EWT is the biggest one, ParTUT is the only one with fusion tokens
-    english_treebank = "EWT"
-
-    ud_eng_path = os.path.join(ud_location, 'UD_English-' + english_treebank)
-    train_file = os.path.join(ud_eng_path, 'en_' + english_treebank.lower() + '-ud-train.txt')
+def get_training_path(treebank, conllu=False):
+    ud_path = os.path.join(ud_location, ud_folder + treebank)
+    train_file = os.path.join(ud_path, ud_lang + treebank.lower() + '-ud-train.txt')
     if conllu:
         train_file = train_file.replace('.txt', '.conllu')
-
-    if get_file:
-        return open(train_file, 'r', encoding='utf-8')
-
-    with open(train_file, 'r', encoding='utf-8') as fin:
-        data = fin.read()
-
-    return data
+    return train_file
 
 
 def load_model(modelname):
@@ -50,15 +41,23 @@ def split_text(text):
 
 
 if __name__ == "__main__":
-    run_eval = False
+    # RUN PARAMETERS
+    run_eval = True
+    my_model = 'en_core_web_sm'
 
     # STEP 0 : loading raw text
-    flat_text = read_english_training(conllu=False, get_file=False)
+    # English treebanks: ESL, EWT, GUM, LinES, ParTUT, PUD
+    # ESL does not contain the actual texts, PUD does not contain a train/dev portion
+    # EWT is the biggest one, ParTUT is the only one with fusion tokens
+    my_treebank = "EWT"
+    train_path = get_training_path(my_treebank, conllu=False)
+    with open(train_path, 'r', encoding='utf-8') as fin:
+        flat_text = fin.read()
 
     # STEP 1: load model
     start = time.time()
-    # nlp = load_model(modelname='en_core_web_sm')
-    nlp = load_english_model()
+    nlp = load_model(modelname=my_model)
+    # nlp = load_english_model()
     end_loading = time.time()
     loading_time = end_loading - start
 
@@ -68,32 +67,39 @@ if __name__ == "__main__":
     end_tokenization = time.time()
     tokenization_time = end_tokenization - end_loading
 
-    # STEP 3: write and evaluate predicted tokenization
+    # STEP 3: record stats and timings
+    gold_file = open(get_training_path(my_treebank, conllu=True), 'r', encoding='utf-8')
+    gold_ud = conll17_ud_eval.load_conllu(gold_file)
+    tokens_per_s = int(len(gold_ud.tokens) / tokenization_time)
+
+    print_header = ['train_path', 'gold_tokens', 'model', 'loading_time', 'tokenization_time', 'tokens_per_s']
+    print_string = [os.path.basename(train_path), len(gold_ud.tokens), my_model,
+                    "%.2f" % loading_time, "%.2f" % tokenization_time, tokens_per_s]
+
+    # STEP 4: evaluate predicted tokens and features
     if run_eval:
         output_path = os.path.join(os.path.dirname(__file__), 'nlp_output_english.conllu')
         with open(output_path, "w", encoding="utf8") as out_file:
             write_conllu(docs, out_file)
-        gold_file = read_english_training(conllu=True, get_file=True)
-        gold_ud = conll17_ud_eval.load_conllu(gold_file)
         with open(output_path, "r", encoding="utf8") as sys_file:
             sys_ud = conll17_ud_eval.load_conllu(sys_file)
         scores = conll17_ud_eval.evaluate(gold_ud, sys_ud)
 
-        for score_name, score in scores.items():
-            print(score_name)
-            print(" p", score.precision)
-            print(" r", score.recall)
-            print(" F", score.f1)
-            print(" acc", score.aligned_accuracy)
-            print()
+        # fixed order for normalized printing
+        for score_name in ['Tokens', 'Words', 'Lemmas', 'Sentences', 'UPOS', 'XPOS', 'Feats', 'AllTags', 'UAS', 'LAS']:
+            score = scores[score_name]
+            print_string.extend(["%.2f" % score.precision,
+                                 "%.2f" % score.recall,
+                                 "%.2f" % score.f1])
+            print_string.append("-" if score.aligned_accuracy is None else "%.2f" % score.aligned_accuracy)
+            print_header.extend([score_name + '_p', score_name + '_r', score_name + '_F', score_name + '_acc'])
 
-        print("word number in gold:", len(gold_ud.words))
-        print("token number in gold:", len(gold_ud.tokens))
-        print()
+    # STEP 5: print the results
+    print(" Loading model took {} seconds: {}".format(loading_time, nlp))
+    print(" Tokenizing text took {} seconds".format(tokenization_time))
+    print(" Tokens per second: {}".format(tokens_per_s))
+    print()
 
-    print("Loading model took {} seconds: {}".format(loading_time, nlp))
-    print("Tokenizing text took {} seconds: {}".format(tokenization_time, nlp))
-
-    if run_eval:
-        print(" which is {} tokens per second".format(len(gold_ud.tokens) / tokenization_time))
+    print(';'.join(map(str, print_header)))
+    print(';'.join(map(str, print_string)))
 


### PR DESCRIPTION
## Description
usage: `run_eval.py out_path ud_dir [-p] [-t] [-m] [-f] [-b] [-l langs] [-c train]`

```
positional arguments:
  out_path              Path to output CSV file
  ud_dir                Path to Universal Dependencies corpus

optional arguments:
  -h, --help            show this help message and exit
  -p, --check-parse     Set flag to evaluate parsing performance
  -l ar, ca, da, de, el, en, es, fa, fi, fr, ga, he, hi, hr, hu, id, it, ja, no, nl, pl, pt, ro, ru, sv, tr, ur, vi, zh, --langs ar, ca, da, de, el, en, es, fa, fi, fr, ga, he, hi, hr, hu, id, it, ja, no, nl, pl, pt, ro, ru, sv, tr, ur, vi, zh
                        Enumeration of languages to evaluate (default: all)
  -t, --exclude-trained-models
                        Set flag to exclude trained models
  -m, --exclude-multi   Set flag to exclude the multi-language model as
                        default baseline
  -f, --hide-freq       Set flag to avoid printing out more detailed high-freq
                        tokenization errors
  -c train, --corpus train
                        Whether to run on train, dev or test
  -b, --best-per-language
                        Set flag to only keep the largest treebank for each
                        language
```

Features of the script:
 * Runs a batch of evaluations of different spaCy models (blank & pretrained) on different UD treebanks
 * Automatically removes treebanks with blinded texts by inspecting the number of unique lemmas in the `stats.xml`
 * Runs on all relevant treebanks unless the `-b` flag is specified, in which case only the largest one per language is retained
 * Compiles one large CSV (del=';') with all evaluation results from one run 
 * Outputs performance of Tokens, Words, Lemmas, Sentences, Feats: precision, recall, F, acc, % of oversegmented, % of undersegmented
 * Additionally outputs performance of UPOS, XPOS, Alltags, UAS and LAS if `-p` is specified (this will remove the blank models from the list)
 * Additionally outputs high-freq under/overtokenization errors (words & shapes) for Tokens specifically, unless the `-f` flag is specified
 * Prints out progress as the evaluations are run sequentially
 * `xx_ent_wiki_sm` is used as a baseline on all treebanks unless the flag `-m` is specified
 * Removes the trained models from evaluation if `-t` is specified
 * The list of languages to evaluate can be specified with `-l`, otherwise a default list is taken which includes all languages for which an UD corpus exists
 * The evaluation is run on all "train" files unless the `-c` flag is set to "dev" or "test"

Examples: 
 * `python run_eval.py output.csv ud-treebanks-v2.3 -t -l "en,fr,nl"` : runs the default blank models for English, French and Dutch: Tokenization stats + over/undertokenization examples
 * `python run_eval.py output.csv ud-treebanks-v2.3 -p -b -f -l "en,fr,nl"` : runs the parsing models for English, French and Dutch, including additional stats like UPOS, XPOS, UAS and LAS, and evaluated only on a single best treebank per language

Remarks:
 * Note that for Norwegian, the abbreviation in UD is 'no' while in spaCy it's 'nb'. The code caters for this specifically. All other languages seem to be having the same abbreviation so the script relies on that.

### Types of change
New feature: UD batch evaluation script

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
