### PR TITLE
Fix vocab deserialization when loading already present lexemes

### DIFF
--- a/spacy/tests/serialize/test_serialize_vocab_strings.py
+++ b/spacy/tests/serialize/test_serialize_vocab_strings.py
@@ -68,7 +68,6 @@ def test_serialize_vocab_lex_attrs_bytes(strings, lex_attr):
     assert vocab2[strings[0]].norm_ == lex_attr
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("strings,lex_attr", test_strings_attrs)
 def test_deserialize_vocab_seen_entries(strings, lex_attr):
     # Reported in #2153

--- a/spacy/vocab.pyx
+++ b/spacy/vocab.pyx
@@ -1,6 +1,7 @@
 # coding: utf8
 # cython: profile=True
 from __future__ import unicode_literals
+from libc.string cimport memcpy
 
 import numpy
 import srsly
@@ -518,7 +519,10 @@ cdef class Vocab:
             for j in range(sizeof(lex_data.data)):
                 lex_data.data[j] = bytes_ptr[i+j]
             Lexeme.c_from_bytes(lexeme, lex_data)
-
+            prev_entry = self._by_orth.get(lexeme.orth)
+            if prev_entry != NULL:
+                memcpy(prev_entry, lexeme, sizeof(LexemeC))
+                continue
             ptr = self.strings._map.get(lexeme.orth)
             if ptr == NULL:
                 continue


### PR DESCRIPTION
When deserializing, the vocab did not check whether a lexeme already existed for the data it was loading back in. We'd just save the lexeme into the hash. The vocab wouldn't actually store a duplicate entry, as the key would be there --- but we'd increment the length counter. We'd also allocate a new Lexeme object, so if you kept doing this, you'd waste a bit of memory.

- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
