### PR TITLE
Add `--latest` option in `spacy train` to save latest n epochs of CLI training

### DIFF
--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -36,6 +36,7 @@ from .. import about
     vectors=("Model to load vectors from", "option", "v", str),
     n_iter=("Number of iterations", "option", "n", int),
     n_examples=("Number of examples", "option", "ns", int),
+    latest=("Number of epochs to save from the latest epoch", "option", "l", int),
     use_gpu=("Use GPU", "option", "g", int),
     version=("Model version", "option", "V", str),
     meta_path=("Optional path to meta.json to use as base.", "option", "m", Path),
@@ -74,6 +75,7 @@ def train(
     pipeline="tagger,parser,ner",
     vectors=None,
     n_iter=30,
+    latest=0,
     n_examples=0,
     use_gpu=-1,
     version="0.0.0",
@@ -286,6 +288,8 @@ def train(
                             cpu_wps = nwords / (end_time - start_time)
                     acc_loc = output_path / ("model%d" % i) / "accuracy.json"
                     srsly.write_json(acc_loc, scorer.scores)
+            if latest > 0 and i >= latest:
+                shutil.rmtree(output_path / ("model%d" % (i - latest)))
 
                     # Update model meta.json
                     meta["lang"] = nlp.lang

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -288,8 +288,6 @@ def train(
                             cpu_wps = nwords / (end_time - start_time)
                     acc_loc = output_path / ("model%d" % i) / "accuracy.json"
                     srsly.write_json(acc_loc, scorer.scores)
-            if latest > 0 and i >= latest:
-                shutil.rmtree(output_path / ("model%d" % (i - latest)))
 
                     # Update model meta.json
                     meta["lang"] = nlp.lang
@@ -332,6 +330,10 @@ def train(
                         gpu_wps=gpu_wps,
                     )
                     msg.row(progress, **row_settings)
+
+            if latest > 0 and i >= latest:
+                shutil.rmtree(output_path / ("model%d" % (i - latest)))
+
     finally:
         with nlp.use_params(optimizer.averages):
             final_model_path = output_path / "model-final"

--- a/website/docs/api/cli.md
+++ b/website/docs/api/cli.md
@@ -198,7 +198,7 @@ will only train the tagger and parser.
 
 ```bash
 $ python -m spacy train [lang] [output_path] [train_path] [dev_path]
-[--base-model] [--pipeline] [--vectors] [--n-iter] [--n-examples] [--use-gpu]
+[--base-model] [--pipeline] [--vectors] [--n-iter] [--latest] [--n-examples] [--use-gpu]
 [--version] [--meta-path] [--init-tok2vec] [--parser-multitasks]
 [--entity-multitasks] [--gold-preproc] [--noise-level] [--learn-tokens]
 [--verbose]
@@ -213,7 +213,8 @@ $ python -m spacy train [lang] [output_path] [train_path] [dev_path]
 | `--base-model`, `-b`                                  | option        | Optional name of base model to update. Can be any loadable spaCy model.                                                                                           |
 | `--pipeline`, `-p` <Tag variant="new">2.1</Tag>       | option        | Comma-separated names of pipeline components to train. Defaults to `'tagger,parser,ner'`.                                                                         |
 | `--vectors`, `-v`                                     | option        | Model to load vectors from.                                                                                                                                       |
-| `--n-iter`, `-n`                                      | option        | Number of iterations (default: `30`).                                                                                                                             |
+| `--n-iter`, `-n`                                      | option        | Number of iterations (default: `30`).|
+| `--latest`, `-l`                                      | option        | Number of epochs to save from the latest epoch (`0` or a negative integer to save all epochs, default: `0`).|
 | `--n-examples`, `-ns`                                 | option        | Number of examples to use (defaults to `0` for all examples).                                                                                                     |
 | `--use-gpu`, `-g`                                     | option        | Whether to use GPU. Can be either `0`, `1` or `-1`.                                                                                                               |
 | `--version`, `-V`                                     | option        | Model version. Will be written out to the model's `meta.json` after training.                                                                                     |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->
Close #3584 by adding an optional parameter `--latest`
## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

This parameter `--latest` saves only the latest `n` epochs trained by the model. This could be more beneficial since the model improves with training. `0` or a negative integer enables saving all epochs, preserving the defaults.

All tests pass except for this warning:
```python3
spaCy/bin/ud/ud_train.py:45
  /home/user/spaCy/bin/ud/ud_train.py:45: DeprecationWarning: invalid escape sequence \s
    space_re = re.compile("\s+")
```

Also refer #3510 for a modification of this idea (save model after every `n` epochs) in `spacy pretrain`  

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
