### PR TITLE
apply SudachiPy as Japanese Tokenizer

### DIFF
--- a/.github/contributors/hiroshi-matsuda-rit.md
+++ b/.github/contributors/hiroshi-matsuda-rit.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI UG (haftungsbeschränkt)](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [ ] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [x] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           | Hiroshi Matsuda      |
+| Company name (if applicable)   | Megagon Labs, Tokyo. |
+| Title or role (if applicable)  | Research Scientist   |
+| Date                           | 07/03/2019           |
+| GitHub username                | hiroshi-matsuda-rit  |
+| Website (optional)             | www.megagon.ai/team  |

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,6 @@ pytest>=4.0.0,<4.1.0
 pytest-timeout>=1.3.0,<2.0.0
 mock>=2.0.0,<3.0.0
 flake8>=3.5.0,<3.6.0
+# Language specific test dependencies
+SudachiPy>=0.3.3 ; python_version>='3.5'
+https://github.com/megagonlabs/ginza/releases/download/v2.0.0/SudachiDict_core-20190531.tar.gz ; python_version>='3.5'

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,5 @@ pytest-timeout>=1.3.0,<2.0.0
 mock>=2.0.0,<3.0.0
 flake8>=3.5.0,<3.6.0
 # Language specific test dependencies
-SudachiPy>=0.3.3 ; python_version>='3.5'
-https://github.com/megagonlabs/ginza/releases/download/v2.0.0/SudachiDict_core-20190531.tar.gz ; python_version>='3.5'
+SudachiPy>=0.3.11 ; python_version>='3.5'
+https://object-storage.tyo2.conoha.io/v1/nc_2520839e1f9641b08211a5c85243124a/sudachi/SudachiDict_core-20190718.tar.gz ; python_version>='3.5'

--- a/setup.py
+++ b/setup.py
@@ -245,7 +245,7 @@ def setup_package():
                 "cuda92": ["thinc_gpu_ops>=0.0.1,<0.1.0", "cupy-cuda92>=5.0.0b4"],
                 "cuda100": ["thinc_gpu_ops>=0.0.1,<0.1.0", "cupy-cuda100>=5.0.0b4"],
                 # Language tokenizers with external dependencies
-                "ja": ["mecab-python3==0.7"],
+                "ja": ["sudachipy>=0.3.3"],
                 "ko": ["natto-py==0.9.0"],
             },
             python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*",

--- a/setup.py
+++ b/setup.py
@@ -245,7 +245,7 @@ def setup_package():
                 "cuda92": ["thinc_gpu_ops>=0.0.1,<0.1.0", "cupy-cuda92>=5.0.0b4"],
                 "cuda100": ["thinc_gpu_ops>=0.0.1,<0.1.0", "cupy-cuda100>=5.0.0b4"],
                 # Language tokenizers with external dependencies
-                "ja": ["sudachipy>=0.3.3"],
+                "ja": ["sudachipy>=0.3.11"],
                 "ko": ["natto-py==0.9.0"],
             },
             python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*",

--- a/spacy/lang/ja/__init__.py
+++ b/spacy/lang/ja/__init__.py
@@ -1,91 +1,23 @@
 # encoding: utf8
 from __future__ import unicode_literals, print_function
 
-import re
 from collections import namedtuple
 
-from .stop_words import STOP_WORDS
-from .tag_map import TAG_MAP
 from ...attrs import LANG
 from ...language import Language
-from ...tokens import Doc
+from ...tokens import Token
+from ...util import get_model_meta
+from ...vocab import Vocab
 from ...compat import copy_reg
-from ...util import DummyTokenizer
+
+from .stop_words import STOP_WORDS
+from .syntax_iterators import SYNTAX_ITERATORS
+from .tag_map import TAG_MAP
+
+from .sudachi_tokenizer import SudachiTokenizer
 
 
 ShortUnitWord = namedtuple("ShortUnitWord", ["surface", "lemma", "pos"])
-
-
-def try_mecab_import():
-    """Mecab is required for Japanese support, so check for it.
-    It it's not available blow up and explain how to fix it."""
-    try:
-        import MeCab
-
-        return MeCab
-    except ImportError:
-        raise ImportError(
-            "Japanese support requires MeCab: "
-            "https://github.com/SamuraiT/mecab-python3"
-        )
-
-
-def resolve_pos(token):
-    """If necessary, add a field to the POS tag for UD mapping.
-    Under Universal Dependencies, sometimes the same Unidic POS tag can
-    be mapped differently depending on the literal token or its context
-    in the sentence. This function adds information to the POS tag to
-    resolve ambiguous mappings.
-    """
-    # TODO: This is a first take. The rules here are crude approximations.
-    # For many of these, full dependencies are needed to properly resolve
-    # PoS mappings.
-    if token.pos == "連体詞,*,*,*":
-        if re.match(r"[こそあど此其彼]の", token.surface):
-            return token.pos + ",DET"
-        if re.match(r"[こそあど此其彼]", token.surface):
-            return token.pos + ",PRON"
-        return token.pos + ",ADJ"
-    return token.pos
-
-
-def detailed_tokens(tokenizer, text):
-    """Format Mecab output into a nice data structure, based on Janome."""
-    node = tokenizer.parseToNode(text)
-    node = node.next  # first node is beginning of sentence and empty, skip it
-    words = []
-    while node.posid != 0:
-        surface = node.surface
-        base = surface  # a default value. Updated if available later.
-        parts = node.feature.split(",")
-        pos = ",".join(parts[0:4])
-        if len(parts) > 7:
-            # this information is only available for words in the tokenizer
-            # dictionary
-            base = parts[7]
-        words.append(ShortUnitWord(surface, base, pos))
-        node = node.next
-    return words
-
-
-class JapaneseTokenizer(DummyTokenizer):
-    def __init__(self, cls, nlp=None):
-        self.vocab = nlp.vocab if nlp is not None else cls.create_vocab(nlp)
-        self.tokenizer = try_mecab_import().Tagger()
-        self.tokenizer.parseToNode("")  # see #2901
-
-    def __call__(self, text):
-        dtokens = detailed_tokens(self.tokenizer, text)
-        words = [x.surface for x in dtokens]
-        spaces = [False] * len(words)
-        doc = Doc(self.vocab, words=words, spaces=spaces)
-        mecab_tags = []
-        for token, dtoken in zip(doc, dtokens):
-            mecab_tags.append(dtoken.pos)
-            token.tag_ = resolve_pos(dtoken)
-            token.lemma_ = dtoken.lemma
-        doc.user_data["mecab_tags"] = mecab_tags
-        return doc
 
 
 class JapaneseDefaults(Language.Defaults):
@@ -93,16 +25,29 @@ class JapaneseDefaults(Language.Defaults):
     lex_attr_getters[LANG] = lambda _text: "ja"
     stop_words = STOP_WORDS
     tag_map = TAG_MAP
+    syntax_iterators = SYNTAX_ITERATORS
     writing_system = {"direction": "ltr", "has_case": False, "has_letters": False}
+
+    if not Token.get_extension('inf'):
+        Token.set_extension('inf', default='')
+    if not Token.get_extension('bunsetu_bi_label'):
+        Token.set_extension('bunsetu_bi_label', default='')
+    if not Token.get_extension('bunsetu_position_type'):
+        Token.set_extension('bunsetu_position_type', default='')
 
     @classmethod
     def create_tokenizer(cls, nlp=None):
-        return JapaneseTokenizer(cls, nlp)
+        return SudachiTokenizer(nlp)
+
+    @classmethod
+    def create_lemmatizer(cls, nlp=None):
+        return None
 
 
 class Japanese(Language):
     lang = "ja"
     Defaults = JapaneseDefaults
+    Tokenizer = SudachiTokenizer
 
     def make_doc(self, text):
         return self.tokenizer(text)
@@ -115,4 +60,6 @@ def pickle_japanese(instance):
 copy_reg.pickle(Japanese, pickle_japanese)
 
 
-__all__ = ["Japanese"]
+__all__ = [
+    'Japanese',
+]

--- a/spacy/lang/ja/sudachi_tokenizer.py
+++ b/spacy/lang/ja/sudachi_tokenizer.py
@@ -92,8 +92,6 @@ class SudachiTokenizer(DummyTokenizer):
                     token.pos_ = 'ADJ'
             token._.inf = ','.join(morph.part_of_speech()[4:])
             token.lemma_ = morph.normalized_form()  # work around: lemma_ must be set after tag_
-        if self.use_sentence_separator:
-            separate_sentences(doc)
         return doc
 
     # add dummy methods for to_bytes, from_bytes, to_disk and from_disk to

--- a/spacy/lang/ja/sudachi_tokenizer.py
+++ b/spacy/lang/ja/sudachi_tokenizer.py
@@ -15,10 +15,6 @@ from ...util import DummyTokenizer
 from .tag_map import TAG_MAP
 
 
-SUDACHI_DEFAULT_MODE = 'C'
-SUDACHI_DEFAULT_SPLITMODE = 'C'
-
-
 def try_import_sudachipy_dictionary():
     try:
         from sudachipy import dictionary
@@ -46,18 +42,16 @@ def morph_tag(tag_array):
 
 
 class SudachiTokenizer(DummyTokenizer):
-    def __init__(self, nlp=None, mode=SUDACHI_DEFAULT_SPLITMODE):
+    def __init__(self, nlp=None):
         self.nlp = nlp
         self.vocab = nlp.vocab if nlp is not None else Vocab()
         dictionary = try_import_sudachipy_dictionary()
 
         dict_ = dictionary.Dictionary()
         self.tokenizer = dict_.create()
-        self.mode = mode
-        self.use_sentence_separator = True
 
     def __call__(self, text):
-        result = self.tokenizer.tokenize(text=text, mode=self.mode)
+        result = self.tokenizer.tokenize(text=text)
         morph_spaces = []
         last_morph = None
         for m in result:
@@ -76,7 +70,6 @@ class SudachiTokenizer(DummyTokenizer):
         if last_morph:
             morph_spaces.append((last_morph, False))
 
-        # the last space is removed by JapaneseReviser at the final stage of pipeline
         words = [m.surface() for m, spaces in morph_spaces]
         spaces = [space for m, space in morph_spaces]
         doc = Doc(self.nlp.vocab if self.nlp else Vocab(), words=words, spaces=spaces)

--- a/spacy/lang/ja/sudachi_tokenizer.py
+++ b/spacy/lang/ja/sudachi_tokenizer.py
@@ -1,0 +1,193 @@
+# encoding: utf8
+from __future__ import unicode_literals, print_function
+
+from importlib import import_module
+import json
+from pathlib import Path
+import re
+import sys
+
+from ...symbols import POS
+from ...tokens import Doc
+from ...vocab import Vocab
+from ...util import DummyTokenizer
+
+from .tag_map import TAG_MAP
+
+
+SUDACHI_DEFAULT_MODE = 'C'
+SUDACHI_DEFAULT_SPLITMODE = 'C'
+
+
+def try_import_sudachipy_dictionary():
+    try:
+        from sudachipy import dictionary
+        return dictionary
+    except ImportError:
+        raise ImportError(
+            "Japanese support requires SudachiPy distributed with ja language model"
+        )
+
+
+# see https://spacy.io/usage/processing-pipelines#component-example1
+def separate_sentences(doc):
+    for i, token in enumerate(doc[:-2]):
+        if token.tag_:
+            if token.tag_ == "補助記号-句点":
+                next_token = doc[i+1]
+                if next_token.tag_ != token.tag_:
+                    next_token.sent_start = True
+
+
+def morph_tag(tag_array):
+    return "-".join([
+        p for p in tag_array if p != '*'
+    ])
+
+
+class SudachiTokenizer(DummyTokenizer):
+    def __init__(self, nlp=None, mode=SUDACHI_DEFAULT_SPLITMODE):
+        self.nlp = nlp
+        self.vocab = nlp.vocab if nlp is not None else Vocab()
+        dictionary = try_import_sudachipy_dictionary()
+
+        dict_ = dictionary.Dictionary()
+        self.tokenizer = dict_.create()
+        self.mode = mode
+        self.use_sentence_separator = True
+
+    def __call__(self, text):
+        result = self.tokenizer.tokenize(text=text, mode=self.mode)
+        morph_spaces = []
+        last_morph = None
+        for m in result:
+            if m.surface():
+                if m.part_of_speech()[0] == '空白':
+                    if last_morph:
+                        morph_spaces.append((last_morph, True))
+                        last_morph = None
+                    else:
+                        morph_spaces.append((m, False))
+                elif last_morph:
+                    morph_spaces.append((last_morph, False))
+                    last_morph = m
+                else:
+                    last_morph = m
+        if last_morph:
+            morph_spaces.append((last_morph, False))
+
+        # the last space is removed by JapaneseReviser at the final stage of pipeline
+        words = [m.surface() for m, spaces in morph_spaces]
+        spaces = [space for m, space in morph_spaces]
+        doc = Doc(self.nlp.vocab if self.nlp else Vocab(), words=words, spaces=spaces)
+        next_tag = morph_tag(morph_spaces[0][0].part_of_speech()[0:4]) if len(doc) else ''
+        for token, (morph, spaces) in zip(doc, morph_spaces):
+            tag = next_tag
+            next_tag = morph_tag(morph_spaces[token.i + 1][0].part_of_speech()[0:4]) if token.i < len(doc) - 1 else ''
+            token.tag_ = tag
+            token.pos = TAG_MAP[tag][POS]
+            # TODO separate lexical rules to resource files
+            if morph.normalized_form() == '為る' and tag == '動詞-非自立可能':
+                token.pos_ = 'AUX'
+            elif tag == '名詞-普通名詞-サ変可能':
+                if next_tag == '動詞-非自立可能':
+                    token.pos_ = 'VERB'
+            elif tag == '名詞-普通名詞-サ変形状詞可能':
+                if next_tag == '動詞-非自立可能':
+                    token.pos_ = 'VERB'
+                elif next_tag == '助動詞' or next_tag.find('形状詞') >= 0:
+                    token.pos_ = 'ADJ'
+            token._.inf = ','.join(morph.part_of_speech()[4:])
+            token.lemma_ = morph.normalized_form()  # work around: lemma_ must be set after tag_
+        if self.use_sentence_separator:
+            separate_sentences(doc)
+        return doc
+
+    # add dummy methods for to_bytes, from_bytes, to_disk and from_disk to
+    # allow serialization (see #1557)
+    def to_bytes(self, **exclude):
+        return b''
+
+    def from_bytes(self, bytes_data, **exclude):
+        return self
+
+    def to_disk(self, path, **exclude):
+        return None
+
+    def from_disk(self, path, **exclude):
+        return self
+
+
+SUDACHI_PATTERN = re.compile(
+    r"^([^\t]*)\t"
+    r"([^\t,]+,[^\t,]+,[^\t,]+,[^\t,]+),"
+    r"([^\t,]+,[^\t,]+)\t"
+    r"([^\t]*)\t"
+    r"([^\t]*)\t"
+    r"([^\t]*)\t"
+    r"([^\t]+)"
+    r"(\t\(OOV\))?$"
+)
+
+
+def read_sudachi_a(path, file, yield_document=False):
+    return read_sudachi(path, file, yield_document, 'A')
+
+
+def read_sudachi_b(path, file, yield_document=False):
+    return read_sudachi(path, file, yield_document, 'B')
+
+
+def read_sudachi_c(path, file, yield_document=False):
+    return read_sudachi(path, file, yield_document, 'C')
+
+
+def read_sudachi(path, file, yield_document=False, mode='B'):
+    sentences = []
+    sentence = []
+    line = None
+    state = 'EOS'
+    for line_index, line in enumerate(file):
+        if line_index == 0 and not line.startswith('#'):
+            print('Skip file: %s' % path, file=sys.stderr)
+            line = None
+            break
+        line = line.rstrip()
+        if line.startswith('#'):
+            continue
+        elif line == 'EOS':
+            if yield_document:
+                sentences.append(sentence)
+            else:
+                yield sentence
+            sentence = []
+            state = 'EOS'
+            continue
+        elif line.startswith('@'):
+            assert state != 'EOS', 'Bad state {}: {} #{}: {}'.format(state, path, line_index + 1, line)
+            if line[1] != mode:
+                continue
+            if state == 'MORPH':
+                sentence.pop()
+                state = 'MODE'
+            line = line[3:]
+        else:
+            state = 'MORPH'
+
+        m = SUDACHI_PATTERN.match(line)
+        surface = None
+        if m:
+            surface = m.group(1)
+            if not surface:  # bug of sudachi java version
+                surface = m.group(4)
+        if surface:
+            sentence.append(surface)
+        else:
+            print('Bad format in %s line #%d' % (path, line_index + 1), file=sys.stderr)
+            print(line, file=sys.stderr)
+
+    if line is not None and (line != 'EOS' or line.startswith('#\td')):
+        print('File not ends with EOS or #d - %s' % path, file=sys.stderr)
+
+    if yield_document:
+        yield sentences

--- a/spacy/lang/ja/syntax_iterators.py
+++ b/spacy/lang/ja/syntax_iterators.py
@@ -1,0 +1,27 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+from spacy.symbols import NOUN, PROPN, PRON
+
+
+def noun_chunks(obj):
+    """
+    Detect base noun phrases from a dependency parse. Works on both Doc and Span.
+    """
+    doc = obj.doc  # Ensure works on both Doc and Span.
+    np_label = doc.vocab.strings.add('NP')
+    start = -1
+    for i, word in enumerate(obj):
+        if word.pos in (NOUN, PROPN, PRON):
+            if start < 0:
+                start = i
+        elif start >= 0:
+            yield start, i, np_label
+            start = -1
+    if start >= 0:
+        yield start, len(doc), np_label
+
+
+SYNTAX_ITERATORS = {
+    'noun_chunks': noun_chunks
+}

--- a/spacy/lang/ja/tag_map.py
+++ b/spacy/lang/ja/tag_map.py
@@ -1,80 +1,78 @@
 # encoding: utf8
 from __future__ import unicode_literals
 
-from ...symbols import POS, PUNCT, INTJ, X, ADJ, AUX, ADP, PART, SCONJ, NOUN
-from ...symbols import SYM, PRON, VERB, ADV, PROPN, NUM, DET
+from ...symbols import POS, PUNCT, INTJ, X, ADJ, AUX, ADP, PART, CCONJ, SCONJ, NOUN
+from ...symbols import SPACE, SYM, PRON, VERB, ADV, PROPN, NUM, DET
 
 
 TAG_MAP = {
-    # Explanation of Unidic tags:
-    # https://www.gavo.t.u-tokyo.ac.jp/~mine/japanese/nlp+slp/UNIDIC_manual.pdf
-    # Universal Dependencies Mapping:
-    # http://universaldependencies.org/ja/overview/morphology.html
-    # http://universaldependencies.org/ja/pos/all.html
-    "記号,一般,*,*": {
-        POS: PUNCT
-    },  # this includes characters used to represent sounds like ドレミ
-    "記号,文字,*,*": {
-        POS: PUNCT
-    },  # this is for Greek and Latin characters used as sumbols, as in math
-    "感動詞,フィラー,*,*": {POS: INTJ},
-    "感動詞,一般,*,*": {POS: INTJ},
-    # this is specifically for unicode full-width space
-    "空白,*,*,*": {POS: X},
-    "形状詞,一般,*,*": {POS: ADJ},
-    "形状詞,タリ,*,*": {POS: ADJ},
-    "形状詞,助動詞語幹,*,*": {POS: ADJ},
-    "形容詞,一般,*,*": {POS: ADJ},
-    "形容詞,非自立可能,*,*": {POS: AUX},  # XXX ADJ if alone, AUX otherwise
-    "助詞,格助詞,*,*": {POS: ADP},
-    "助詞,係助詞,*,*": {POS: ADP},
-    "助詞,終助詞,*,*": {POS: PART},
-    "助詞,準体助詞,*,*": {POS: SCONJ},  # の as in 走るのが速い
-    "助詞,接続助詞,*,*": {POS: SCONJ},  # verb ending て
-    "助詞,副助詞,*,*": {POS: PART},  # ばかり, つつ after a verb
-    "助動詞,*,*,*": {POS: AUX},
-    "接続詞,*,*,*": {POS: SCONJ},  # XXX: might need refinement
-    "接頭辞,*,*,*": {POS: NOUN},
-    "接尾辞,形状詞的,*,*": {POS: ADJ},  # がち, チック
-    "接尾辞,形容詞的,*,*": {POS: ADJ},  # -らしい
-    "接尾辞,動詞的,*,*": {POS: NOUN},  # -じみ
-    "接尾辞,名詞的,サ変可能,*": {POS: NOUN},  # XXX see 名詞,普通名詞,サ変可能,*
-    "接尾辞,名詞的,一般,*": {POS: NOUN},
-    "接尾辞,名詞的,助数詞,*": {POS: NOUN},
-    "接尾辞,名詞的,副詞可能,*": {POS: NOUN},  # -後, -過ぎ
-    "代名詞,*,*,*": {POS: PRON},
-    "動詞,一般,*,*": {POS: VERB},
-    "動詞,非自立可能,*,*": {POS: VERB},  # XXX VERB if alone, AUX otherwise
-    "動詞,非自立可能,*,*,AUX": {POS: AUX},
-    "動詞,非自立可能,*,*,VERB": {POS: VERB},
-    "副詞,*,*,*": {POS: ADV},
-    "補助記号,ＡＡ,一般,*": {POS: SYM},  # text art
-    "補助記号,ＡＡ,顔文字,*": {POS: SYM},  # kaomoji
-    "補助記号,一般,*,*": {POS: SYM},
-    "補助記号,括弧開,*,*": {POS: PUNCT},  # open bracket
-    "補助記号,括弧閉,*,*": {POS: PUNCT},  # close bracket
-    "補助記号,句点,*,*": {POS: PUNCT},  # period or other EOS marker
-    "補助記号,読点,*,*": {POS: PUNCT},  # comma
-    "名詞,固有名詞,一般,*": {POS: PROPN},  # general proper noun
-    "名詞,固有名詞,人名,一般": {POS: PROPN},  # person's name
-    "名詞,固有名詞,人名,姓": {POS: PROPN},  # surname
-    "名詞,固有名詞,人名,名": {POS: PROPN},  # first name
-    "名詞,固有名詞,地名,一般": {POS: PROPN},  # place name
-    "名詞,固有名詞,地名,国": {POS: PROPN},  # country name
-    "名詞,助動詞語幹,*,*": {POS: AUX},
-    "名詞,数詞,*,*": {POS: NUM},  # includes Chinese numerals
-    "名詞,普通名詞,サ変可能,*": {POS: NOUN},  # XXX: sometimes VERB in UDv2; suru-verb noun
-    "名詞,普通名詞,サ変可能,*,NOUN": {POS: NOUN},
-    "名詞,普通名詞,サ変可能,*,VERB": {POS: VERB},
-    "名詞,普通名詞,サ変形状詞可能,*": {POS: NOUN},  # ex: 下手
-    "名詞,普通名詞,一般,*": {POS: NOUN},
-    "名詞,普通名詞,形状詞可能,*": {POS: NOUN},  # XXX: sometimes ADJ in UDv2
-    "名詞,普通名詞,形状詞可能,*,NOUN": {POS: NOUN},
-    "名詞,普通名詞,形状詞可能,*,ADJ": {POS: ADJ},
-    "名詞,普通名詞,助数詞可能,*": {POS: NOUN},  # counter / unit
-    "名詞,普通名詞,副詞可能,*": {POS: NOUN},
-    "連体詞,*,*,*": {POS: ADJ},  # XXX this has exceptions based on literal token
-    "連体詞,*,*,*,ADJ": {POS: ADJ},
-    "連体詞,*,*,*,PRON": {POS: PRON},
-    "連体詞,*,*,*,DET": {POS: DET},
+    # Universal Dependencies Mapping
+    # (private repository)
+    # https://github.com/mynlp/udjapanese/blob/master/UDJapaneseBCCWJ/unidic_to_udpos_mapping/bccwj_pos_suw_rule.json
+
+    "記号-一般": {POS: SYM},
+    "記号-文字": {POS: SYM},
+
+    "感動詞-フィラー": {POS: INTJ},
+    "感動詞-一般": {POS: INTJ},
+
+    # spaces should be treated as token.whitespace_
+    "空白": {POS: SPACE},
+
+    "形状詞-一般": {POS: ADJ},
+    "形状詞-タリ": {POS: ADJ},
+    "形状詞-助動詞語幹": {POS: ADJ},
+    "形容詞-一般": {POS: ADJ},
+    "形容詞-非自立可能": {POS: ADJ},  # All the root tokens are ADJ
+
+    "助詞-格助詞": {POS: ADP},
+    "助詞-係助詞": {POS: ADP},
+    "助詞-終助詞": {POS: PART},
+    "助詞-準体助詞": {POS: SCONJ},
+    "助詞-接続助詞": {POS: CCONJ},
+    "助詞-副助詞": {POS: ADP},
+    "助動詞": {POS: AUX},
+    "接続詞": {POS: SCONJ},
+
+    "接頭辞": {POS: NOUN},
+    "接尾辞-形状詞的": {POS: NOUN},
+    "接尾辞-形容詞的": {POS: NOUN},
+    "接尾辞-動詞的": {POS: NOUN},
+    "接尾辞-名詞的-サ変可能": {POS: NOUN},  # All the root tokens are NOUN
+    "接尾辞-名詞的-一般": {POS: NOUN},
+    "接尾辞-名詞的-助数詞": {POS: NOUN},
+    "接尾辞-名詞的-副詞可能": {POS: NOUN},  # All the root tokens are NOUN
+
+    "代名詞": {POS: PRON},
+    "動詞-一般": {POS: VERB},
+    "動詞-非自立可能": {POS: VERB},  # All the root tokens are VERB except the tokens lemma is '為る' and POS is AUX
+    "副詞": {POS: ADV},
+
+    "補助記号-ＡＡ-一般": {POS: SYM},  # text art
+    "補助記号-ＡＡ-顔文字": {POS: SYM},  # kaomoji
+    "補助記号-一般": {POS: PUNCT},
+    "補助記号-括弧開": {POS: PUNCT},  # open bracket
+    "補助記号-括弧閉": {POS: PUNCT},  # close bracket
+    "補助記号-句点": {POS: PUNCT},  # period or other EOS marker
+    "補助記号-読点": {POS: PUNCT},  # comma
+
+    "名詞-固有名詞-一般": {POS: PROPN},  # general proper noun
+    "名詞-固有名詞-人名-一般": {POS: PROPN},  # person's name
+    "名詞-固有名詞-人名-姓": {POS: PROPN},  # surname
+    "名詞-固有名詞-人名-名": {POS: PROPN},  # first name
+    "名詞-固有名詞-地名-一般": {POS: PROPN},  # place name
+    "名詞-固有名詞-地名-国": {POS: PROPN},  # country name
+
+    "名詞-助動詞語幹": {POS: AUX},
+    "名詞-数詞": {POS: NUM},  # includes Chinese numerals
+
+    "名詞-普通名詞-サ変可能": {POS: NOUN},  # ADJ=3349 and VERB=3411 for root
+
+    "名詞-普通名詞-サ変形状詞可能": {POS: NOUN},  # ADJ=40 and NOUN=30 for root
+    "名詞-普通名詞-一般": {POS: NOUN},
+    "名詞-普通名詞-形状詞可能": {POS: ADJ},  # ADJ=404 and NOUN=161 for root
+    "名詞-普通名詞-助数詞可能": {POS: NOUN},  # All the root tokens are NOUN
+    "名詞-普通名詞-副詞可能": {POS: NOUN},  # All the root tokens are NOUN
+
+    "連体詞": {POS: DET},
 }

--- a/spacy/pipeline/functions.py
+++ b/spacy/pipeline/functions.py
@@ -36,7 +36,7 @@ def merge_entities(doc):
     return doc
 
 
-def merge_subtokens(doc, label="subtok"):
+def merge_subtokens(doc, label="subtok", **kwargs):
     """Merge subtokens into a single token.
 
     doc (Doc): The Doc object.

--- a/spacy/tests/conftest.py
+++ b/spacy/tests/conftest.py
@@ -120,7 +120,7 @@ def it_tokenizer():
 
 @pytest.fixture(scope="session")
 def ja_tokenizer():
-    pytest.importorskip("MeCab")
+    pytest.importorskip("sudachipy")
     return get_lang_class("ja").Defaults.create_tokenizer()
 
 

--- a/spacy/tests/lang/ja/test_lemmatization.py
+++ b/spacy/tests/lang/ja/test_lemmatization.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import pytest
 
 
+@pytest.mark.skipif('sys.version_info < (3, 5)')
 @pytest.mark.parametrize(
     "word,lemma",
     [("新しく", "新しい"), ("赤く", "赤い"), ("すごく", "凄い"), ("いただきました", "頂く"), ("なった", "成る")],

--- a/spacy/tests/lang/ja/test_tokenizer.py
+++ b/spacy/tests/lang/ja/test_tokenizer.py
@@ -6,7 +6,7 @@ import pytest
 
 # fmt: off
 TOKENIZER_TESTS = [
-    ("日本語だよ", ['日本', '語', 'だ', 'よ']),
+    ("日本語だよ", ['日本語', 'だ', 'よ']),
     ("東京タワーの近くに住んでいます。", ['東京', 'タワー', 'の', '近く', 'に', '住ん', 'で', 'い', 'ます', '。']),
     ("吾輩は猫である。", ['吾輩', 'は', '猫', 'で', 'ある', '。']),
     ("月に代わって、お仕置きよ!", ['月', 'に', '代わっ', 'て', '、', 'お', '仕置き', 'よ', '!']),
@@ -14,35 +14,38 @@ TOKENIZER_TESTS = [
 ]
 
 TAG_TESTS = [
-    ("日本語だよ", ['名詞,固有名詞,地名,国', '名詞,普通名詞,一般,*', '助動詞,*,*,*', '助詞,終助詞,*,*']),
-    ("東京タワーの近くに住んでいます。", ['名詞,固有名詞,地名,一般', '名詞,普通名詞,一般,*', '助詞,格助詞,*,*', '名詞,普通名詞,副詞可能,*', '助詞,格助詞,*,*', '動詞,一般,*,*', '助詞,接続助詞,*,*', '動詞,非自立可能,*,*', '助動詞,*,*,*', '補助記号,句点,*,*']),
-    ("吾輩は猫である。", ['代名詞,*,*,*', '助詞,係助詞,*,*', '名詞,普通名詞,一般,*', '助動詞,*,*,*', '動詞,非自立可能,*,*', '補助記号,句点,*,*']),
-    ("月に代わって、お仕置きよ!", ['名詞,普通名詞,助数詞可能,*', '助詞,格助詞,*,*', '動詞,一般,*,*', '助詞,接続助詞,*,*', '補助記号,読点,*,*', '接頭辞,*,*,*', '名詞,普通名詞,一般,*', '助詞,終助詞,*,*', '補助記号,句点,*,*']),
-    ("すもももももももものうち", ['名詞,普通名詞,一般,*', '助詞,係助詞,*,*', '名詞,普通名詞,一般,*', '助詞,係助詞,*,*', '名詞,普通名詞,一般,*', '助詞,格助詞,*,*', '名詞,普通名詞,副詞可能,*'])
+    ("日本語だよ", ['名詞-普通名詞-一般', '助動詞', '助詞-終助詞']),
+    ("東京タワーの近くに住んでいます。", ['名詞-固有名詞-地名-一般', '名詞-普通名詞-一般', '助詞-格助詞', '名詞-普通名詞-副詞可能', '助詞-格助詞', '動詞-一般', '助詞-接続助詞', '動詞-非自立可能', '助動詞', '補助記号-句点']),
+    ("吾輩は猫である。", ['代名詞', '助詞-係助詞', '名詞-普通名詞-一般', '助動詞', '動詞-非自立可能', '補助記号-句点']),
+    ("月に代わって、お仕置きよ!", ['名詞-普通名詞-助数詞可能', '助詞-格助詞', '動詞-一般', '助詞-接続助詞', '補助記号-読点', '接頭辞', '名詞-普通名詞-一般', '助詞-終助詞', '補助記号-句点']),
+    ("すもももももももものうち", ['名詞-普通名詞-一般', '助詞-係助詞', '名詞-普通名詞-一般', '助詞-係助詞', '名詞-普通名詞-一般', '助詞-格助詞', '名詞-普通名詞-副詞可能'])
 ]
 
 POS_TESTS = [
-    ('日本語だよ', ['PROPN', 'NOUN', 'AUX', 'PART']),
-    ('東京タワーの近くに住んでいます。', ['PROPN', 'NOUN', 'ADP', 'NOUN', 'ADP', 'VERB', 'SCONJ', 'VERB', 'AUX', 'PUNCT']),
+    ('日本語だよ', ['NOUN', 'AUX', 'PART']),
+    ('東京タワーの近くに住んでいます。', ['PROPN', 'NOUN', 'ADP', 'NOUN', 'ADP', 'VERB', 'CCONJ', 'VERB', 'AUX', 'PUNCT']),
     ('吾輩は猫である。', ['PRON', 'ADP', 'NOUN', 'AUX', 'VERB', 'PUNCT']),
-    ('月に代わって、お仕置きよ!', ['NOUN', 'ADP', 'VERB', 'SCONJ', 'PUNCT', 'NOUN', 'NOUN', 'PART', 'PUNCT']),
+    ('月に代わって、お仕置きよ!', ['NOUN', 'ADP', 'VERB', 'CCONJ', 'PUNCT', 'NOUN', 'NOUN', 'PART', 'PUNCT']),
     ('すもももももももものうち', ['NOUN', 'ADP', 'NOUN', 'ADP', 'NOUN', 'ADP', 'NOUN'])
 ]
 # fmt: on
 
 
+@pytest.mark.skipif('sys.version_info < (3, 5)')
 @pytest.mark.parametrize("text,expected_tokens", TOKENIZER_TESTS)
 def test_ja_tokenizer(ja_tokenizer, text, expected_tokens):
     tokens = [token.text for token in ja_tokenizer(text)]
     assert tokens == expected_tokens
 
 
+@pytest.mark.skipif('sys.version_info < (3, 5)')
 @pytest.mark.parametrize("text,expected_tags", TAG_TESTS)
 def test_ja_tokenizer_tags(ja_tokenizer, text, expected_tags):
     tags = [token.tag_ for token in ja_tokenizer(text)]
     assert tags == expected_tags
 
 
+@pytest.mark.skipif('sys.version_info < (3, 5)')
 @pytest.mark.parametrize("text,expected_pos", POS_TESTS)
 def test_ja_tokenizer_pos(ja_tokenizer, text, expected_pos):
     pos = [token.pos_ for token in ja_tokenizer(text)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
- Apply SudachiPy as Japanese tokenizer.
- Fix an error while executing train command with -T option

Please see issue https://github.com/explosion/spaCy/issues/3756#issuecomment-510081693 for details.

This PR is simplified version of #3899.

### Types of change
- new feature

## Checklist
- [X] I have submitted the spaCy Contributor Agreement.
- [X] I ran the tests, and all new and existing tests passed.
- [X] My changes don't require a change to the documentation, or if they do, I've added all required information.
