### PR TITLE
💫 Support mutable default values for extension attributes

### DIFF
--- a/spacy/tests/doc/test_underscore.py
+++ b/spacy/tests/doc/test_underscore.py
@@ -106,3 +106,37 @@ def test_underscore_raises_for_invalid(invalid_kwargs):
 def test_underscore_accepts_valid(valid_kwargs):
     valid_kwargs["force"] = True
     Doc.set_extension("test", **valid_kwargs)
+
+
+def test_underscore_mutable_defaults_list(en_vocab):
+    """Test that mutable default arguments are handled correctly (see #2581)."""
+    Doc.set_extension("mutable", default=[])
+    doc1 = Doc(en_vocab, words=["one"])
+    doc2 = Doc(en_vocab, words=["two"])
+    doc1._.mutable.append("foo")
+    assert len(doc1._.mutable) == 1
+    assert doc1._.mutable[0] == "foo"
+    assert len(doc2._.mutable) == 0
+    doc1._.mutable = ["bar", "baz"]
+    doc1._.mutable.append("foo")
+    assert len(doc1._.mutable) == 3
+    assert len(doc2._.mutable) == 0
+
+
+def test_underscore_mutable_defaults_dict(en_vocab):
+    """Test that mutable default arguments are handled correctly (see #2581)."""
+    Token.set_extension("mutable", default={})
+    token1 = Doc(en_vocab, words=["one"])[0]
+    token2 = Doc(en_vocab, words=["two"])[0]
+    token1._.mutable["foo"] = "bar"
+    assert len(token1._.mutable) == 1
+    assert token1._.mutable["foo"] == "bar"
+    assert len(token2._.mutable) == 0
+    token1._.mutable["foo"] = "baz"
+    assert len(token1._.mutable) == 1
+    assert token1._.mutable["foo"] == "baz"
+    token1._.mutable["x"] = []
+    token1._.mutable["x"].append("y")
+    assert len(token1._.mutable) == 2
+    assert token1._.mutable["x"] == ["y"]
+    assert len(token2._.mutable) == 0

--- a/website/docs/usage/processing-pipelines.md
+++ b/website/docs/usage/processing-pipelines.md
@@ -458,9 +458,7 @@ There are three main types of extensions, which can be defined using the
 1. **Attribute extensions.** Set a default value for an attribute, which can be
    overwritten manually at any time. Attribute extensions work like "normal"
    variables and are the quickest way to store arbitrary information on a `Doc`,
-   `Span` or `Token`. Attribute defaults behaves just like argument defaults
-   [in Python functions](http://docs.python-guide.org/en/latest/writing/gotchas/#mutable-default-arguments),
-   and should not be used for mutable values like dictionaries or lists.
+   `Span` or `Token`.
 
    ```python
     Doc.set_extension("hello", default=True)
@@ -526,25 +524,6 @@ Once you've registered your custom attribute, you can also use the built-in
 `set`, `get` and `has` methods to modify and retrieve the attributes. This is
 especially useful it you want to pass in a string instead of calling
 `doc._.my_attr`.
-
-<Infobox title="Using mutable default values" variant="danger">
-
-When using **mutable values** like dictionaries or lists as the `default`
-argument, keep in mind that they behave just like mutable default arguments
-[in Python functions](http://docs.python-guide.org/en/latest/writing/gotchas/#mutable-default-arguments).
-This can easily cause unintended results, like the same value being set on _all_
-objects instead of only one particular instance. In most cases, it's better to
-use **getters and setters**, and only set the `default` for boolean or string
-values.
-
-```diff
-+ Doc.set_extension('fruits', getter=get_fruits, setter=set_fruits)
-
-- Doc.set_extension('fruits', default={})
-- doc._.fruits['apple'] = u'🍎'  # all docs now have {'apple': u'🍎'}
-```
-
-</Infobox>
 
 ### Example: Pipeline component for GPE entities and country meta data via a REST API {#component-example3}
 


### PR DESCRIPTION
## Description

Also see #2581.
Closes #3036.

### Previous behaviour

> When using **mutable values** like dictionaries or lists as the `default` argument, keep in mind that they behave just like mutable default arguments [in Python functions](http://docs.python-guide.org/en/latest/writing/gotchas/#mutable-default-arguments). This can easily cause unintended results, like the same value being set on _all_ objects instead of only one particular instance. In most cases, it's better to use **getters and setters**, and only set the `default` for boolean or string values.

### The following now works

```python
Doc.set_extension('mutable', default=[])

doc1 = nlp("Hello world")
doc2 = nlp("What's up?")

doc1._.mutable.append("foo")
print(doc1._.mutable)  # ['foo']
print(doc2._.mutable)  # []
```

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
