### PR TITLE
Clarify expected type; fix name

### DIFF
--- a/website/api/goldparse.jade
+++ b/website/api/goldparse.jade
@@ -151,7 +151,7 @@ p
 
     +row
         +cell #[code entities]
-        +cell iterable
+        +cell list
         +cell
             |  A sequence of #[code (start, end, label)] triples. #[code start]
             |  and #[code end] should be character-offset integers denoting the
@@ -185,7 +185,7 @@ p
         +cell The document that the BILUO tags refer to.
 
     +row
-        +cell #[code entities]
+        +cell #[code tags]
         +cell iterable
         +cell
             |  A sequence of #[+a("/api/annotation#biluo") BILUO] tags with


### PR DESCRIPTION
### Types of change

Documentation

Not sure if you periodically sync docs & (C|P)ython source docstrings, but `biluo_tags_from_offsets`'s source should also indicate that it reads through `entities` twice.

## Checklist
- [ ] I have submitted the spaCy Contributor Agreement. 
  * N/A? Is that required for documentation?
- N/A ~~I ran the tests, and all new and existing tests passed.~~
- N/A ~~My changes don't require a change to the documentation, or if they do, I've added all required information.~~
