### PR TITLE
Added support for serializing overwrite and ent_id_sep

### DIFF
--- a/.github/contributors/kognate.md
+++ b/.github/contributors/kognate.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI GmbH](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [X] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           | Joshua B. Smith      |
+| Company name (if applicable)   |                      |
+| Title or role (if applicable)  |                      |
+| Date                           | July 7, 2019         |
+| GitHub username                | kognate              |
+| Website (optional)             |                      |

--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -274,4 +274,3 @@ class EntityRuler(object):
         }
         path = ensure_path(path)
         to_disk(path, serializers, {})
-

--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -1,14 +1,16 @@
 # coding: utf8
 from __future__ import unicode_literals
 
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 import srsly
 
 from ..errors import Errors
 from ..compat import basestring_
-from ..util import ensure_path
+from ..util import ensure_path, to_disk, from_disk
 from ..tokens import Span
 from ..matcher import Matcher, PhraseMatcher
+
+DEFAULT_ENT_ID_SEP = '||'
 
 
 class EntityRuler(object):
@@ -48,7 +50,7 @@ class EntityRuler(object):
         self.phrase_patterns = defaultdict(list)
         self.matcher = Matcher(nlp.vocab)
         self.phrase_matcher = PhraseMatcher(nlp.vocab)
-        self.ent_id_sep = cfg.get("ent_id_sep", "||")
+        self.ent_id_sep = cfg.get("ent_id_sep", DEFAULT_ENT_ID_SEP)
         patterns = cfg.get("patterns")
         if patterns is not None:
             self.add_patterns(patterns)
@@ -196,7 +198,7 @@ class EntityRuler(object):
 
     def _create_label(self, label, ent_id):
         """Join Entity label with ent_id if the pattern has an `id` attribute
-        
+
         RETURNS (str): The ent_label joined with configured `ent_id_sep`
         """
         if isinstance(ent_id, basestring_):
@@ -212,8 +214,10 @@ class EntityRuler(object):
 
         DOCS: https://spacy.io/api/entityruler#from_bytes
         """
-        patterns = srsly.msgpack_loads(patterns_bytes)
-        self.add_patterns(patterns)
+        cfg = srsly.msgpack_loads(patterns_bytes)
+        self.add_patterns(cfg.get('patterns', cfg))
+        self.overwrite = cfg.get('overwrite', False)
+        self.ent_id_sep = cfg.get('ent_id_sep', DEFAULT_ENT_ID_SEP)
         return self
 
     def to_bytes(self, **kwargs):
@@ -223,7 +227,12 @@ class EntityRuler(object):
 
         DOCS: https://spacy.io/api/entityruler#to_bytes
         """
-        return srsly.msgpack_dumps(self.patterns)
+
+        serial = OrderedDict((
+            ('overwrite', self.overwrite),
+            ('ent_id_sep', self.ent_id_sep),
+            ('patterns', self.patterns)))
+        return srsly.msgpack_dumps(serial)
 
     def from_disk(self, path, **kwargs):
         """Load the entity ruler from a file. Expects a file containing
@@ -236,9 +245,14 @@ class EntityRuler(object):
         DOCS: https://spacy.io/api/entityruler#from_disk
         """
         path = ensure_path(path)
-        path = path.with_suffix(".jsonl")
-        patterns = srsly.read_jsonl(path)
-        self.add_patterns(patterns)
+        cfg = {}
+        deserializers = {
+            'patterns': lambda p: self.add_patterns(srsly.read_jsonl(p.with_suffix('.jsonl'))),
+            'cfg': lambda p: cfg.update(srsly.read_json(p))
+        }
+        from_disk(path, deserializers, {})
+        self.overwrite = cfg.get('overwrite', False)
+        self.ent_id_sep = cfg.get('ent_id_sep', DEFAULT_ENT_ID_SEP)
         return self
 
     def to_disk(self, path, **kwargs):
@@ -251,6 +265,13 @@ class EntityRuler(object):
 
         DOCS: https://spacy.io/api/entityruler#to_disk
         """
+        cfg = {'overwrite': self.overwrite,
+               'ent_id_sep': self.ent_id_sep}
+        serializers = {
+            'patterns': lambda p: srsly.write_jsonl(p.with_suffix('.jsonl'),
+                                                    self.patterns),
+            'cfg': lambda p: srsly.write_json(p, cfg)
+        }
         path = ensure_path(path)
-        path = path.with_suffix(".jsonl")
-        srsly.write_jsonl(path, self.patterns)
+        to_disk(path, serializers, {})
+

--- a/spacy/tests/regression/test_issue3526.py
+++ b/spacy/tests/regression/test_issue3526.py
@@ -8,6 +8,7 @@ from spacy.pipeline import EntityRuler
 from spacy import load
 from tempfile import TemporaryDirectory
 
+
 @pytest.fixture
 def nlp():
     return Language()
@@ -46,6 +47,7 @@ def test_entity_ruler_existing_overwrite_serialize_bytes(nlp, patterns):
     assert len(ruler.labels) == 4
     assert new_ruler.overwrite == ruler.overwrite
     assert new_ruler.ent_id_sep == ruler.ent_id_sep
+
 
 def test_entity_ruler_in_pipeline_from_issue(nlp, patterns):
     nlp1 = load('en_core_web_sm')

--- a/spacy/tests/regression/test_issue3526.py
+++ b/spacy/tests/regression/test_issue3526.py
@@ -6,7 +6,8 @@ from spacy.tokens import Span
 from spacy.language import Language
 from spacy.pipeline import EntityRuler
 from spacy import load
-from tempfile import TemporaryDirectory
+from tempfile import mkdtemp
+from shutil import rmtree
 
 
 @pytest.fixture
@@ -49,10 +50,14 @@ def test_entity_ruler_in_pipeline_from_issue(patterns, en_vocab):
 
     ruler.add_patterns([{"label": "ORG", "pattern": "Apple"}])
     nlp.add_pipe(ruler)
-    with TemporaryDirectory() as tmpdir:
+    try:
+        tmpdir = mkdtemp()
         nlp.to_disk(tmpdir)
         assert nlp.pipeline[-1][-1].patterns == [{"label": "ORG", "pattern": "Apple"}]
         assert nlp.pipeline[-1][-1].overwrite is True
         nlp2 = load(tmpdir)
         assert nlp2.pipeline[-1][-1].patterns == [{"label": "ORG", "pattern": "Apple"}]
         assert nlp2.pipeline[-1][-1].overwrite is True
+    finally:
+        rmtree(tmpdir)
+

--- a/spacy/tests/regression/test_issue3526.py
+++ b/spacy/tests/regression/test_issue3526.py
@@ -49,6 +49,7 @@ def test_entity_ruler_existing_overwrite_serialize_bytes(nlp, patterns):
     assert new_ruler.ent_id_sep == ruler.ent_id_sep
 
 
+@pytest.mark.models
 def test_entity_ruler_in_pipeline_from_issue(nlp, patterns):
     nlp1 = load('en_core_web_sm')
     ruler = EntityRuler(nlp, overwrite_ents=True)

--- a/spacy/tests/regression/test_issue3526.py
+++ b/spacy/tests/regression/test_issue3526.py
@@ -1,0 +1,62 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+import pytest
+from spacy.tokens import Span
+from spacy.language import Language
+from spacy.pipeline import EntityRuler
+from spacy import load
+from tempfile import TemporaryDirectory
+
+@pytest.fixture
+def nlp():
+    return Language()
+
+
+@pytest.fixture
+def patterns():
+    return [
+        {"label": "HELLO", "pattern": "hello world"},
+        {"label": "BYE", "pattern": [{"LOWER": "bye"}, {"LOWER": "bye"}]},
+        {"label": "HELLO", "pattern": [{"ORTH": "HELLO"}]},
+        {"label": "COMPLEX", "pattern": [{"ORTH": "foo", "OP": "*"}]},
+        {"label": "TECH_ORG", "pattern": "Apple", "id": "a1"},
+    ]
+
+
+@pytest.fixture
+def add_ent():
+    def add_ent_component(doc):
+        doc.ents = [Span(doc, 0, 3, label=doc.vocab.strings["ORG"])]
+        return doc
+
+    return add_ent_component
+
+
+def test_entity_ruler_existing_overwrite_serialize_bytes(nlp, patterns):
+    ruler = EntityRuler(nlp, patterns=patterns, overwrite_ents=True)
+    ruler_bytes = ruler.to_bytes()
+    assert len(ruler) == len(patterns)
+    assert len(ruler.labels) == 4
+    assert ruler.overwrite
+    new_ruler = EntityRuler(nlp)
+    new_ruler.from_bytes(ruler_bytes)
+    new_ruler = new_ruler.from_bytes(ruler_bytes)
+    assert len(ruler) == len(patterns)
+    assert len(ruler.labels) == 4
+    assert new_ruler.overwrite == ruler.overwrite
+    assert new_ruler.ent_id_sep == ruler.ent_id_sep
+
+def test_entity_ruler_in_pipeline_from_issue(nlp, patterns):
+    nlp1 = load('en_core_web_sm')
+    ruler = EntityRuler(nlp, overwrite_ents=True)
+
+    ruler.add_patterns([{"label": "ORG", "pattern": "Apple"}])
+    nlp1.add_pipe(ruler)
+    with TemporaryDirectory() as tmpdir:
+        nlp1.to_disk(tmpdir)
+        assert nlp1.pipeline[-1][-1].patterns == [{"label": "ORG", "pattern": "Apple"}]
+        assert nlp1.pipeline[-1][-1].overwrite is True
+        nlp2 = load(tmpdir)
+        assert nlp2.pipeline[-1][-1].patterns == [{"label": "ORG", "pattern": "Apple"}]
+        assert nlp2.pipeline[-1][-1].overwrite is True

--- a/spacy/tests/regression/test_issue3526.py
+++ b/spacy/tests/regression/test_issue3526.py
@@ -8,7 +8,8 @@ from spacy.pipeline import EntityRuler
 from spacy import load
 from tempfile import mkdtemp
 from shutil import rmtree
-
+import srsly
+from pathlib import Path
 
 @pytest.fixture
 def patterns():
@@ -42,6 +43,33 @@ def test_entity_ruler_existing_overwrite_serialize_bytes(patterns, en_vocab):
     assert len(new_ruler.labels) == 4
     assert new_ruler.overwrite == ruler.overwrite
     assert new_ruler.ent_id_sep == ruler.ent_id_sep
+
+
+def test_entity_ruler_existing_bytes_old_format_safe(patterns, en_vocab):
+    nlp = Language(vocab=en_vocab)
+    ruler = EntityRuler(nlp, patterns=patterns, overwrite_ents=True)
+    bytes_old_style = srsly.msgpack_dumps(ruler.patterns)
+    new_ruler = EntityRuler(nlp)
+    new_ruler = new_ruler.from_bytes(bytes_old_style)
+    assert len(new_ruler) == len(ruler)
+    assert new_ruler.patterns == ruler.patterns
+    assert new_ruler.overwrite is not ruler.overwrite
+
+
+def test_entity_ruler_from_disk_old_format_safe(patterns, en_vocab):
+    nlp = Language(vocab=en_vocab)
+    ruler = EntityRuler(nlp, patterns=patterns, overwrite_ents=True)
+    try:
+        tmpdir = mkdtemp()
+        out_file = Path(tmpdir) / "entity_ruler.jsonl"
+        srsly.write_jsonl(out_file, ruler.patterns)
+        new_ruler = EntityRuler(nlp)
+        new_ruler = new_ruler.from_disk(out_file)
+        assert new_ruler.patterns == ruler.patterns
+        assert len(new_ruler) == len(ruler)
+        assert new_ruler.overwrite is not ruler.overwrite
+    finally:
+        rmtree(tmpdir)
 
 
 def test_entity_ruler_in_pipeline_from_issue(patterns, en_vocab):


### PR DESCRIPTION
Added support for serializing `overwrite` and `ent_id_sep`

## Description
This PR fixes #3526 and serializes `overwrite` and `ent_id_sep`.   I tried to follow patterns I found in `nn_parser.pyx` and `Sentencizer` for the bytes and file-based serialization changes.  New tests include (similar) example from the issue itself, and a test of the `to_bytes`/`from_bytes` serialization.

The code handles restoring from serialized objects from the previous format and should be fully backwards compatible (serialized elements from before this change can be deserialized).  

### Types of change
This is a bug fix and does not change overall functionality.  

## Checklist
- [x] I have submitted the spaCy Contributor Agreement. (in this PR)
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
