### PR TITLE
Fix french lemmatization

### DIFF
--- a/spacy/lang/fr/lemmatizer/lemmatizer.py
+++ b/spacy/lang/fr/lemmatizer/lemmatizer.py
@@ -131,7 +131,7 @@ def lemmatize(string, index, exceptions, rules):
     if not forms:
         forms.extend(oov_forms)
     if not forms and string in LOOKUP.keys():
-        forms.append(LOOKUP[string])
+        forms.append(LOOKUP[string][0])
     if not forms:
         forms.append(string)
     return list(set(forms))

--- a/spacy/tests/regression/test_issue3178.py
+++ b/spacy/tests/regression/test_issue3178.py
@@ -1,0 +1,10 @@
+from __future__ import unicode_literals
+import pytest
+import spacy
+
+
+@pytest.mark.models('fr')
+def test_issue1959(FR):
+    texts = ['Je suis la mauvaise herbe', "Me, myself and moi"]
+    for text in texts:
+        FR(text)


### PR DESCRIPTION
This branch fixes an error in the handling of some words in French like "je" and "me".
The error is caused by an expected return type by FrenchLemmartizer. This callable class is supposed to return a list of strings but sometimes returns a list of a tuple containing one string.