### PR TITLE
Add resume logic to spacy pretrain

### DIFF
--- a/spacy/cli/pretrain.py
+++ b/spacy/cli/pretrain.py
@@ -18,6 +18,7 @@ from ..attrs import ID, HEAD
 from .._ml import Tok2Vec, flatten, chain, create_default_optimizer
 from .._ml import masked_language_model
 from .. import util
+from .train import _load_pretrained_tok2vec
 
 
 @plac.annotations(
@@ -36,6 +37,12 @@ from .. import util
     seed=("Seed for random number generators", "option", "s", float),
     n_iter=("Number of iterations to pretrain", "option", "i", int),
     n_save_every=("Save model every X batches.", "option", "se", int),
+    init_tok2vec=(
+        "Path to pretrained weights for the token-to-vector parts of the models. See 'spacy pretrain'. Experimental.",
+        "option",
+        "t2v",
+        Path,
+    ),
 )
 def pretrain(
     texts_loc,
@@ -53,6 +60,7 @@ def pretrain(
     min_length=5,
     seed=0,
     n_save_every=None,
+    init_tok2vec=None,
 ):
     """
     Pre-train the 'token-to-vector' (tok2vec) layer of pipeline components,
@@ -70,6 +78,9 @@ def pretrain(
     errors around this need some improvement.
     """
     config = dict(locals())
+    for key in config:
+        if isinstance(config[key], Path):
+            config[key] = str(config[key])
     msg = Printer()
     util.fix_random_seed(seed)
 
@@ -112,6 +123,10 @@ def pretrain(
             subword_features=True,  # Set to False for Chinese etc
         ),
     )
+    # Load in pre-trained weights
+    if init_tok2vec is not None:
+        components = _load_pretrained_tok2vec(nlp, init_tok2vec)
+        msg.text("Loaded pretrained tok2vec for: {}".format(components))
     optimizer = create_default_optimizer(model.ops)
     tracker = ProgressTracker(frequency=10000)
     msg.divider("Pre-training tok2vec layer")

--- a/website/docs/api/cli.md
+++ b/website/docs/api/cli.md
@@ -305,6 +305,8 @@ $ python -m spacy pretrain [texts_loc] [vectors_model] [output_dir] [--width]
 | `--n-iter`, `-i`        | option     | Number of iterations to pretrain.                                                                                                 |
 | `--use-vectors`, `-uv`  | flag       | Whether to use the static vectors as input features.                                                                              |
 | `--n-save_every`, `-se` | option     | Save model every X batches.                                                                                                       |
+| `--n-save_every`, `-se` | option     | Save model every X batches.                                                                                                       |
+| `--init-tok2vec`, `-t2v` <Tag variant="new">2.1</Tag> | option        | Path to pretrained weights for the token-to-vector parts of the models. See `spacy pretrain`. Experimental.|
 | **CREATES**             | weights    | The pre-trained weights that can be used to initialize `spacy train`.                                                             |
 
 ### JSONL format for raw text {#pretrain-jsonl}

--- a/website/docs/api/cli.md
+++ b/website/docs/api/cli.md
@@ -305,7 +305,6 @@ $ python -m spacy pretrain [texts_loc] [vectors_model] [output_dir] [--width]
 | `--n-iter`, `-i`        | option     | Number of iterations to pretrain.                                                                                                 |
 | `--use-vectors`, `-uv`  | flag       | Whether to use the static vectors as input features.                                                                              |
 | `--n-save_every`, `-se` | option     | Save model every X batches.                                                                                                       |
-| `--n-save_every`, `-se` | option     | Save model every X batches.                                                                                                       |
 | `--init-tok2vec`, `-t2v` <Tag variant="new">2.1</Tag> | option        | Path to pretrained weights for the token-to-vector parts of the models. See `spacy pretrain`. Experimental.|
 | **CREATES**             | weights    | The pre-trained weights that can be used to initialize `spacy train`.                                                             |
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Adds resume logic to `spacy pretrain` after some discussion here: https://github.com/explosion/spaCy/pull/3510#issuecomment-478334698

### Test

Save this file to `sample_sents.jsonl`

```
{"text": "hello there."}
{"text": "hello there."}
{"text": "hello there."}
{"text": "hello there."}
{"text": "hello there."}
{"text": "hello there."}
{"text": "hello there."}
{"text": "hello there."}
{"text": "hello there."}
{"text": "hello there."}
{"text": "hello there."}
{"text": "hello there."}
{"text": "hello there."}
{"text": "hello there."}
{"text": "hello there."}
{"text": "hello there."}
```

Then run `spacy pretrain`.

```bash
spacy pretrain sample_sents.jsonl en_core_web_md here -nw 1 -bs 1 -i 10 -uv -se 2
```

There will be some files in the `here` directory. You can load one of the pre-trained weights by:

```bash
spacy pretrain sample_sents.jsonl en_core_web_md here -nw 1 -bs 1 -i 10 -uv -se 2 -t2v ./here/model2.bin
```

🛑 Warning: Currently, `_load_pretrained_tok2vec` is incompatible in some cases betweeen the `-uv` option and `vectors_model` arguments / options (https://github.com/explosion/spaCy/pull/3510#issuecomment-483733166).

| Pretrain | Load pretrained Tok2Vec | Result | 
| --- | --- | --- |
| None | `en_core_web_md` | No `vectors` error |
| None | `en_core_web_sm` | ✅ |
| `-uv` | `en_core_web_md` | ✅ |
| `-uv` | `en_core_web_sm` | Broadcast shape error |

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

This is a new option to `spacy pretrain` called `--init-tok2vec`. It works just like `--init-tok2vec` in `spacy train`.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.