### PR TITLE
💫 Make jsonschema dependency optional

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,10 @@ srsly>=0.0.5,<1.1.0
 # Third party dependencies
 numpy>=1.15.0
 requests>=2.13.0,<3.0.0
-jsonschema>=2.6.0,<3.1.0
 plac<1.0.0,>=0.9.6
 pathlib==1.0.1; python_version < "3.4"
+# Optional dependencies
+jsonschema>=2.6.0,<3.1.0
 # Development dependencies
 cython>=0.25
 pytest>=4.0.0,<4.1.0

--- a/setup.py
+++ b/setup.py
@@ -232,7 +232,6 @@ def setup_package():
                 "blis>=0.2.2,<0.3.0",
                 "plac<1.0.0,>=0.9.6",
                 "requests>=2.13.0,<3.0.0",
-                "jsonschema>=2.6.0,<3.1.0",
                 "wasabi>=0.2.0,<1.1.0",
                 "srsly>=0.0.5,<1.1.0",
                 'pathlib==1.0.1; python_version < "3.4"',

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -385,6 +385,8 @@ class Errors(object):
     E134 = ("Alias '{alias}' defined for unknown entity '{entity}'.")
     E135 = ("If you meant to replace a built-in component, use `create_pipe`: "
             "`nlp.replace_pipe('{name}', nlp.create_pipe('{name}'))`")
+    E136 = ("This additional feature requires the jsonschema library to be "
+            "installed:\npip install jsonschema")
 
 
 @add_codes

--- a/spacy/matcher/matcher.pyx
+++ b/spacy/matcher/matcher.pyx
@@ -48,7 +48,10 @@ cdef class Matcher:
         self._extra_predicates = []
         self.vocab = vocab
         self.mem = Pool()
-        self.validator = get_json_validator(TOKEN_PATTERN_SCHEMA) if validate else None
+        if validate:
+            self.validator = get_json_validator(TOKEN_PATTERN_SCHEMA)
+        else:
+            self.validator = None
 
     def __reduce__(self):
         data = (self.vocab, self._patterns, self._callbacks)

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -14,8 +14,11 @@ import functools
 import itertools
 import numpy.random
 import srsly
-from jsonschema import Draft4Validator
 
+try:
+    import jsonschema
+except ImportError:
+    jsonschema = None
 
 try:
     import cupy.random
@@ -682,7 +685,9 @@ def get_json_validator(schema):
     # validator that's used (e.g. different draft implementation), without
     # having to change it all across the codebase.
     # TODO: replace with (stable) Draft6Validator, if available
-    return Draft4Validator(schema)
+    if jsonschema is None:
+        raise ValueError(Errors.E136)
+    return jsonschema.Draft4Validator(schema)
 
 
 def validate_schema(schema):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

The [`jsonschema`](https://github.com/Julian/jsonschema) library is great, but it also draws in various other [third-party dependencies](https://github.com/Julian/jsonschema/blob/3b8e3da631c5499f20468eb9154df603afbdc2b0/setup.cfg#L28-L33). Since `jsonschema` is only really used in additional validation features (setting `validate=True` on the `Matcher` and `PhraseMatcher`, or in the new and currently experimental/undocumented `debug-data` command), this PR makes it an optional dependency.

If it's not installed, the user will see an error and installation instructions for `jsonschema`.

### Types of change
installation improvement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
