### PR TITLE
Update French example sents and add two German stop words

### DIFF
--- a/spacy/lang/de/stop_words.py
+++ b/spacy/lang/de/stop_words.py
@@ -5,8 +5,8 @@ from __future__ import unicode_literals
 STOP_WORDS = set(
     """
 á a ab aber ach acht achte achten achter achtes ag alle allein allem allen
-aller allerdings alles allgemeinen als also am an andere anderen andern anders
-auch auf aus ausser außer ausserdem außerdem
+aller allerdings alles allgemeinen als also am an andere anderen anderem andern
+anders auch auf aus ausser außer ausserdem außerdem
 
 bald bei beide beiden beim beispiel bekannt bereits besonders besser besten bin
 bis bisher bist
@@ -35,8 +35,8 @@ großen grosser großer grosses großes gut gute guter gutes
 habe haben habt hast hat hatte hätte hatten hätten heisst heißt her heute hier
 hin hinter hoch
 
-ich ihm ihn ihnen ihr ihre ihrem ihrer ihres im immer in indem infolgedessen
-ins irgend ist
+ich ihm ihn ihnen ihr ihre ihrem ihren ihrer ihres im immer in indem
+infolgedessen ins irgend ist
 
 ja jahr jahre jahren je jede jedem jeden jeder jedermann jedermanns jedoch
 jemand jemandem jemanden jene jenem jenen jener jenes jetzt

--- a/spacy/lang/fr/examples.py
+++ b/spacy/lang/fr/examples.py
@@ -11,9 +11,9 @@ Example sentences to test spaCy and its language models.
 
 
 sentences = [
-    "Apple cherche a acheter une startup anglaise pour 1 milliard de dollard",
-    "Les voitures autonomes voient leur assurances décalées vers les constructeurs",
-    "San Francisco envisage d'interdire les robots coursiers",
+    "Apple cherche à acheter une startup anglaise pour 1 milliard de dollars",
+    "Les voitures autonomes déplacent la responsabilité de l'assurance vers les constructeurs",
+    "San Francisco envisage d'interdire les robots coursiers sur les trottoirs",
     "Londres est une grande ville du Royaume-Uni",
     "L’Italie choisit ArcelorMittal pour reprendre la plus grande aciérie d’Europe",
     "Apple lance HomePod parce qu'il se sent menacé par l'Echo d'Amazon",


### PR DESCRIPTION
## Description
I updated the French example sentences as suggested in [this comment](https://github.com/explosion/spaCy/issues/1107#issuecomment-352291273) a while back. And added the two German stop words "anderem" and "ihren" which where missing but similar to the existing ones.

### Types of change
Minor enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
