### PR TITLE
Evaluation of NER model per entity type, closes #3490

### DIFF
--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -105,7 +105,6 @@ class Scorer(object):
             "ents_f": self.ents_f,
             "tags_acc": self.tags_acc,
             "token_acc": self.token_acc,
-
         }
 
     @property
@@ -113,7 +112,8 @@ class Scorer(object):
         """RETURNS (dict): Scores per NER entity
         """
         return {
-            k: {'p': v.precision * 100, 'r': v.recall * 100, 'f': v.fscore * 100} for k,v in self.ner_per_ents.items()
+            k: {"p": v.precision * 100, "r": v.recall * 100, "f": v.fscore * 100}
+            for k, v in self.ner_per_ents.items()
         }
 
     def score(self, doc, gold, verbose=False, punct_labels=("p", "punct")):
@@ -159,8 +159,8 @@ class Scorer(object):
                     cand_deps.add((gold_i, gold_head, token.dep_.lower()))
         if "-" not in [token[-1] for token in gold.orig_annot]:
             cand_ents = set()
-            current_ent = {k.label_:set() for k in doc.ents}
-            current_gold = {k.label_:set() for k in doc.ents}
+            current_ent = {k.label_: set() for k in doc.ents}
+            current_gold = {k.label_: set() for k in doc.ents}
             for ent in doc.ents:
                 if ent.label_ not in self.ner_per_ents:
                     self.ner_per_ents[ent.label_] = PRFScore()
@@ -171,10 +171,18 @@ class Scorer(object):
                     self.ner_per_ents[ent.label_].fp += 1
                 else:
                     cand_ents.add((ent.label_, first, last))
-                    current_ent[ent.label_].add(tuple(x for x in cand_ents if x[0] == ent.label_))
-                    current_gold[ent.label_].add(tuple(x for x in gold_ents if x[0] == ent.label_))
+                    current_ent[ent.label_].add(
+                        tuple(x for x in cand_ents if x[0] == ent.label_)
+                    )
+                    current_gold[ent.label_].add(
+                        tuple(x for x in gold_ents if x[0] == ent.label_)
+                    )
             # Scores per ent
-            [v.score_set(current_ent[k], current_gold[k]) for k, v in self.ner_per_ents.items() if k in current_ent]
+            [
+                v.score_set(current_ent[k], current_gold[k])
+                for k, v in self.ner_per_ents.items()
+                if k in current_ent
+            ]
             # Score for all ents
             self.ner.score_set(cand_ents, gold_ents)
         self.tags.score_set(cand_tags, gold_tags)

--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -113,7 +113,7 @@ class Scorer(object):
         """RETURNS (dict): Scores per NER entity
         """
         return {
-            k: {'p': v.precision, 'r': v.recall, 'f': v.fscore} for k,v in self.ner_per_ents.items()
+            k: {'p': v.precision * 100, 'r': v.recall * 100, 'f': v.fscore * 100} for k,v in self.ner_per_ents.items()
         }
 
     def score(self, doc, gold, verbose=False, punct_labels=("p", "punct")):
@@ -159,8 +159,8 @@ class Scorer(object):
                     cand_deps.add((gold_i, gold_head, token.dep_.lower()))
         if "-" not in [token[-1] for token in gold.orig_annot]:
             cand_ents = set()
-            current_ent = dict()
-            current_gold = dict()
+            current_ent = {k.label_:set() for k in doc.ents}
+            current_gold = {k.label_:set() for k in doc.ents}
             for ent in doc.ents:
                 if ent.label_ not in self.ner_per_ents:
                     self.ner_per_ents[ent.label_] = PRFScore()
@@ -171,10 +171,10 @@ class Scorer(object):
                     self.ner_per_ents[ent.label_].fp += 1
                 else:
                     cand_ents.add((ent.label_, first, last))
-                    current_ent[ent.label_] = set([tuple(x for x in cand_ents if x[0] == ent.label_)])
-                    current_gold[ent.label_] = set([tuple(x for x in gold_ents if x[0] == ent.label_)])
-                # Scores per ent
-                self.ner_per_ents[ent.label_].score_set(current_ent[ent.label_], current_gold[ent.label_])
+                    current_ent[ent.label_].add(tuple(x for x in cand_ents if x[0] == ent.label_))
+                    current_gold[ent.label_].add(tuple(x for x in gold_ents if x[0] == ent.label_))
+            # Scores per ent
+            [v.score_set(current_ent[k], current_gold[k]) for k, v in self.ner_per_ents.items() if k in current_ent]
             # Score for all ents
             self.ner.score_set(cand_ents, gold_ents)
         self.tags.score_set(cand_tags, gold_tags)

--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -160,8 +160,8 @@ class Scorer(object):
                     cand_deps.add((gold_i, gold_head, token.dep_.lower()))
         if "-" not in [token[-1] for token in gold.orig_annot]:
             cand_ents = set()
-            current_ent = set()
-            current_gold = set()
+            current_ent = dict()
+            current_gold = dict()
             for ent in doc.ents:
                 if ent.label_ not in self.ner_per_ents:
                     self.ner_per_ents[ent.label_] = PRFScore()
@@ -172,10 +172,10 @@ class Scorer(object):
                     self.ner_per_ents[ent.label_].fp += 1
                 else:
                     cand_ents.add((ent.label_, first, last))
-                    current_ent.add(tuple(x for x in cand_ents if x[0] == ent.label_))
-                    current_gold.add(tuple(x for x in gold_ents if x[0] == ent.label_))
+                    current_ent[ent.label_] = set([tuple(x for x in cand_ents if x[0] == ent.label_)])
+                    current_gold[ent.label_] = set([tuple(x for x in gold_ents if x[0] == ent.label_)])
                 # Scores per ent
-                self.ner_per_ents[ent.label_].score_set(current_ent, current_gold)
+                self.ner_per_ents[ent.label_].score_set(current_ent[ent.label_], current_gold[ent.label_])
             # Score for all ents
             self.ner.score_set(cand_ents, gold_ents)
         self.tags.score_set(cand_tags, gold_tags)

--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -112,10 +112,9 @@ class Scorer(object):
     def scores_per_ents(self):
         """RETURNS (dict): Scores per NER entity
         """
-        r = dict()
-        for k, v in self.ner_per_ents.items():
-            r[k] = (v.precision, v.recall, v.fscore)
-        return r
+        return {
+            k: {'p': v.precision, 'r': v.recall, 'f': v.fscore} for k,v in self.ner_per_ents.items()
+        }
 
     def score(self, doc, gold, verbose=False, punct_labels=("p", "punct")):
         """Update the evaluation scores from a single Doc / GoldParse pair.

--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -105,10 +105,10 @@ class Scorer(object):
             "ents_f": self.ents_f,
             "tags_acc": self.tags_acc,
             "token_acc": self.token_acc,
+            "ents_per_type": self.__scores_per_ents(),
         }
 
-    @property
-    def scores_per_ents(self):
+    def __scores_per_ents(self):
         """RETURNS (dict): Scores per NER entity
         """
         return {


### PR DESCRIPTION
## Description

Now each ent score is tracked individually in order to have its own Precision, Recall and F1 Score.

This issue is discussed here in #3490. 

~~This is an ongoing pull request, there is still a few things to do.~~

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

This is an enhancement to show scores per entity tag, in addition to the overall scores.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [X] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
