### PR TITLE
💫 Allow setting of custom attributes during retokenization (closes #3314)

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -326,6 +326,17 @@ class Errors(object):
             "performance")
     E117 = ("The newly split tokens must match the text of the original token. "
             "New orths: {new}. Old text: {old}.")
+    E118 = ("The custom extension attribute '{attr}' is not registered on the "
+            "Token object so it can't be set during retokenization. To "
+            "register an attribute, use the Token.set_extension classmethod.")
+    E119 = ("Can't set custom extension attribute '{attr}' during retokenization "
+            "because it's not writable. This usually means it was registered "
+            "with a getter function (and no setter) or as a method extension, "
+            "so the value is computed dynamically. To overwrite a custom "
+            "attribute manually, it should be registered with a default value "
+            "or with a getter AND setter.")
+    E120 = ("Can't set custom extension attributes during retokenization. "
+            "Expected dict mapping attribute names to values, but got: {value}")
 
 
 @add_codes

--- a/spacy/tests/regression/test_issue1971.py
+++ b/spacy/tests/regression/test_issue1971.py
@@ -36,8 +36,8 @@ def test_issue_1971_2(en_vocab):
 
 def test_issue_1971_3(en_vocab):
     """Test that pattern matches correctly for multiple extension attributes."""
-    Token.set_extension("a", default=1)
-    Token.set_extension("b", default=2)
+    Token.set_extension("a", default=1, force=True)
+    Token.set_extension("b", default=2, force=True)
     doc = Doc(en_vocab, words=["hello", "world"])
     matcher = Matcher(en_vocab)
     matcher.add("A", None, [{"_": {"a": 1}}])
@@ -51,8 +51,8 @@ def test_issue_1971_4(en_vocab):
     """Test that pattern matches correctly with multiple extension attribute
     values on a single token.
     """
-    Token.set_extension("ext_a", default="str_a")
-    Token.set_extension("ext_b", default="str_b")
+    Token.set_extension("ext_a", default="str_a", force=True)
+    Token.set_extension("ext_b", default="str_b", force=True)
     matcher = Matcher(en_vocab)
     doc = Doc(en_vocab, words=["this", "is", "text"])
     pattern = [{"_": {"ext_a": "str_a", "ext_b": "str_b"}}] * 3

--- a/spacy/tokens/_retokenize.pyx
+++ b/spacy/tokens/_retokenize.pyx
@@ -47,8 +47,6 @@ cdef class Retokenizer:
             self.tokens_to_merge.add(token.i)
         if "_" in attrs:  # Extension attributes
             extensions = attrs["_"]
-            if not isinstance(extensions, dict):
-                raise ValueError(Errors.E120.format(value=repr(extensions)))
             _validate_extensions(extensions)
             attrs = {key: value for key, value in attrs.items() if key != "_"}
             attrs = intify_attrs(attrs, strings_map=self.doc.vocab.strings)
@@ -66,8 +64,6 @@ cdef class Retokenizer:
         if "_" in attrs:  # Extension attributes
             extensions = attrs["_"]
             for extension in extensions:
-                if not isinstance(extension, dict):
-                    raise ValueError(Errors.E120.format(value=repr(extension)))
                 _validate_extensions(extension)
             attrs = {key: value for key, value in attrs.items() if key != "_"}
             attrs = intify_attrs(attrs, strings_map=self.doc.vocab.strings)
@@ -424,6 +420,8 @@ def _split(Doc doc, int token_index, orths, heads, attrs):
 
 
 def _validate_extensions(extensions):
+    if not isinstance(extensions, dict):
+        raise ValueError(Errors.E120.format(value=repr(extensions)))
     for key, value in extensions.items():
         # Get the extension and make sure it's available and writable
         extension = Token.get_extension(key)

--- a/spacy/tokens/_retokenize.pyx
+++ b/spacy/tokens/_retokenize.pyx
@@ -196,6 +196,7 @@ def _merge(Doc doc, int start, int end, attributes):
     # Return the merged Python object
     return doc[start]
 
+
 def _bulk_merge(Doc doc, merges):
     """Retokenize the document, such that the spans described in 'merges'
      are merged into a single token. This method assumes that the merges

--- a/spacy/tokens/underscore.py
+++ b/spacy/tokens/underscore.py
@@ -75,3 +75,18 @@ def get_ext_args(**kwargs):
     if method is not None and not hasattr(method, "__call__"):
         raise ValueError(Errors.E091.format(name="method", value=repr(method)))
     return (default, method, getter, setter)
+
+
+def is_writable_attr(ext):
+    """Check if an extension attribute is writable.
+    ext (tuple): The (default, getter, setter, method) tuple available  via
+        {Doc,Span,Token}.get_extension.
+    RETURNS (bool): Whether the attribute is writable.
+    """
+    default, method, getter, setter = ext
+    # Extension is writable if it has a setter (getter + setter), if it has a
+    # default value (or, if its default value is none, none of the other values
+    # should be set).
+    if setter is not None or default is not None or all(e is None for e in ext):
+        return True
+    return False

--- a/website/docs/api/doc.md
+++ b/website/docs/api/doc.md
@@ -403,6 +403,8 @@ invalidated, although they may accidentally continue to work.
 ### Retokenizer.merge {#retokenizer.merge tag="method"}
 
 Mark a span for merging. The `attrs` will be applied to the resulting token.
+Writable custom extension attributes can be provided as a dictionary mapping
+attribute names to values as the `"_"` key.
 
 > #### Example
 >
@@ -428,7 +430,8 @@ subtoken index. For example, `(doc[3], 1)` will attach the subtoken to the
 second subtoken of `doc[3]`. This mechanism allows attaching subtokens to other
 newly created subtokens, without having to keep track of the changing token
 indices. If the specified head token will be split within the retokenizer block
-and no subtoken index is specified, it will default to `0`.
+and no subtoken index is specified, it will default to `0`. Attributes to set on
+subtokens can be provided as a list of values.
 
 > #### Example
 >

--- a/website/docs/usage/linguistic-features.md
+++ b/website/docs/usage/linguistic-features.md
@@ -1049,6 +1049,55 @@ with doc.retokenize() as retokenizer:
 
 </Infobox>
 
+### Overwriting custom extension attributes {#retokenization-extensions}
+
+If you've registered custom
+[extension attributes](/usage/processing-pipelines##custom-components-attributes),
+you can overwrite them during tokenization by providing a dictionary of
+attribute names mapped to new values as the `"_"` key in the `attrs`. For
+merging, you need to provide one dictionary of attributes for the resulting
+merged token. For splitting, you need to provide a list of dictionaries with
+custom attributes, one per split subtoken.
+
+<Infobox title="Important note" variant="warning">
+
+To set extension attributes during retokenization, the attributes need to be
+**registered** using the [`Token.set_extension`](/api/token#set_extension)
+method and they need to be **writable**. This means that they should either have
+a default value that can be overwritten, or a getter _and_ setter. Method
+extensions or extensions with only a getter are computed dynamically, so their
+values can't be overwritten. For more details, see the
+[extension attribute docs](/usage/processing-pipelines/#custom-components-attributes).
+
+</Infobox>
+
+> #### ✏️ Things to try
+>
+> 1. Add another custom extension – maybe `"music_style"`? – and overwrite it.
+> 2. Change the extension attribute to use only a `getter` function. You should
+>    see that spaCy raises an error, because the attribute is not writable
+>    anymore.
+> 3. Rewrite the code to split a token with `retokenizer.split`. Remember that
+>    you need to provide a list of extension attribute values as the `"_"`
+>    property, one for each split subtoken.
+
+```python
+### {executable="true"}
+import spacy
+from spacy.tokens import Token
+
+# Register a custom token attribute, token._.is_musician
+Token.set_extension("is_musician", default=False)
+
+nlp = spacy.load("en_core_web_sm")
+doc = nlp("I like David Bowie")
+print("Before:", [(token.text, token._.is_musician) for token in doc])
+
+with doc.retokenize() as retokenizer:
+    retokenizer.merge(doc[2:4], attrs={"_": {"is_musician": True}})
+print("After:", [(token.text, token._.is_musician) for token in doc])
+```
+
 ## Sentence Segmentation {#sbd}
 
 A [`Doc`](/api/doc) object's sentences are available via the `Doc.sents`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

This PR adds the abilility to override custom extension attributes during merging. This will only work for attributes that are writable, i.e. attributes registered with a default value like `default=False` or attribute that have both a getter *and* a setter implemented.

```python
Token.set_extension('is_musician', default=False)

doc = nlp("I like David Bowie.")
with doc.retokenize() as retokenizer:
    attrs = {"LEMMA": "David Bowie", "_": {"is_musician": True}}
    retokenizer.merge(doc[2:4], attrs=attrs)

assert doc[2].text == "David Bowie"
assert doc[2].lemma_ == "David Bowie"
assert doc[2]._.is_musician
```

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
