### PR TITLE
Fix issue #3288

### DIFF
--- a/spacy/tests/regression/test_issue3288.py
+++ b/spacy/tests/regression/test_issue3288.py
@@ -8,7 +8,6 @@ from spacy import displacy
 from ..util import get_doc
 
 
-@pytest.mark.xfail
 def test_issue3288(en_vocab):
     """Test that retokenization works correctly via displaCy when punctuation
     is merged onto the preceeding token and tensor is resized."""

--- a/spacy/tokens/_retokenize.pyx
+++ b/spacy/tokens/_retokenize.pyx
@@ -222,7 +222,7 @@ def _bulk_merge(Doc doc, merges):
     # whether the row is to be deleted, then use numpy.delete
     if doc.tensor is not None and doc.tensor.size != 0:
         doc.tensor = _resize_tensor(doc.tensor,
-            [(m[1][0].start, m[1][0].end) for m in merges])
+            [(m[0].start, m[0].end) for m in merges])
     # Memorize span roots and sets dependencies of the newly merged
     # tokens to the dependencies of their roots.
     span_roots = []


### PR DESCRIPTION
The code to resize the `doc.tensor` inside `Retokenizer.merge()` assumed the wrong input shape, leading to errors. 

- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
