### PR TITLE
💫 Fix NER when preset entities cross sentence boundaries

### DIFF
--- a/spacy/syntax/_parser_model.pyx
+++ b/spacy/syntax/_parser_model.pyx
@@ -157,6 +157,10 @@ cdef void cpu_log_loss(float* d_scores,
     cdef double max_, gmax, Z, gZ
     best = arg_max_if_gold(scores, costs, is_valid, O)
     guess = arg_max_if_valid(scores, is_valid, O)
+    if best == -1 or guess == -1:
+        # These shouldn't happen, but if they do, we want to make sure we don't
+        # cause an OOB access.
+        return
     Z = 1e-10
     gZ = 1e-10
     max_ = scores[guess]

--- a/spacy/syntax/_state.pxd
+++ b/spacy/syntax/_state.pxd
@@ -323,6 +323,12 @@ cdef cppclass StateC:
         if this._s_i >= 1:
             this._s_i -= 1
 
+    void force_final() nogil:
+        # This should only be used in desperate situations, as it may leave
+        # the analysis in an unexpected state.
+        this._s_i = 0
+        this._b_i = this.length
+
     void unshift() nogil:
         this._b_i -= 1
         this._buffer[this._b_i] = this.S(0)

--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -363,9 +363,14 @@ cdef class Parser:
         for i in range(batch_size):
             self.moves.set_valid(is_valid, states[i])
             guess = arg_max_if_valid(&scores[i*nr_class], is_valid, nr_class)
-            action = self.moves.c[guess]
-            action.do(states[i], action.label)
-            states[i].push_hist(guess)
+            if guess == -1:
+                # This shouldn't happen, but it's hard to raise an error here,
+                # and we don't want to infinite loop. So, force to end state.
+                states[i].force_final()
+            else:
+                action = self.moves.c[guess]
+                action.do(states[i], action.label)
+                states[i].push_hist(guess)
         free(is_valid)
 
     def transition_beams(self, beams, float[:, ::1] scores):

--- a/spacy/tests/regression/test_issue3345.py
+++ b/spacy/tests/regression/test_issue3345.py
@@ -1,5 +1,9 @@
 """Test interaction between preset entities and sentence boundaries in NER."""
+# coding: utf8
+from __future__ import unicode_literals
+
 import spacy
+import pytest
 from spacy.tokens import Doc
 from spacy.pipeline import EntityRuler, EntityRecognizer
 

--- a/spacy/tests/regression/test_issue3345.py
+++ b/spacy/tests/regression/test_issue3345.py
@@ -1,9 +1,8 @@
-"""Test interaction between preset entities and sentence boundaries in NER."""
 # coding: utf8
 from __future__ import unicode_literals
 
-import spacy
 import pytest
+from spacy.lang.en import English
 from spacy.tokens import Doc
 from spacy.pipeline import EntityRuler, EntityRecognizer
 
@@ -11,7 +10,7 @@ from spacy.pipeline import EntityRuler, EntityRecognizer
 @pytest.mark.xfail
 def test_issue3345():
     """Test case where preset entity crosses sentence boundary."""
-    nlp = spacy.blank("en")
+    nlp = English()
     doc = Doc(nlp.vocab, words=["I", "live", "in", "New", "York"])
     doc[4].is_sent_start = True
 


### PR DESCRIPTION
Refactor and update constraints that determine which NER transitions are
valid in a given state.

Previously, no valid actions were available if a preset entity crossed
a sentence boundary. Closes #3345.

## Checklist

- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
