### PR TITLE
Adding support for `entity_id` in EntityRuler

### DIFF
--- a/.github/contributors/kabirkhan.md
+++ b/.github/contributors/kabirkhan.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI UG (haftungsbeschränkt)](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your 
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                    |
+|------------------------------- | ------------------------ |
+| Name                           | Kabir Khan               |
+| Company name (if applicable)   |                          |
+| Title or role (if applicable)  |                          |
+| Date                           | 2019-04-08               |
+| GitHub username                | kabirkhan                |
+| Website (optional)             |                          |

--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -136,7 +136,7 @@ class EntityRuler(object):
             if 'meta' in entry and 'entity_id' in entry['meta']:
                 entity_id = entry['meta']['entity_id']
                 if isinstance(entity_id, basestring_):
-                    label = f'{label}|{entity_id}'
+                    label = '{}|{}'.format(label, entity_id)
             pattern = entry["pattern"]
             if isinstance(pattern, basestring_):
                 self.phrase_patterns[label].append(self.nlp(pattern))

--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -133,6 +133,10 @@ class EntityRuler(object):
         """
         for entry in patterns:
             label = entry["label"]
+            if 'meta' in entry and 'entity_id' in entry['meta']:
+                entity_id = entry['meta']['entity_id']
+                if isinstance(entity_id, basestring_):
+                    label = f'{label}|{entity_id}'
             pattern = entry["pattern"]
             if isinstance(pattern, basestring_):
                 self.phrase_patterns[label].append(self.nlp(pattern))

--- a/spacy/tests/pipeline/test_entity_ruler.py
+++ b/spacy/tests/pipeline/test_entity_ruler.py
@@ -19,6 +19,7 @@ def patterns():
         {"label": "BYE", "pattern": [{"LOWER": "bye"}, {"LOWER": "bye"}]},
         {"label": "HELLO", "pattern": [{"ORTH": "HELLO"}]},
         {"label": "COMPLEX", "pattern": [{"ORTH": "foo", "OP": "*"}]},
+        {'label': 'TECH_ORG', 'pattern': 'Apple', 'meta': {'entity_id': 'a1'}},
     ]
 
 
@@ -34,7 +35,7 @@ def add_ent():
 def test_entity_ruler_init(nlp, patterns):
     ruler = EntityRuler(nlp, patterns=patterns)
     assert len(ruler) == len(patterns)
-    assert len(ruler.labels) == 3
+    assert len(ruler.labels) == 4
     assert "HELLO" in ruler
     assert "BYE" in ruler
     nlp.add_pipe(ruler)
@@ -77,14 +78,22 @@ def test_entity_ruler_existing_complex(nlp, patterns, add_ent):
     assert len(doc.ents[1]) == 2
 
 
+def test_entity_ruler_entity_id(nlp, patterns):
+    ruler = EntityRuler(nlp, patterns=patterns, overwrite_ents=True)
+    nlp.add_pipe(ruler)
+    doc = nlp("Apple is a technology company")
+    assert len(doc.ents) == 1
+    assert doc.ents[0].label_ == "TECH_ORG|a1"
+
+
 def test_entity_ruler_serialize_bytes(nlp, patterns):
     ruler = EntityRuler(nlp, patterns=patterns)
     assert len(ruler) == len(patterns)
-    assert len(ruler.labels) == 3
+    assert len(ruler.labels) == 4
     ruler_bytes = ruler.to_bytes()
     new_ruler = EntityRuler(nlp)
     assert len(new_ruler) == 0
     assert len(new_ruler.labels) == 0
     new_ruler = new_ruler.from_bytes(ruler_bytes)
     assert len(ruler) == len(patterns)
-    assert len(ruler.labels) == 3
+    assert len(ruler.labels) == 4


### PR DESCRIPTION
Adds support for a very simple way to add an explicit `entity_id` to matched patterns in the EntityRuler pipeline component based on adding a `meta` property to each pattern that contains a string `entity_id` property

## Description
New patterns supported:
patterns = [
    {'label': 'ORG', 'pattern': 'Apple', 'meta': {'entity_id': 'a1'}},
    {'label': 'GPE', 'pattern': [{'lower': 'san'}, {'lower': 'francisco'}], 'meta': {'entity_id': 'a2'}}
]

doc = nlp('Apple is a company founded in San Francisco')
[(e.text, e.label_) for e in doc.ents]
> [('Apple', 'ORG|a1'), ('San Francisco', 'GPE|a2')]

### Types of change
Enhancement to EntityRuler

**Note:**
Docs not updated. I wanted to get initial feedback before adding to documentation.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
