### PR TITLE
💫 Suggestion: PhraseMatcher pattern validation

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -60,6 +60,13 @@ class Warnings(object):
             "make displaCy start another one. Instead, you should be able to "
             "replace displacy.serve with displacy.render to show the "
             "visualization.")
+    W012 = ("A Doc object you're adding to the PhraseMatcher for pattern "
+            "'{key}' is parsed and/or tagged, but to match on '{attr}', you "
+            "don't actually need this information. This means that creating "
+            "the patterns is potentially much slower, because all pipeline "
+            "components are applied. To only create tokenized Doc objects, "
+            "try using `nlp.make_doc(text)` or process all texts as a stream "
+            "using `list(nlp.tokenizer.pipe(all_texts))`.")
 
 
 @add_codes

--- a/spacy/tests/matcher/test_phrase_matcher.py
+++ b/spacy/tests/matcher/test_phrase_matcher.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+import pytest
 from spacy.matcher import PhraseMatcher
 from spacy.tokens import Doc
 from ..util import get_doc
@@ -78,3 +79,23 @@ def test_phrase_matcher_bool_attrs(en_vocab):
     assert end1 == 3
     assert start2 == 3
     assert end2 == 6
+
+
+def test_phrase_matcher_validation(en_vocab):
+    doc1 = Doc(en_vocab, words=["Test"])
+    doc1.is_parsed = True
+    doc2 = Doc(en_vocab, words=["Test"])
+    doc2.is_tagged = True
+    doc3 = Doc(en_vocab, words=["Test"])
+    matcher = PhraseMatcher(en_vocab, validate=True)
+    with pytest.warns(UserWarning):
+        matcher.add("TEST1", None, doc1)
+    with pytest.warns(UserWarning):
+        matcher.add("TEST2", None, doc2)
+    with pytest.warns(None) as record:
+        matcher.add("TEST3", None, doc3)
+        assert not record.list
+    matcher = PhraseMatcher(en_vocab, attr="POS", validate=True)
+    with pytest.warns(None) as record:
+        matcher.add("TEST4", None, doc2)
+        assert not record.list


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

In most cases, the `PhraseMatcher` will match on the verbatim token text (`ORTH`) or as of v2.1, sometimes the lowercase text (`LOWER`). This means that we only need a tokenized Doc, without any other attributes.

If phrase patterns are created by processing large terminology lists with the full `nlp` object, this easily can make things a lot slower, because all components will be applied, even if we don't actually need the attributes they set (like part-of-speech tags, dependency labels). So this PR adds a suggested feature for validating phrase patterns on `PhraseMatcher.add` by checking the attribute to match on and whether the pattern `Doc` objects are tagged or parsed.  For now, the validation has to be enabled explicitly by setting `validate=True`.

The warning message also includes recommended best practices, e.g. to use `nlp.make_doc` or `nlp.tokenizer.pipe` for even faster processing. So basically, this means:

```python
# bad
patterns = [nlp(text) for text in texts]

# better
patterns = [nlp.make_doc(text) for text in texts]

# even better
patterns = list(nlp.tokenizer.pipe(texts))

# if certain attributes are needed
with nlp.disable_pipes('parser', 'ner'):
    patterns = list(nlp.pipe(texts))
```

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.