### PR TITLE
💫 Raise better error if token is pickled (resolves #2833)

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -303,7 +303,11 @@ class Errors(object):
     E109 = ("Model for component '{name}' not initialized. Did you forget to load "
             "a model, or forget to call begin_training()?")
     E110 = ("Invalid displaCy render wrapper. Expected callable, got: {obj}")
-
+    E111 = ("Pickling a token is not supported, because tokens are only views "
+            "of the parent Doc and can't exist on their own. A pickled token "
+            "would always have to include its Doc and Vocab, which has "
+            "practically no advantage over pickling the parent Doc directly. "
+            "So instead of pickling the token, pickle the Doc it belongs to.")
 
 @add_codes
 class TempErrors(object):

--- a/spacy/tests/regression/test_issue2833.py
+++ b/spacy/tests/regression/test_issue2833.py
@@ -1,0 +1,13 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import pytest
+from spacy.tokens import Doc
+from spacy.compat import pickle
+
+
+def test_issue2833(en_vocab):
+    """Test that a custom error is raised if a token is pickled."""
+    doc = Doc(en_vocab, words=["Hello", "world"])
+    with pytest.raises(NotImplementedError):
+        pickle.dumps(doc[0])

--- a/spacy/tokens/token.pyx
+++ b/spacy/tokens/token.pyx
@@ -115,6 +115,9 @@ cdef class Token:
         else:
             raise ValueError(Errors.E041.format(op=op))
 
+    def __reduce__(self):
+        raise NotImplementedError(Errors.E111)
+
     @property
     def _(self):
         return Underscore(Underscore.token_extensions, self,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Raises a better error with a more helpful message in `Token.__reduce__`. This should probably also be mentioned in the new "saving and loading" docs.

### Types of change
small enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
