### PR TITLE
Typo error fixed in examples

### DIFF
--- a/spacy/lang/ca/examples.py
+++ b/spacy/lang/ca/examples.py
@@ -17,6 +17,6 @@ sentences = [
     "Londres és una gran ciutat del Regne Unit",
     "El gat menja peix",
     "Veig a l'home amb el telescopi",
-    "L'Aranya menja mosques",
+    "L'aranya menja mosques",
     "El pingüí incuba en el seu niu",
 ]


### PR DESCRIPTION
## Description
Catalan typo in the examples file. 

### Types of change
Language typo.

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
