### PR TITLE
Fix symlink creation to show error message on failure

### DIFF
--- a/.github/contributors/BreakBB.md
+++ b/.github/contributors/BreakBB.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI UG (haftungsbeschränkt)](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your 
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                    |
+|------------------------------- | ------------------------ |
+| Name                           | Björn Böing              |
+| Company name (if applicable)   |                          |
+| Title or role (if applicable)  |                          |
+| Date                           | 15.04.2019               |
+| GitHub username                | BreakBB                  |
+| Website (optional)             |                          |

--- a/spacy/compat.py
+++ b/spacy/compat.py
@@ -92,7 +92,9 @@ def symlink_to(orig, dest):
     if is_windows:
         import subprocess
 
-        subprocess.call(["mklink", "/d", path2str(orig), path2str(dest)], shell=True)
+        subprocess.check_call(
+            ["mklink", "/d", path2str(orig), path2str(dest)], shell=True
+        )
     else:
         orig.symlink_to(dest)
 

--- a/spacy/tests/test_misc.py
+++ b/spacy/tests/test_misc.py
@@ -7,7 +7,7 @@ import ctypes
 from pathlib import Path
 from spacy import util
 from spacy import prefer_gpu, require_gpu
-from spacy.compat import symlink_to, symlink_remove, path2str
+from spacy.compat import symlink_to, symlink_remove, path2str, is_windows
 from spacy._ml import PrecomputableAffine
 from subprocess import CalledProcessError
 
@@ -106,9 +106,10 @@ def test_require_gpu():
 def test_create_symlink_windows(
     symlink_setup_target, symlink_target, symlink, is_admin
 ):
-    """Test the creation of symlinks on windows. If run as admin it should succeed, otherwise a CalledProcessError should be raised."""
+    """Test the creation of symlinks on windows. If run as admin or not on windows it should succeed, otherwise a CalledProcessError should be raised."""
     assert symlink_target.exists()
-    if is_admin:
+
+    if is_admin or not is_windows:
         try:
             symlink_to(symlink, symlink_target)
             assert symlink.exists()

--- a/spacy/tests/test_misc.py
+++ b/spacy/tests/test_misc.py
@@ -3,11 +3,13 @@ from __future__ import unicode_literals
 
 import pytest
 import os
+import ctypes
 from pathlib import Path
 from spacy import util
 from spacy import prefer_gpu, require_gpu
 from spacy.compat import symlink_to, symlink_remove, path2str
 from spacy._ml import PrecomputableAffine
+from subprocess import CalledProcessError
 
 
 @pytest.fixture
@@ -28,10 +30,23 @@ def symlink_setup_target(request, symlink_target, symlink):
     # https://github.com/pytest-dev/pytest/issues/2508#issuecomment-309934240
 
     def cleanup():
-        symlink_remove(symlink)
+        # Remove symlink only if it was created
+        if symlink.exists():
+            symlink_remove(symlink)
         os.rmdir(path2str(symlink_target))
 
     request.addfinalizer(cleanup)
+
+
+@pytest.fixture
+def is_admin():
+    """Determine if the tests are run as admin or not."""
+    try:
+        admin = os.getuid() == 0
+    except AttributeError:
+        admin = ctypes.windll.shell32.IsUserAnAdmin() != 0
+
+    return admin
 
 
 @pytest.mark.parametrize("text", ["hello/world", "hello world"])
@@ -88,7 +103,19 @@ def test_require_gpu():
         require_gpu()
 
 
-def test_create_symlink_windows(symlink_setup_target, symlink_target, symlink):
+def test_create_symlink_windows(
+    symlink_setup_target, symlink_target, symlink, is_admin
+):
+    """Test the creation of symlinks on windows. If run as admin it should succeed, otherwise a CalledProcessError should be raised."""
     assert symlink_target.exists()
-    symlink_to(symlink, symlink_target)
-    assert symlink.exists()
+    if is_admin:
+        try:
+            symlink_to(symlink, symlink_target)
+            assert symlink.exists()
+        except CalledProcessError as e:
+            pytest.fail(e)
+    else:
+        with pytest.raises(CalledProcessError):
+            symlink_to(symlink, symlink_target)
+
+        assert not symlink.exists()


### PR DESCRIPTION
## Description
When the creation of symlinks fails on Windows (for example because the user doesn't have the required permissions) the user now correctly sees the corresponding error message. Before the fix the user would simply see the error message of `mklink`, but a success from spaCy, when installing a module with:

`python -m spacy download de`

> Collecting de_core_news_sm==2.1.0 from https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-2.1.0/de_core_news_sm-2.1.0.tar.gz#egg=de_core_news_sm==2.1.0
>   Downloading https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-2.1.0/de_core_news_sm-2.1.0.tar.gz (11.1MB)
> Installing collected packages: de-core-news-sm
>   Running setup.py install for de-core-news-sm: started
>     Running setup.py install for de-core-news-sm: finished with status 'done'
> Successfully installed de-core-news-sm-2.1.0
> [+] Download and installation successful
> You can now load the model via spacy.load('de_core_news_sm')
Ihre Berechtigungen reichen nicht aus, um diesen Vorgang auszuführen.
> [+] Linking successful
> C:\Users\boei006\AppData\Local\Programs\Python\Python37\lib\site-packages\de_core_news_sm
> -->
> C:\Users\boei006\AppData\Local\Programs\Python\Python37\lib\site-packages\spacy\data\de
> You can now load the model via spacy.load('de')

Now the user gets the correct error message when the creation of the symlink fails:

> Collecting de_core_news_sm==2.1.0 from https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-2.1.0/de_core_news_sm-2.1.0.tar.gz#egg=de_core_news_sm==2.1.0
>   Downloading https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-2.1.0/de_core_news_sm-2.1.0.tar.gz (11.1MB)
> Installing collected packages: de-core-news-sm
>   Running setup.py install for de-core-news-sm: started
>     Running setup.py install for de-core-news-sm: finished with status 'done'
> Successfully installed de-core-news-sm-2.1.0
> [+] Download and installation successful
> You can now load the model via spacy.load('de_core_news_sm')
> Ihre Berechtigungen reichen nicht aus, um diesen Vorgang auszuführen.
> [x] Couldn't link model to 'de'
> Creating a symlink in spacy/data failed. Make sure you have the required
> permissions and try re-running the command as admin, or use a virtualenv. You
> can still import the model as a module and call its load() method, or create the
> symlink manually.
> C:\DEV\GIT\spacy fork\spaCy\.env\lib\site-packages\de_core_news_sm -->
> C:\DEV\GIT\spacy fork\spaCy\spacy\data\de
> [!] Download successful but linking failed
> Creating a shortcut link for 'de' didn't work (maybe you don't have admin
> permissions?), but you can still load the model via its full package name: nlp =
> spacy.load('de_core_news_sm')

The previous test would fail with the changes, when called as non admin. To "test" the behaviour for non-admins a check is included in the test to assert the Exception. This is not ideal, but as far as I know there is no way to call a simple test with different permissions.

This should clear issues like #3113 and #3307.

### Types of change
Bug fix.

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
