### PR TITLE
Fix jsonl to json conversion

### DIFF
--- a/spacy/cli/converters/jsonl2json.py
+++ b/spacy/cli/converters/jsonl2json.py
@@ -3,18 +3,51 @@ from __future__ import unicode_literals
 
 import srsly
 
-from ...util import get_lang_class
+from ...gold import docs_to_json
+from ...util import get_lang_class, minibatch
 
 
 def ner_jsonl2json(input_data, lang=None, n_sents=10, use_morphology=False):
     if lang is None:
         raise ValueError("No --lang specified, but tokenization required")
     json_docs = []
-    input_tuples = [srsly.json_loads(line) for line in input_data]
+    input_examples = [srsly.json_loads(line) for line in input_data.strip().split("\n")]
     nlp = get_lang_class(lang)()
-    for i, (raw_text, ents) in enumerate(input_tuples):
-        doc = nlp.make_doc(raw_text)
-        doc[0].is_sent_start = True
-        doc.ents = [doc.char_span(s, e, label=L) for s, e, L in ents["entities"]]
-        json_docs.append(doc.to_json())
+    sentencizer = nlp.create_pipe("sentencizer")
+    for i, batch in enumerate(minibatch(input_examples, size=n_sents)):
+        docs = []
+        for record in batch:
+            raw_text = record["text"]
+            if "entities" in record:
+                ents = record["entities"]
+            else:
+                ents = record["spans"]
+            ents = [(e["start"], e["end"], e["label"]) for e in ents]
+            doc = nlp.make_doc(raw_text)
+            sentencizer(doc)
+            spans = [doc.char_span(s, e, label=L) for s, e, L in ents]
+            doc.ents = _cleanup_spans(spans)
+            docs.append(doc)
+        json_docs.append(docs_to_json(docs, id=i))
     return json_docs
+
+
+def _cleanup_spans(spans):
+    output = []
+    seen = set()
+    for span in spans:
+        if span is not None:
+            # Trim whitespace
+            while len(span) and span[0].is_space:
+                span = span[1:]
+            while len(span) and span[-1].is_space:
+                span = span[:-1]
+            if not len(span):
+                continue
+            for i in range(span.start, span.end):
+                if i in seen:
+                    break
+            else:
+                output.append(span)
+                seen.update(range(span.start, span.end))
+    return output


### PR DESCRIPTION
Generation of spaCy's unideal json training format was broken, as we merged work towards replacing it with the jsonl format. However, we didn't want to fully deprecate the json format it 2.1, as it's a breaking change. This patch reverts a minor breakage we introduced during this, to the `spacy.gold.docs_to_json` function.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
