### PR TITLE
label in span not writable anymore

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -358,6 +358,10 @@ class Errors(object):
             "arguments to exclude fields from being serialized or deserialized "
             "is now deprecated. Please use the `exclude` argument instead. "
             "For example: exclude=['{arg}'].")
+    E129 = ("Can not write the label of an existing Span object. "
+            "Instead, create a new Span object and specify the `label` keyword argument, "
+            "for example:\nfrom spacy.tokens import Span\n"
+            "span = Span(doc, start=3, end=5, label='GPE')")
 
 
 @add_codes

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -358,11 +358,11 @@ class Errors(object):
             "arguments to exclude fields from being serialized or deserialized "
             "is now deprecated. Please use the `exclude` argument instead. "
             "For example: exclude=['{arg}'].")
-    E129 = ("Can not write the label of an existing Span object because a Span "
-            "is only a read-only view of the underlying Token objects stored in the Doc. "
+    E129 = ("Cannot write the label of an existing Span object because a Span "
+            "is a read-only view of the underlying Token objects stored in the Doc. "
             "Instead, create a new Span object and specify the `label` keyword argument, "
             "for example:\nfrom spacy.tokens import Span\n"
-            "span = Span(doc, start=3, end=5, label='GPE')")
+            "span = Span(doc, start={start}, end={end}, label='{label}')")
 
 
 @add_codes

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -358,7 +358,8 @@ class Errors(object):
             "arguments to exclude fields from being serialized or deserialized "
             "is now deprecated. Please use the `exclude` argument instead. "
             "For example: exclude=['{arg}'].")
-    E129 = ("Can not write the label of an existing Span object. "
+    E129 = ("Can not write the label of an existing Span object because a Span "
+            "is only a read-only view of the underlying Token objects stored in the Doc. "
             "Instead, create a new Span object and specify the `label` keyword argument, "
             "for example:\nfrom spacy.tokens import Span\n"
             "span = Span(doc, start=3, end=5, label='GPE')")

--- a/spacy/tests/doc/test_span.py
+++ b/spacy/tests/doc/test_span.py
@@ -178,12 +178,10 @@ def test_span_string_label(doc):
     assert span.label == doc.vocab.strings["hello"]
 
 
-@pytest.mark.xfail(reason="label is not writable")
-def test_span_string_set_label(doc):
+def test_span_label_readonly(doc):
     span = Span(doc, 0, 1)
-    span.label_ = "hello"
-    assert span.label_ == "hello"
-    assert span.label == doc.vocab.strings["hello"]
+    with pytest.raises(NotImplementedError):
+        span.label_ = "hello"
 
 
 def test_span_ents_property(doc):

--- a/spacy/tests/doc/test_span.py
+++ b/spacy/tests/doc/test_span.py
@@ -178,6 +178,7 @@ def test_span_string_label(doc):
     assert span.label == doc.vocab.strings["hello"]
 
 
+@pytest.mark.xfail(reason="label is not writable")
 def test_span_string_set_label(doc):
     span = Span(doc, 0, 1)
     span.label_ = "hello"

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -653,7 +653,7 @@ cdef class Span:
             return self.doc.vocab.strings[self.label]
 
         def __set__(self, unicode label_):
-            raise NotImplementedError(TempErrors.T007.format(attr="label_"))
+            raise NotImplementedError(Errors.E129)
 
 
 cdef int _count_words_to_root(const TokenC* token, int sent_length) except -1:

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -653,7 +653,7 @@ cdef class Span:
             return self.doc.vocab.strings[self.label]
 
         def __set__(self, unicode label_):
-            self.label = self.doc.vocab.strings.add(label_)
+            raise NotImplementedError(TempErrors.T007.format(attr="label_"))
 
 
 cdef int _count_words_to_root(const TokenC* token, int sent_length) except -1:

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -653,6 +653,8 @@ cdef class Span:
             return self.doc.vocab.strings[self.label]
 
         def __set__(self, unicode label_):
+            if not label_:
+                label_ = ''
             raise NotImplementedError(Errors.E129.format(start=self.start, end=self.end, label=label_))
 
 

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -653,7 +653,7 @@ cdef class Span:
             return self.doc.vocab.strings[self.label]
 
         def __set__(self, unicode label_):
-            raise NotImplementedError(Errors.E129)
+            raise NotImplementedError(Errors.E129.format(start=self.start, end=self.end, label=label_))
 
 
 cdef int _count_words_to_root(const TokenC* token, int sent_length) except -1:


### PR DESCRIPTION
Revert part of PR https://github.com/explosion/spaCy/pull/3031 which made `Span.label_` writable. This can get confusing when e.g. running something like 

```
for ent in doc.ents:
    ent.label_ = "GPE"
```
Which wouldn't actually write the "GPE" annotation to the underlying `Token` / `doc` objects. With this PR, the above code isn't executable anymore and will throw a `NotImplementedError` similar to the one as implemented for property `ent_id`.

### Types of change
Functionality change

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
