### PR TITLE
Make "text" key in JSONL format optional when "tokens" key is provided

### DIFF
--- a/spacy/cli/pretrain.py
+++ b/spacy/cli/pretrain.py
@@ -181,10 +181,10 @@ def make_update(model, docs, optimizer, drop=0.0, objective="L2"):
 def make_docs(nlp, batch, min_length, max_length):
     docs = []
     for record in batch:
-        text = record["text"]
         if "tokens" in record:
             doc = Doc(nlp.vocab, words=record["tokens"])
         else:
+            text = record["text"]
             doc = nlp.make_doc(text)
         if "heads" in record:
             heads = record["heads"]

--- a/website/docs/api/cli.md
+++ b/website/docs/api/cli.md
@@ -327,7 +327,7 @@ tokenization can be provided.
 
 | Key      | Type    | Description                                  |
 | -------- | ------- | -------------------------------------------- |
-| `text`   | unicode | The raw input text.                          |
+| `text`   | unicode | The raw input text. Is not required if `tokens` available. |
 | `tokens` | list    | Optional tokenization, one string per token. |
 
 ```json
@@ -335,6 +335,7 @@ tokenization can be provided.
 {"text": "Can I ask where you work now and what you do, and if you enjoy it?"}
 {"text": "They may just pull out of the Seattle market completely, at least until they have autonomous vehicles."}
 {"text": "My cynical view on this is that it will never be free to the public. Reason: what would be the draw of joining the military? Right now their selling point is free Healthcare and Education. Ironically both are run horribly and most, that I've talked to, come out wishing they never went in."}
+{"tokens": ["If", "tokens", "are", "provided", "then", "we", "can", "skip", "the", "raw", "input", "text"]}
 ```
 
 ## Init Model {#init-model new="2"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

As it was discussed in the issue #3694, the PR modifies `pretrain` function a bit to make it possible skip `text` attribute in the JSONL records when `tokens` attribute is provided.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

The only change is moving dictionary key access into the `else` branch of conditional logic. Also, the docs were adjusted a bit to reflect the new behavior. Though probably this update should be a bit more clear and verbose than my version. Please let me know if this should be re-written to become more explicit, or if something else should be added.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ ] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

I didn't run the tests because it seems that the [`test_cli.py`](https://github.com/explosion/spaCy/blob/master/spacy/tests/test_cli.py) doesn't test the function that was modified, and it will not show any changes in behavior even if they were introduced. I can check that everything works as expected (including the website) but a bit later because setting up `spacy`'s environment takes some time.