### PR TITLE
Allow English stopwords with any type of apostrophe

### DIFF
--- a/spacy/lang/en/stop_words.py
+++ b/spacy/lang/en/stop_words.py
@@ -69,7 +69,10 @@ yet you your yours yourself yourselves
 """.split()
 )
 
-for hyphen in ["'", "`", "‘", "´", "’"]:
-    for stopword in u"n't 'd 'll 'm 're 's 've".split():
-        STOP_WORDS.add(stopword.replace("'", hyphen))
+contractions = ["n't", "'d", "'ll", "'m", "'re", "'s", "'ve"]
+STOP_WORDS.update(contractions)
+
+for apostrophe in ["‘", "’"]:
+    for stopword in contractions:
+        STOP_WORDS.add(stopword.replace("'", apostrophe))
 

--- a/spacy/lang/en/stop_words.py
+++ b/spacy/lang/en/stop_words.py
@@ -39,7 +39,7 @@ made make many may me meanwhile might mine more moreover most mostly move much
 must my myself
 
 name namely neither never nevertheless next nine no nobody none noone nor not
-nothing now nowhere n't
+nothing now nowhere 
 
 of off often on once one only onto or other others otherwise our ours ourselves
 out over own
@@ -66,7 +66,10 @@ whereafter whereas whereby wherein whereupon wherever whether which while
 whither who whoever whole whom whose why will with within without would
 
 yet you your yours yourself yourselves
-
-'d 'll 'm 're 's 've
 """.split()
 )
+
+for hyphen in ["'", "`", "‘", "´", "’"]:
+    for stopword in "n't 'd 'll 'm 're 's 've".split():
+        STOP_WORDS.add(stopword.replace("'", hyphen))
+

--- a/spacy/lang/en/stop_words.py
+++ b/spacy/lang/en/stop_words.py
@@ -70,6 +70,6 @@ yet you your yours yourself yourselves
 )
 
 for hyphen in ["'", "`", "‘", "´", "’"]:
-    for stopword in "n't 'd 'll 'm 're 's 've".split():
+    for stopword in u"n't 'd 'll 'm 're 's 've".split():
         STOP_WORDS.add(stopword.replace("'", hyphen))
 

--- a/spacy/tests/regression/test_issue3449.py
+++ b/spacy/tests/regression/test_issue3449.py
@@ -1,3 +1,4 @@
+# coding: utf8
 import pytest
 
 from spacy.lang.en import English

--- a/spacy/tests/regression/test_issue3449.py
+++ b/spacy/tests/regression/test_issue3449.py
@@ -1,0 +1,22 @@
+import pytest
+
+from spacy.lang.en import English
+
+
+@pytest.mark.xfail(reason="Current default suffix rules avoid one upper-case letter before a dot.")
+def test_issue3449():
+    nlp = English()
+    nlp.add_pipe(nlp.create_pipe('sentencizer'))
+
+    text1 = "He gave the ball to I. Do you want to go to the movies with I?"
+    text2 = "He gave the ball to I.  Do you want to go to the movies with I?"
+    text3 = "He gave the ball to I.\nDo you want to go to the movies with I?"
+
+    t1 = nlp(text1)
+    t2 = nlp(text2)
+    t3 = nlp(text3)
+
+    assert t1[5].text == 'I'
+    assert t2[5].text == 'I'
+    assert t3[5].text == 'I'
+

--- a/spacy/tests/regression/test_issue3449.py
+++ b/spacy/tests/regression/test_issue3449.py
@@ -1,4 +1,6 @@
 # coding: utf8
+from __future__ import unicode_literals
+
 import pytest
 
 from spacy.lang.en import English

--- a/spacy/tests/regression/test_issue3521.py
+++ b/spacy/tests/regression/test_issue3521.py
@@ -1,14 +1,16 @@
 # coding: utf8
+from __future__ import unicode_literals
+
 import pytest
 
 
 @pytest.mark.parametrize(
     "word",
     [
-        u"don't",
-        u"don’t",
-        u"I'd",
-        u"I’d",
+        "don't",
+        "don’t",
+        "I'd",
+        "I’d",
     ],
 )
 def test_issue3521(en_tokenizer, word):

--- a/spacy/tests/regression/test_issue3521.py
+++ b/spacy/tests/regression/test_issue3521.py
@@ -1,0 +1,20 @@
+import pytest
+
+from spacy.lang.en import English
+
+
+@pytest.mark.parametrize(
+    "word",
+    [
+        "don't",
+        "don’t",
+        "I'd",
+        "I’d",
+    ],
+)
+def test_issue3521(fr_tokenizer, word):
+    nlp = English()
+
+    tok = nlp(word)[1]
+    assert tok.is_stop
+

--- a/spacy/tests/regression/test_issue3521.py
+++ b/spacy/tests/regression/test_issue3521.py
@@ -1,3 +1,4 @@
+# coding: utf8
 import pytest
 
 

--- a/spacy/tests/regression/test_issue3521.py
+++ b/spacy/tests/regression/test_issue3521.py
@@ -1,7 +1,5 @@
 import pytest
 
-from spacy.lang.en import English
-
 
 @pytest.mark.parametrize(
     "word",
@@ -12,9 +10,7 @@ from spacy.lang.en import English
         "I’d",
     ],
 )
-def test_issue3521(fr_tokenizer, word):
-    nlp = English()
-
-    tok = nlp(word)[1]
+def test_issue3521(en_tokenizer, word):
+    tok = en_tokenizer(word)[1]
+    # 'not' and 'would' should be stopwords, also in their abbreviated forms
     assert tok.is_stop
-

--- a/spacy/tests/regression/test_issue3521.py
+++ b/spacy/tests/regression/test_issue3521.py
@@ -4,10 +4,10 @@ import pytest
 @pytest.mark.parametrize(
     "word",
     [
-        "don't",
-        "don’t",
-        "I'd",
-        "I’d",
+        u"don't",
+        u"don’t",
+        u"I'd",
+        u"I’d",
     ],
 )
 def test_issue3521(en_tokenizer, word):


### PR DESCRIPTION
Fixing Issue https://github.com/explosion/spaCy/issues/3521: Contraction `n’t` not tagged as stop word.

## Description

- I removed the English stop words with a hyphen from the generic stop list and added a small loop that for each such hyphenated stopword, adds all variants with all potential hyphens.
- I added a relevant unit test that succeeds after implementing above fix
- I added a failing unit test for Issue https://github.com/explosion/spaCy/issues/3449 (an issue I looked into before but can't be fixed generically)

### Types of change
Small fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
