### PR TITLE
Fix dependency copy for as_doc

### DIFF
--- a/spacy/tests/regression/test_issue3962.py
+++ b/spacy/tests/regression/test_issue3962.py
@@ -1,0 +1,15 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+import spacy
+
+
+def test_issue3962():
+    nlp = spacy.load('en_core_web_md')
+    doc = nlp('He jests at scars, that never felt a wound.')
+    span = doc[0:3]
+    doc2 = span.as_doc()
+    assert doc2
+    doc2_json = doc2.to_json()
+    print(doc2_json)
+    assert doc2_json

--- a/spacy/tests/regression/test_issue3962.py
+++ b/spacy/tests/regression/test_issue3962.py
@@ -18,7 +18,7 @@ def doc(en_tokenizer):
 
 def test_issue3962(doc):
     """ Ensure that as_doc does not result in out-of-bound access of tokens.
-    This is achieved by setting the head to itself it it would lie out of the span otherwise."""
+    This is achieved by setting the head to itself if it would lie out of the span otherwise."""
     assert doc[1].dep_ == "ccomp"
     assert doc[1].head.text == "felt"
     assert doc[2].dep_ == "prep"

--- a/spacy/tests/regression/test_issue3962.py
+++ b/spacy/tests/regression/test_issue3962.py
@@ -17,8 +17,26 @@ def doc(en_tokenizer):
 
 
 def test_issue3962(doc):
-    span = doc[0:3]
+    """ Ensure that as_doc does not result in out-of-bound access of tokens.
+    This is achieved by setting the head to itself it it would lie out of the span otherwise."""
+    assert doc[1].dep_ == "ccomp"
+    assert doc[1].head.text == "felt"
+    assert doc[2].dep_ == "prep"
+    assert doc[2].head.text == "jests"
+    assert doc[3].dep_ == "pobj"
+    assert doc[3].head.text == "at"
+    assert doc[4].dep_ == "punct"
+    assert doc[4].head.text == "felt"
+    span = doc[1:5]
     doc2 = span.as_doc()
     assert doc2
     doc2_json = doc2.to_json()
     assert doc2_json
+    assert doc2[0].dep_ == "ccomp"
+    assert doc2[0].head.text == "jests"  # head set back to itself
+    assert doc2[1].dep_ == "prep"
+    assert doc2[1].head.text == "jests"
+    assert doc2[2].dep_ == "pobj"
+    assert doc2[2].head.text == "at"
+    assert doc2[3].dep_ == "punct"
+    assert doc2[3].head.text == ","      # head set back to itself

--- a/spacy/tests/regression/test_issue3962.py
+++ b/spacy/tests/regression/test_issue3962.py
@@ -35,17 +35,17 @@ def test_issue3962(doc):
     doc2_json = doc2.to_json()
     assert doc2_json
 
-    # We should still have 1 sentence
-    assert len(list(doc2.sents)) == 1
-
-    assert doc2[0].head.text == "jests"  # head set to itself
+    assert doc2[0].head.text == "jests"  # head set to itself, being the new artificial root
     assert doc2[0].dep_ == "dep"
     assert doc2[1].head.text == "jests"
     assert doc2[1].dep_ == "prep"
     assert doc2[2].head.text == "at"
     assert doc2[2].dep_ == "pobj"
-    assert doc2[3].head.text == "jests"  # head set to span root
+    assert doc2[3].head.text == "jests"  # head set to the new artificial root
     assert doc2[3].dep_ == "dep"
+
+    # We should still have 1 sentence
+    assert len(list(doc2.sents)) == 1
 
     span3 = doc[6:9]  # "never felt a"
     doc3 = span3.as_doc()
@@ -92,10 +92,7 @@ def test_issue3962_long(two_sent_doc):
     doc2_json = doc2.to_json()
     assert doc2_json
 
-    # We should still have 2 sentences - currently not the case because all is attached to "jests"
-    # assert len(list(doc2.sents)) == 2
-
-    assert doc2[0].head.text == "jests"  # head set to itself
+    assert doc2[0].head.text == "jests"  # head set to itself, being the new artificial root (in sentence 1)
     assert doc2[0].dep_ == "ROOT"
     assert doc2[1].head.text == "jests"
     assert doc2[1].dep_ == "prep"
@@ -103,7 +100,13 @@ def test_issue3962_long(two_sent_doc):
     assert doc2[2].dep_ == "pobj"
     assert doc2[3].head.text == "jests"
     assert doc2[3].dep_ == "punct"
-    assert doc2[4].head.text == "jests"  # head set to span root
+    assert doc2[4].head.text == "They"  # head set to itself, being the new artificial root (in sentence 2)
     assert doc2[4].dep_ == "dep"
-    assert doc2[4].head.text == "jests"  # head set to span root
+    assert doc2[4].head.text == "They"  # head set to the new artificial head (in sentence 2)
     assert doc2[4].dep_ == "dep"
+
+    # We should still have 2 sentences
+    sents = list(doc2.sents)
+    assert len(sents) == 2
+    assert sents[0].text == "jests at scars ."
+    assert sents[1].text == "They never"

--- a/spacy/tests/regression/test_issue3962.py
+++ b/spacy/tests/regression/test_issue3962.py
@@ -30,24 +30,48 @@ def doc(en_tokenizer):
 def test_issue3962(doc):
     """ Ensure that as_doc does not result in out-of-bound access of tokens.
     This is achieved by setting the head to itself if it would lie out of the span otherwise."""
-    assert doc[1].dep_ == "ccomp"
+    assert doc[0].head.text == "jests"
     assert doc[1].head.text == "felt"
-    assert doc[2].dep_ == "prep"
     assert doc[2].head.text == "jests"
-    assert doc[3].dep_ == "pobj"
     assert doc[3].head.text == "at"
-    assert doc[4].dep_ == "punct"
     assert doc[4].head.text == "felt"
-    span = doc[1:5]
-    doc2 = span.as_doc()
+    assert doc[5].head.text == "felt"
+    assert doc[6].head.text == "felt"
+    assert doc[7].head.text == "felt"
+    assert doc[8].head.text == "wound"
+    assert doc[9].head.text == "felt"
+    assert doc[10].head.text == "felt"
+
+    span2 = doc[1:5]
+    doc2 = span2.as_doc()
     assert doc2
     doc2_json = doc2.to_json()
     assert doc2_json
-    assert doc2[0].dep_ == "ccomp"
+
+    # Note: doc2 is now two sentences, because we can't recover from the lost ROOT "felt"
+
     assert doc2[0].head.text == "jests"  # head set back to itself
-    assert doc2[1].dep_ == "prep"
+    assert doc2[0].dep_ == "dep"
     assert doc2[1].head.text == "jests"
-    assert doc2[2].dep_ == "pobj"
+    assert doc2[1].dep_ == "prep"
     assert doc2[2].head.text == "at"
-    assert doc2[3].dep_ == "punct"
+    assert doc2[2].dep_ == "pobj"
     assert doc2[3].head.text == ","  # head set back to itself
+    assert doc2[3].dep_ == "dep"
+
+    span3 = doc[6:9]
+    doc3 = span3.as_doc()
+    assert doc3
+    doc3_json = doc3.to_json()
+    assert doc3_json
+    print(doc3)
+
+    assert doc3[0].head.text == "felt"
+    assert doc3[0].dep_ == "neg"
+    assert doc3[1].head.text == "felt"
+    assert doc3[1].dep_ == "ROOT"
+    assert doc3[2].head.text == "felt"  # head set to ancestor
+    assert doc3[2].dep_ == "dep"
+
+    # doc3 should still be one sentence as "a" can be attached to "felt" instead of "wound"
+    assert len(list(doc3.sents)) == 1

--- a/spacy/tests/regression/test_issue3962.py
+++ b/spacy/tests/regression/test_issue3962.py
@@ -5,11 +5,18 @@ import spacy
 
 
 def test_issue3962():
-    nlp = spacy.load('en_core_web_md')
+    nlp = spacy.load('en_core_web_md')  # TODO: not supposed to have a model in a unit test here
     doc = nlp('He jests at scars, that never felt a wound.')
+
     span = doc[0:3]
     doc2 = span.as_doc()
     assert doc2
     doc2_json = doc2.to_json()
-    print(doc2_json)
     assert doc2_json
+
+    # TODO: remove
+    for i, token in enumerate(doc):
+        print(i, token.text, token.pos, token.pos_, token.dep, token.dep_, token.head)
+    print()
+    for i, token in enumerate(doc2):
+        print(i, token.text, token.pos, token.pos_, token.dep, token.dep_, token.head)

--- a/spacy/tests/regression/test_issue3962.py
+++ b/spacy/tests/regression/test_issue3962.py
@@ -10,8 +10,19 @@ from ..util import get_doc
 def doc(en_tokenizer):
     text = "He jests at scars, that never felt a wound."
     heads = [1, 6, -1, -1, 3, 2, 1, 0, 1, -2, -3]
-    deps = ["nsubj", "ccomp", "prep", "pobj", "punct", "nsubj", "neg", "ROOT",
-            "det", "dobj", "punct"]
+    deps = [
+        "nsubj",
+        "ccomp",
+        "prep",
+        "pobj",
+        "punct",
+        "nsubj",
+        "neg",
+        "ROOT",
+        "det",
+        "dobj",
+        "punct",
+    ]
     tokens = en_tokenizer(text)
     return get_doc(tokens.vocab, words=[t.text for t in tokens], heads=heads, deps=deps)
 
@@ -39,4 +50,4 @@ def test_issue3962(doc):
     assert doc2[2].dep_ == "pobj"
     assert doc2[2].head.text == "at"
     assert doc2[3].dep_ == "punct"
-    assert doc2[3].head.text == ","      # head set back to itself
+    assert doc2[3].head.text == ","  # head set back to itself

--- a/spacy/tests/regression/test_issue3962.py
+++ b/spacy/tests/regression/test_issue3962.py
@@ -47,7 +47,7 @@ def test_issue3962(doc):
     assert doc2[3].head.text == "jests"  # head set to span root
     assert doc2[3].dep_ == "dep"
 
-    span3 = doc[6:9]
+    span3 = doc[6:9]  # "never felt a"
     doc3 = span3.as_doc()
     doc3_json = doc3.to_json()
     assert doc3_json
@@ -87,7 +87,7 @@ def two_sent_doc(en_tokenizer):
 def test_issue3962_long(two_sent_doc):
     """ Ensure that as_doc does not result in out-of-bound access of tokens.
     This is achieved by setting the head to itself if it would lie out of the span otherwise."""
-    span2 = two_sent_doc[1:7]
+    span2 = two_sent_doc[1:7]  # "jests at scars. They never"
     doc2 = span2.as_doc()
     doc2_json = doc2.to_json()
     assert doc2_json

--- a/spacy/tests/regression/test_issue3962.py
+++ b/spacy/tests/regression/test_issue3962.py
@@ -1,22 +1,24 @@
 # coding: utf8
 from __future__ import unicode_literals
 
-import spacy
+import pytest
+
+from ..util import get_doc
 
 
-def test_issue3962():
-    nlp = spacy.load('en_core_web_md')  # TODO: not supposed to have a model in a unit test here
-    doc = nlp('He jests at scars, that never felt a wound.')
+@pytest.fixture
+def doc(en_tokenizer):
+    text = "He jests at scars, that never felt a wound."
+    heads = [1, 6, -1, -1, 3, 2, 1, 0, 1, -2, -3]
+    deps = ["nsubj", "ccomp", "prep", "pobj", "punct", "nsubj", "neg", "ROOT",
+            "det", "dobj", "punct"]
+    tokens = en_tokenizer(text)
+    return get_doc(tokens.vocab, words=[t.text for t in tokens], heads=heads, deps=deps)
 
+
+def test_issue3962(doc):
     span = doc[0:3]
     doc2 = span.as_doc()
     assert doc2
     doc2_json = doc2.to_json()
     assert doc2_json
-
-    # TODO: remove
-    for i, token in enumerate(doc):
-        print(i, token.text, token.pos, token.pos_, token.dep, token.dep_, token.head)
-    print()
-    for i, token in enumerate(doc2):
-        print(i, token.text, token.pos, token.pos_, token.dep, token.dep_, token.head)

--- a/spacy/tests/regression/test_issue3962.py
+++ b/spacy/tests/regression/test_issue3962.py
@@ -30,41 +30,27 @@ def doc(en_tokenizer):
 def test_issue3962(doc):
     """ Ensure that as_doc does not result in out-of-bound access of tokens.
     This is achieved by setting the head to itself if it would lie out of the span otherwise."""
-    assert doc[0].head.text == "jests"
-    assert doc[1].head.text == "felt"
-    assert doc[2].head.text == "jests"
-    assert doc[3].head.text == "at"
-    assert doc[4].head.text == "felt"
-    assert doc[5].head.text == "felt"
-    assert doc[6].head.text == "felt"
-    assert doc[7].head.text == "felt"
-    assert doc[8].head.text == "wound"
-    assert doc[9].head.text == "felt"
-    assert doc[10].head.text == "felt"
-
-    span2 = doc[1:5]
+    span2 = doc[1:5]  # "jests at scars ,"
     doc2 = span2.as_doc()
-    assert doc2
     doc2_json = doc2.to_json()
     assert doc2_json
 
-    # Note: doc2 is now two sentences, because we can't recover from the lost ROOT "felt"
+    # We should still have 1 sentence
+    assert len(list(doc2.sents)) == 1
 
-    assert doc2[0].head.text == "jests"  # head set back to itself
+    assert doc2[0].head.text == "jests"  # head set to itself
     assert doc2[0].dep_ == "dep"
     assert doc2[1].head.text == "jests"
     assert doc2[1].dep_ == "prep"
     assert doc2[2].head.text == "at"
     assert doc2[2].dep_ == "pobj"
-    assert doc2[3].head.text == ","  # head set back to itself
+    assert doc2[3].head.text == "jests"  # head set to span root
     assert doc2[3].dep_ == "dep"
 
     span3 = doc[6:9]
     doc3 = span3.as_doc()
-    assert doc3
     doc3_json = doc3.to_json()
     assert doc3_json
-    print(doc3)
 
     assert doc3[0].head.text == "felt"
     assert doc3[0].dep_ == "neg"
@@ -73,5 +59,51 @@ def test_issue3962(doc):
     assert doc3[2].head.text == "felt"  # head set to ancestor
     assert doc3[2].dep_ == "dep"
 
-    # doc3 should still be one sentence as "a" can be attached to "felt" instead of "wound"
+    # We should still have 1 sentence as "a" can be attached to "felt" instead of "wound"
     assert len(list(doc3.sents)) == 1
+
+
+@pytest.fixture
+def two_sent_doc(en_tokenizer):
+    text = "He jests at scars. They never felt a wound."
+    heads = [1, 0, -1, -1, -3, 2, 1, 0, 1, -2, -3]
+    deps = [
+        "nsubj",
+        "ROOT",
+        "prep",
+        "pobj",
+        "punct",
+        "nsubj",
+        "neg",
+        "ROOT",
+        "det",
+        "dobj",
+        "punct",
+    ]
+    tokens = en_tokenizer(text)
+    return get_doc(tokens.vocab, words=[t.text for t in tokens], heads=heads, deps=deps)
+
+
+def test_issue3962_long(two_sent_doc):
+    """ Ensure that as_doc does not result in out-of-bound access of tokens.
+    This is achieved by setting the head to itself if it would lie out of the span otherwise."""
+    span2 = two_sent_doc[1:7]
+    doc2 = span2.as_doc()
+    doc2_json = doc2.to_json()
+    assert doc2_json
+
+    # We should still have 2 sentences - currently not the case because all is attached to "jests"
+    # assert len(list(doc2.sents)) == 2
+
+    assert doc2[0].head.text == "jests"  # head set to itself
+    assert doc2[0].dep_ == "ROOT"
+    assert doc2[1].head.text == "jests"
+    assert doc2[1].dep_ == "prep"
+    assert doc2[2].head.text == "at"
+    assert doc2[2].dep_ == "pobj"
+    assert doc2[3].head.text == "jests"
+    assert doc2[3].dep_ == "punct"
+    assert doc2[4].head.text == "jests"  # head set to span root
+    assert doc2[4].dep_ == "dep"
+    assert doc2[4].head.text == "jests"  # head set to span root
+    assert doc2[4].dep_ == "dep"

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -800,10 +800,10 @@ cdef class Doc:
             for i in range(length):
                 token = &self.c[i]
                 value =  array[i, col]
-                if (i+value) in range(self.length):
+                if (i+value) in range(length):
                     Token.set_struct_attr(token, attr_ids[col], value)
         # Now load the data
-        for i in range(self.length):
+        for i in range(length):
             token = &self.c[i]
             for j in range(n_attrs):
                 if attr_ids[j] != TAG and attr_ids[j] != HEAD:
@@ -813,7 +813,7 @@ cdef class Doc:
         self.is_tagged = bool(self.is_tagged or TAG in attrs or POS in attrs)
         # If document is parsed, set children
         if self.is_parsed:
-            set_children_from_heads(self.c, self.length)
+            set_children_from_heads(self.c, length)
         return self
 
     def get_lca_matrix(self):

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -793,11 +793,20 @@ cdef class Doc:
             for i in range(length):
                 if array[i, col] != 0:
                     self.vocab.morphology.assign_tag(&tokens[i], array[i, col])
+        # Copy HEAD only when it refers to a token in this doc (in case this represents a span of a larger doc)
+        cdef attr_t value
+        if HEAD in attrs:
+            col = attrs.index(HEAD)
+            for i in range(length):
+                token = &self.c[i]
+                value =  array[i, col]
+                if (i+value) in range(self.length):
+                    Token.set_struct_attr(token, attr_ids[col], value)
         # Now load the data
         for i in range(self.length):
             token = &self.c[i]
             for j in range(n_attrs):
-                if attr_ids[j] != TAG:
+                if attr_ids[j] != TAG and attr_ids[j] != HEAD:
                     Token.set_struct_attr(token, attr_ids[j], array[i, j])
         # Set flags
         self.is_parsed = bool(self.is_parsed or HEAD in attrs or DEP in attrs)

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -793,20 +793,11 @@ cdef class Doc:
             for i in range(length):
                 if array[i, col] != 0:
                     self.vocab.morphology.assign_tag(&tokens[i], array[i, col])
-        # Copy HEAD only when it refers to a token in this doc (in case this represents a span of a larger doc)
-        cdef attr_t value
-        if HEAD in attrs:
-            col = attrs.index(HEAD)
-            for i in range(length):
-                token = &self.c[i]
-                value =  array[i, col]
-                if (i+value) in range(length):
-                    Token.set_struct_attr(token, attr_ids[col], value)
         # Now load the data
         for i in range(length):
             token = &self.c[i]
             for j in range(n_attrs):
-                if attr_ids[j] != TAG and attr_ids[j] != HEAD:
+                if attr_ids[j] != TAG:
                     Token.set_struct_attr(token, attr_ids[j], array[i, j])
         # Set flags
         self.is_parsed = bool(self.is_parsed or HEAD in attrs or DEP in attrs)

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -264,7 +264,9 @@ cdef class Span:
                 # if we couldn't find a better ancestor, set its head to itself
                 value = array[i, head_col]
                 if (i+value) not in range(length):
-                    array[i, head_col] = 0
+                    span_root = self.root.i - self.start
+                    assert span_root in range(length)
+                    array[i, head_col] = span_root - i
                     if DEP in attrs:
                         array[i, attrs.index(DEP)] = dep
 


### PR DESCRIPTION
The `span.as_doc` functionality seems to have some issues (cf. Issue #3962 and Issue #3669) which I think are related to the dependency graph being cut into pieces. Some tokens may still refer to other tokens outside the `span`, thus resulting in an out of bounds error when that token is being accessed.

## Description
In `doc.from_array` I have added code that checks the offset of the head for each token, and does not copy the value unless that token is inside the doc : `if (i+value) in range(self.length)`. The token head defaults to 0 (i.e. itself) if the value is not copied/set.

This fix feels a little hacky, so happy to get feedback. Also currently the actual dependency link (e.g. `ccomp`) is being copied even if the head isn't, but I think we need that to ensure other cases keep working where a token refers to itself as head.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
