### PR TITLE
more friendly textcat errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Our libraries
 cymem>=2.0.2,<2.1.0
 preshed>=2.0.1,<2.1.0
-thinc>=7.0.2,<7.1.0
+thinc>=7.0.5,<7.1.0
 blis>=0.2.2,<0.3.0
 murmurhash>=0.28.0,<1.1.0
 wasabi>=0.2.0,<1.1.0

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -403,6 +403,7 @@ class Errors(object):
     E140 = ("The list of entities, prior probabilities and entity vectors should be of equal length.")
     E141 = ("Entity vectors should be of length {required} instead of the provided {found}.")
     E142 = ("Unsupported loss_function '{loss_func}'. Use either 'L2' or 'cosine'")
+    E143 = ("Labels for component '{name}' not initialized. Did you forget to call add_label()?")
 
 
 @add_codes


### PR DESCRIPTION
Provide more friendly errors when the `textcat` pipeline was been initialised incorrectly (e.g. no labels were added to the component), cf Issue https://github.com/explosion/spaCy/issues/3912.

## Description
* call the new `require_labels` in `begin_training` when initializing a new Model
* call `require_model` in `update`
* upgrade `thinc` in the requirements to `7.0.5` to ensure `test_issue3880` (https://github.com/explosion/spaCy/issues/3880) doesn't fail

### Types of change
small enhancements

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
