### PR TITLE
Fix/irreg adverbs extension

### DIFF
--- a/spacy/lang/en/lemmatizer/_adverbs_irreg.py
+++ b/spacy/lang/en/lemmatizer/_adverbs_irreg.py
@@ -5,9 +5,27 @@ from __future__ import unicode_literals
 ADVERBS_IRREG = {
     "best": ("well",),
     "better": ("well",),
+    "closer": ("close",),
+    "closest": ("close",)
     "deeper": ("deeply",),
+    "earlier": ("early",),
+    "earliest": ("early",),
     "farther": ("far",),
     "further": ("far",),
+    "faster": ("fast",),
+    "fastest": ("fast",),
     "harder": ("hard",),
     "hardest": ("hard",),
+    "longer": ("long",),
+    "longest": ("long",),
+    "nearer": ("near",),
+    "nearest": ("near",),
+    "nigher": ("nigh",),
+    "nighest": ("nigh",),
+    "quicker": ("quick",),
+    "quickest": ("quick",)
+    "slower": ("slow",),
+    "slowest": ("slowest",)
+    "sooner": ("soon",),
+    "soonest": ("soon",)
 }

--- a/spacy/lang/en/lemmatizer/_adverbs_irreg.py
+++ b/spacy/lang/en/lemmatizer/_adverbs_irreg.py
@@ -6,7 +6,7 @@ ADVERBS_IRREG = {
     "best": ("well",),
     "better": ("well",),
     "closer": ("close",),
-    "closest": ("close",)
+    "closest": ("close",),
     "deeper": ("deeply",),
     "earlier": ("early",),
     "earliest": ("early",),
@@ -23,9 +23,9 @@ ADVERBS_IRREG = {
     "nigher": ("nigh",),
     "nighest": ("nigh",),
     "quicker": ("quick",),
-    "quickest": ("quick",)
+    "quickest": ("quick",),
     "slower": ("slow",),
-    "slowest": ("slowest",)
+    "slowest": ("slowest",),
     "sooner": ("soon",),
     "soonest": ("soon",)
 }

--- a/spacy/tests/lang/en/test_exceptions.py
+++ b/spacy/tests/lang/en/test_exceptions.py
@@ -124,3 +124,9 @@ def test_en_tokenizer_norm_exceptions(en_tokenizer, text, norms):
 def test_en_lex_attrs_norm_exceptions(en_tokenizer, text, norm):
     tokens = en_tokenizer(text)
     assert tokens[0].norm_ == norm
+
+
+@pytest.mark.parametrize("text", ["faster", "fastest", "better", "best"])
+def test_en_lemmatizer_handles_irreg_adverbs(en_tokenizer, text):
+    tokens = en_tokenizer(text)
+    assert tokens[0].lemma_ in ["fast", "well"]


### PR DESCRIPTION
## Minor fix: extend list of irregular adverbs

Fixes #3444 

Lemma of an adverb is itself most of the time. However, some short adverbs can admit comparative or superlative, for instance as in this issue reported `fast -> faster`. 

### Types of change

I made a small refinement f extending the list of irregular adverbs by adding comparartive and superlatives f short adverbs.


## Checklist
- [ x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ x] My changes don't require a change to the documentation, or if they do, I've added all required information.
