### PR TITLE
💫 Replace {Doc,Span}.merge with Doc.retokenize

### DIFF
--- a/spacy/cli/ud/ud_run_test.py
+++ b/spacy/cli/ud/ud_run_test.py
@@ -112,10 +112,10 @@ def write_conllu(docs, file_):
     for i, doc in enumerate(docs):
         matches = merger(doc)
         spans = [doc[start : end + 1] for _, start, end in matches]
-        offsets = [(span.start_char, span.end_char) for span in spans]
-        for start_char, end_char in offsets:
-            doc.merge(start_char, end_char)
-        # TODO: This shuldn't be necessary? Should be handled in merge
+        with doc.retokenize() as retokenizer:
+            for span in spans:
+                retokenizer.merge(span)
+        # TODO: This shouldn't be necessary? Should be handled in merge
         for word in doc:
             if word.i == word.head.i:
                 word.dep_ = "ROOT"

--- a/spacy/cli/ud/ud_train.py
+++ b/spacy/cli/ud/ud_train.py
@@ -217,9 +217,9 @@ def write_conllu(docs, file_):
     for i, doc in enumerate(docs):
         matches = merger(doc)
         spans = [doc[start : end + 1] for _, start, end in matches]
-        offsets = [(span.start_char, span.end_char) for span in spans]
-        for start_char, end_char in offsets:
-            doc.merge(start_char, end_char)
+        with doc.retokenize() as retokenizer:
+            for span in spans:
+                retokenizer.merge(span)
         file_.write("# newdoc id = {i}\n".format(i=i))
         for j, sent in enumerate(doc.sents):
             file_.write("# sent_id = {i}.{j}\n".format(i=i, j=j))

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -67,6 +67,9 @@ class Warnings(object):
             "components are applied. To only create tokenized Doc objects, "
             "try using `nlp.make_doc(text)` or process all texts as a stream "
             "using `list(nlp.tokenizer.pipe(all_texts))`.")
+    W013 = ("As of v2.1.0, {obj}.merge is deprecated. Please use the more "
+            "efficient and less error-prone Doc.retokenize context manager "
+            "instead.")
 
 
 @add_codes

--- a/spacy/tests/doc/test_span_merge.py
+++ b/spacy/tests/doc/test_span_merge.py
@@ -16,17 +16,9 @@ def test_spans_merge_tokens(en_tokenizer):
     assert len(doc) == 4
     assert doc[0].head.text == "Angeles"
     assert doc[1].head.text == "start"
-    doc.merge(0, len("Los Angeles"), tag="NNP", lemma="Los Angeles", ent_type="GPE")
-    assert len(doc) == 3
-    assert doc[0].text == "Los Angeles"
-    assert doc[0].head.text == "start"
-
-    doc = get_doc(tokens.vocab, words=[t.text for t in tokens], heads=heads)
-    assert len(doc) == 4
-    assert doc[0].head.text == "Angeles"
-    assert doc[1].head.text == "start"
-    doc.merge(0, len("Los Angeles"), tag="NNP", lemma="Los Angeles", label="GPE")
-
+    with doc.retokenize() as retokenizer:
+        attrs = {"tag": "NNP", "lemma": "Los Angeles", "ent_type": "GPE"}
+        retokenizer.merge(doc[0:2], attrs=attrs)
     assert len(doc) == 3
     assert doc[0].text == "Los Angeles"
     assert doc[0].head.text == "start"
@@ -71,30 +63,28 @@ def test_span_np_merges(en_tokenizer):
     heads = [1, 0, 2, 1, -3, -1, -1, -1]
     tokens = en_tokenizer(text)
     doc = get_doc(tokens.vocab, words=[t.text for t in tokens], heads=heads)
-
     assert doc[4].head.i == 1
-    doc.merge(
-        doc[2].idx, doc[4].idx + len(doc[4]), tag="NP", lemma="tool", ent_type="O"
-    )
+    with doc.retokenize() as retokenizer:
+        attrs = {"tag": "NP", "lemma": "tool", "ent_type": "O"}
+        retokenizer.merge(doc[2:5], attrs=attrs)
     assert doc[2].head.i == 1
 
     text = "displaCy is a lightweight and modern dependency parse tree visualization tool built with CSS3 and JavaScript."
     heads = [1, 0, 8, 3, -1, -2, 4, 3, 1, 1, -9, -1, -1, -1, -1, -2, -15]
     tokens = en_tokenizer(text)
     doc = get_doc(tokens.vocab, words=[t.text for t in tokens], heads=heads)
-
-    ents = [(e[0].idx, e[-1].idx + len(e[-1]), e.label_, e.lemma_) for e in doc.ents]
-    for start, end, label, lemma in ents:
-        merged = doc.merge(start, end, tag=label, lemma=lemma, ent_type=label)
-        assert merged is not None, (start, end, label, lemma)
+    with doc.retokenize() as retokenizer:
+        for ent in doc.ents:
+            attrs = {"tag": ent.label_, "lemma": ent.lemma_, "ent_type": ent.label_}
+            retokenizer.merge(ent, attrs=attrs)
 
     text = "One test with entities like New York City so the ents list is not void"
     heads = [1, 11, -1, -1, -1, 1, 1, -3, 4, 2, 1, 1, 0, -1, -2]
     tokens = en_tokenizer(text)
     doc = get_doc(tokens.vocab, words=[t.text for t in tokens], heads=heads)
-    for span in doc.ents:
-        merged = doc.merge()
-        assert merged is not None, (span.start, span.end, span.label_, span.lemma_)
+    with doc.retokenize() as retokenizer:
+        for ent in doc.ents:
+            retokenizer.merge(ent)
 
 
 def test_spans_entity_merge(en_tokenizer):
@@ -109,13 +99,11 @@ def test_spans_entity_merge(en_tokenizer):
         tokens.vocab, words=[t.text for t in tokens], heads=heads, tags=tags, ents=ents
     )
     assert len(doc) == 17
-    for ent in doc.ents:
-        label, lemma, type_ = (
-            ent.root.tag_,
-            ent.root.lemma_,
-            max(w.ent_type_ for w in ent),
-        )
-        ent.merge(label=label, lemma=lemma, ent_type=type_)
+    with doc.retokenize() as retokenizer:
+        for ent in doc.ents:
+            ent_type = max(w.ent_type_ for w in ent)
+            attrs = {"lemma": ent.root.lemma_, "ent_type": ent_type}
+            retokenizer.merge(ent, attrs=attrs)
     # check looping is ok
     assert len(doc) == 15
 
@@ -132,7 +120,8 @@ def test_spans_entity_merge_iob():
     assert doc[1].ent_iob_ == "I"
     assert doc[2].ent_iob_ == "I"
     assert doc[3].ent_iob_ == "B"
-    doc[0:1].merge()
+    with doc.retokenize() as retokenizer:
+        retokenizer.merge(doc[0:1])
     assert doc[0].ent_iob_ == "B"
     assert doc[1].ent_iob_ == "I"
 
@@ -172,8 +161,10 @@ def test_spans_sentence_update_after_merge(en_tokenizer):
     sent1, sent2 = list(doc.sents)
     init_len = len(sent1)
     init_len2 = len(sent2)
-    doc[0:2].merge(label="none", lemma="none", ent_type="none")
-    doc[-2:].merge(label="none", lemma="none", ent_type="none")
+    with doc.retokenize() as retokenizer:
+        attrs = {"lemma": "none", "ent_type": "none"}
+        retokenizer.merge(doc[0:2], attrs=attrs)
+        retokenizer.merge(doc[-2:], attrs=attrs)
     assert len(sent1) == init_len - 1
     assert len(sent2) == init_len2 - 1
 
@@ -191,5 +182,7 @@ def test_spans_subtree_size_check(en_tokenizer):
     doc = get_doc(tokens.vocab, words=[t.text for t in tokens], heads=heads, deps=deps)
     sent1 = list(doc.sents)[0]
     init_len = len(list(sent1.root.subtree))
-    doc[0:2].merge(label="none", lemma="none", ent_type="none")
+    with doc.retokenize() as retokenizer:
+        attrs = {"lemma": "none", "ent_type": "none"}
+        retokenizer.merge(doc[0:2], attrs=attrs)
     assert len(list(sent1.root.subtree)) == init_len - 1

--- a/spacy/tests/lang/test_initialize.py
+++ b/spacy/tests/lang/test_initialize.py
@@ -18,4 +18,4 @@ LANGUAGES = ["af", "ar", "bg", "bn", "ca", "cs", "da", "de", "el", "en", "es",
 @pytest.mark.parametrize("lang", LANGUAGES)
 def test_lang_initialize(lang):
     """Test that languages can be initialized."""
-    lang_cls = get_lang_class(lang)()
+    lang_cls = get_lang_class(lang)()  # noqa: F841

--- a/spacy/tests/matcher/test_matcher_api.py
+++ b/spacy/tests/matcher/test_matcher_api.py
@@ -46,7 +46,9 @@ def test_matcher_from_usage_docs(en_vocab):
         if doc.vocab.strings[match_id] == "HAPPY":
             doc.sentiment += 0.1
         span = doc[start:end]
-        token = span.merge()
+        with doc.retokenize() as retokenizer:
+            retokenizer.merge(span)
+        token = doc[start]
         token.vocab[token.text].norm_ = "happy emoji"
 
     matcher = Matcher(en_vocab)

--- a/spacy/tests/parser/test_parse.py
+++ b/spacy/tests/parser/test_parse.py
@@ -66,9 +66,9 @@ def test_parser_merge_pp(en_tokenizer):
     doc = get_doc(
         tokens.vocab, words=[t.text for t in tokens], deps=deps, heads=heads, tags=tags
     )
-    nps = [(np[0].idx, np[-1].idx + len(np[-1]), np.lemma_) for np in doc.noun_chunks]
-    for start, end, lemma in nps:
-        doc.merge(start, end, label="NP", lemma=lemma)
+    with doc.retokenize() as retokenizer:
+        for np in doc.noun_chunks:
+            retokenizer.merge(np, attrs={"lemma": np.lemma_})
     assert doc[0].text == "A phrase"
     assert doc[1].text == "with"
     assert doc[2].text == "another phrase"

--- a/spacy/tests/regression/test_issue1501-2000.py
+++ b/spacy/tests/regression/test_issue1501-2000.py
@@ -86,7 +86,8 @@ def test_issue1547():
     words = ["\n", "worda", ".", "\n", "wordb", "-", "Biosphere", "2", "-", " \n"]
     doc = Doc(Vocab(), words=words)
     doc.ents = [Span(doc, 6, 8, label=doc.vocab.strings["PRODUCT"])]
-    doc[5:7].merge()
+    with doc.retokenize() as retokenizer:
+        retokenizer.merge(doc[5:7])
     assert [ent.text for ent in doc.ents]
 
 

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -898,6 +898,7 @@ cdef class Doc:
             indices did not fall at token boundaries.
         """
         cdef unicode tag, lemma, ent_type
+        deprecation_warning(Warnings.W013.format(obj="Doc"))
         if len(args) == 3:
             deprecation_warning(Warnings.W003)
             tag, lemma, ent_type = args

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -18,6 +18,7 @@ from ..attrs cimport *
 from ..lexeme cimport Lexeme
 from ..compat import is_config, basestring_
 from ..errors import Errors, TempErrors, Warnings, user_warning, models_warning
+from ..errors import deprecation_warning
 from .underscore import Underscore, get_ext_args
 
 
@@ -193,6 +194,7 @@ cdef class Span:
             attributes are inherited from the syntactic root token of the span.
         RETURNS (Token): The newly merged token.
         """
+        deprecation_warning(Warnings.W013.format(obj="Span"))
         return self.doc.merge(self.start_char, self.end_char, *args,
                               **attributes)
 


### PR DESCRIPTION
## Description

As of v2.1, `Doc.merge` and `Span.merge` will still work, but they'll be officially considered deprecated. Instead, the more efficient and less error-prone `Doc.retokenize` contextmanager should be used. This PR fixes this across the code base and tests.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
