### PR TITLE
Raise Error for a narrow unicode build of Python

### DIFF
--- a/.github/CONTRIBUTOR_AGREEMENT.md
+++ b/.github/CONTRIBUTOR_AGREEMENT.md
@@ -87,7 +87,7 @@ U.S. Federal law. Any choice of law rules will not apply.
 7. Please place an “x” on one of the applicable statement below. Please do NOT
 mark both statements:
 
-    * [ ] I am signing on behalf of myself as an individual and no other person
+    * [x] I am signing on behalf of myself as an individual and no other person
     or entity, including my employer, has or will have rights with respect to my
     contributions.
 
@@ -98,9 +98,9 @@ mark both statements:
 
 | Field                          | Entry                |
 |------------------------------- | -------------------- |
-| Name                           |                      |
+| Name                           | Bharat Raghunathan   |
 | Company name (if applicable)   |                      |
 | Title or role (if applicable)  |                      |
-| Date                           |                      |
-| GitHub username                |                      |
+| Date                           | 19 - 03 - 2019       |
+| GitHub username                | Bharat123rox         |
 | Website (optional)             |                      |

--- a/.github/contributors/Bharat123rox.md
+++ b/.github/contributors/Bharat123rox.md
@@ -87,7 +87,7 @@ U.S. Federal law. Any choice of law rules will not apply.
 7. Please place an “x” on one of the applicable statement below. Please do NOT
 mark both statements:
 
-    * [ ] I am signing on behalf of myself as an individual and no other person
+    * [x] I am signing on behalf of myself as an individual and no other person
     or entity, including my employer, has or will have rights with respect to my
     contributions.
 
@@ -98,9 +98,9 @@ mark both statements:
 
 | Field                          | Entry                |
 |------------------------------- | -------------------- |
-| Name                           |                      |
+| Name                           | Bharat Raghunathan   |
 | Company name (if applicable)   |                      |
 | Title or role (if applicable)  |                      |
-| Date                           |                      |
-| GitHub username                |                      |
+| Date                           | 19 - 03 - 2019       |
+| GitHub username                | Bharat123rox         |
 | Website (optional)             |                      |

--- a/spacy/__init__.py
+++ b/spacy/__init__.py
@@ -1,6 +1,7 @@
 # coding: utf8
 from __future__ import unicode_literals
 import warnings
+import sys
 
 warnings.filterwarnings("ignore", message="numpy.dtype size changed")
 warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
@@ -13,6 +14,12 @@ from .glossary import explain
 from .about import __version__
 from .errors import Warnings, deprecation_warning
 from . import util
+
+if __version__ >= '2.1.0' and sys.maxunicode <= 65535:
+    raise ValueError('''You are running a narrow unicode build,
+    which is incompatible with spacy >= 2.1.0, reinstall Python and use a
+    wide unicode build instead. You can also rebuild Python and
+    set the --enable-unicode=ucs4 flag.''')
 
 
 def load(name, **overrides):

--- a/spacy/__init__.py
+++ b/spacy/__init__.py
@@ -12,14 +12,11 @@ from thinc.neural.util import prefer_gpu, require_gpu
 from .cli.info import info as cli_info
 from .glossary import explain
 from .about import __version__
-from .errors import Warnings, deprecation_warning
+from .errors import Errors, Warnings, deprecation_warning
 from . import util
 
-if __version__ >= '2.1.0' and sys.maxunicode <= 65535:
-    raise ValueError('''You are running a narrow unicode build,
-    which is incompatible with spacy >= 2.1.0, reinstall Python and use a
-    wide unicode build instead. You can also rebuild Python and
-    set the --enable-unicode=ucs4 flag.''')
+if sys.maxunicode == 65535:
+    raise SystemError(Errors.E130)
 
 
 def load(name, **overrides):

--- a/spacy/__init__.py
+++ b/spacy/__init__.py
@@ -15,6 +15,7 @@ from .about import __version__
 from .errors import Errors, Warnings, deprecation_warning
 from . import util
 
+
 if sys.maxunicode == 65535:
     raise SystemError(Errors.E130)
 

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -367,6 +367,10 @@ class Errors(object):
             "Instead, create a new Span object and specify the `label` keyword argument, "
             "for example:\nfrom spacy.tokens import Span\n"
             "span = Span(doc, start={start}, end={end}, label='{label}')")
+    E130 = ("You are running a narrow unicode build, "
+            "which is incompatible with spacy >= 2.1.0, reinstall Python and "
+            "use a wide unicode build instead. You can also rebuild Python "
+            "and set the --enable-unicode=ucs4 flag.")
 
 
 @add_codes

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -367,10 +367,10 @@ class Errors(object):
             "Instead, create a new Span object and specify the `label` keyword argument, "
             "for example:\nfrom spacy.tokens import Span\n"
             "span = Span(doc, start={start}, end={end}, label='{label}')")
-    E130 = ("You are running a narrow unicode build, "
-            "which is incompatible with spacy >= 2.1.0, reinstall Python and "
-            "use a wide unicode build instead. You can also rebuild Python "
-            "and set the --enable-unicode=ucs4 flag.")
+    E130 = ("You are running a narrow unicode build, which is incompatible "
+            "with spacy >= 2.1.0. To fix this, reinstall Python and use a wide "
+            "unicode build instead. You can also rebuild Python and set the "
+            "--enable-unicode=ucs4 flag.")
 
 
 @add_codes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->
Fix #3426 by raising a `ValueError` if a narrow unicode build is detected.
## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

A generic `ValueError` has been provided (Is it correct?). The error message is provided with a slight modification from [here](https://spacy.io/usage#narrow-unicode). IMO, I felt a `UnicodeDecodeError` or `UnicodeEncodeError` doesn't fit here. In case the error message has to be improved, do let me know!

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation?

Narrow Unicode Error from spacy 2.1 onwards

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement (Along with this PR).
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation.
