### PR TITLE
Corrected example model URL in requirements.txt

### DIFF
--- a/website/docs/usage/models.md
+++ b/website/docs/usage/models.md
@@ -326,7 +326,7 @@ URLs.
 ```text
 ### requirements.txt
 spacy>=2.0.0,<3.0.0
-https://github.com/spacy-models/releases/download/en_core_web_sm-2.0.0/en_core_web_sm-2.0.0.tar.gz#egg=en_core_web_sm
+https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.1.0/en_core_web_sm-2.1.0.tar.gz#egg=en_core_web_sm
 ```
 
 Specifying `#egg=` with the package name tells pip which package to expect from


### PR DESCRIPTION
## Description
The URL used to show how to add a model to the requirements.txt had the old release path (excl. explosion).

### Types of change
Change in documentation.

## Checklist
- [ x] I have submitted the spaCy Contributor Agreement.
- [ x] I ran the tests, and all new and existing tests passed.
- [ x] My changes don't require a change to the documentation, or if they do, I've added all required information.
