### PR TITLE
Updates to docs for website build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -447,17 +447,7 @@ use the `get_doc()` utility function to construct it manually.
 
 ## Updating the website
 
-Our [website and docs](https://spacy.io) are implemented in
-[Jade/Pug](https://www.jade-lang.org), and built or served by
-[Harp](https://harpjs.com). Jade/Pug is an extensible templating language with a
-readable syntax, that compiles to HTML. Here's how to view the site locally:
-
-```bash
-sudo npm install --global harp
-git clone https://github.com/explosion/spaCy
-cd spaCy/website
-harp server
-```
+For instructions on how to build and run the [website](https://spacy.io) locally see **[Setup and installation](https://github.com/explosion/spaCy/blob/master/website/README.md#setup-and-installation-setup)** in the *website* directory's README.
 
 The docs can always use another example or more detail, and they should always
 be up to date and not misleading. To quickly find the correct file to edit,

--- a/website/README.md
+++ b/website/README.md
@@ -457,7 +457,7 @@ sit amet dignissim justo congue.
 ## Setup and installation {#setup}
 
 Before running the setup, make sure your versions of
-[Node](https://nodejs.org/en/) and [npm](https://www.npmjs.com/) are up to date.
+[Node](https://nodejs.org/en/) and [npm](https://www.npmjs.com/) are up to date.  Node v10.15 or later is required.
 
 ```bash
 # Clone the repository


### PR DESCRIPTION
Minor updates to documentation for building the website locally. This closes #3648.

## Description
CONTRIBUTING.md contained instructions for the old harp web server. This was replaced with a reference to website/README.md. In that file the only change was to add a note that Node 10.15 or later is required.

Note: this PR replaces #3649 which was improperly branched off a set of unrelated changes.

### Types of change
Simple doc change only.

## Checklist
- [X] I have submitted the spaCy Contributor Agreement.
- [X] I ran the tests, and all new and existing tests passed.
- [X] My changes don't require a change to the documentation, or if they do, I've added all required information.
