### PR TITLE
Bugfix/issue 3968

### DIFF
--- a/.github/contributors/FallakAsad.md
+++ b/.github/contributors/FallakAsad.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI GmbH](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [X] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           |                      |
+| Company name (if applicable)   |                      |
+| Title or role (if applicable)  |                      |
+| Date                           |                      |
+| GitHub username                |                      |
+| Website (optional)             |                      |

--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -172,12 +172,8 @@ class Scorer(object):
                     self.ner_per_ents[ent.label_].fp += 1
                 else:
                     cand_ents.add((ent.label_, first, last))
-                    current_ent[ent.label_].add(
-                        tuple(x for x in cand_ents if x[0] == ent.label_)
-                    )
-                    current_gold[ent.label_].add(
-                        tuple(x for x in gold_ents if x[0] == ent.label_)
-                    )
+                    [current_ent[ent.label_].add(x) for x in cand_ents if x[0] == ent.label_]
+                    [current_gold[ent.label_].add(x) for x in gold_ents if x[0] == ent.label_]
             # Scores per ent
             [
                 v.score_set(current_ent[k], current_gold[k])

--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -172,8 +172,8 @@ class Scorer(object):
                     self.ner_per_ents[ent.label_].fp += 1
                 else:
                     cand_ents.add((ent.label_, first, last))
-                    [current_ent[ent.label_].add(x) for x in cand_ents if x[0] == ent.label_]
-                    [current_gold[ent.label_].add(x) for x in gold_ents if x[0] == ent.label_]
+                    current_ent[ent.label_].update([x for x in cand_ents if x[0] == ent.label_])
+                    current_gold[ent.label_].update([x for x in gold_ents if x[0] == ent.label_])
             # Scores per ent
             [
                 v.score_set(current_ent[k], current_gold[k])

--- a/spacy/tests/regression/test_issue3968.py
+++ b/spacy/tests/regression/test_issue3968.py
@@ -1,0 +1,34 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from spacy.gold import GoldParse
+from spacy.scorer import Scorer
+from ..util import get_doc
+
+test_samples = [
+    [
+        "100 - 200",
+        {
+            "entities": [
+                [0, 3, "CARDINAL"],
+                [6, 9, "CARDINAL"]
+            ]
+        }
+    ]
+]
+
+def test_issue3625(en_vocab):
+    scorer = Scorer()
+    for input_, annot in test_samples:
+        doc = get_doc(en_vocab, words = input_.split(' '), ents = [[0,1,'CARDINAL'], [2,3,'CARDINAL']]);    
+        gold = GoldParse(doc, entities = annot['entities'])
+        scorer.score(doc, gold)
+    results = scorer.scores
+
+    # Expects total accuracy and accuracy for each each entity to be 100%
+    assert results['ents_p'] == 100
+    assert results['ents_f'] == 100
+    assert results['ents_r'] == 100
+    assert results['ents_per_type']['CARDINAL']['p'] == 100
+    assert results['ents_per_type']['CARDINAL']['f'] == 100
+    assert results['ents_per_type']['CARDINAL']['r'] == 100


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
Per entity calculations for  f-score, precision and recall were incorrect because of bug in spacy/scorer.py. See issue https://github.com/explosion/spaCy/issues/3968 for more details.

### Types of change
A bug fix in spacy/scorer.py for invalid per entity values for f-score, precision and recall. I ran tests with "pytest [spacy directory] --slow" command 

Test result before my changes:
1967 passed, 319 skipped, 60 xfailed, 1 warnings in 36.88 seconds

Test result after my changes:
1968 passed, 319 skipped, 60 xfailed, 1 warnings in 36.83 seconds 

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ x ] I have submitted the spaCy Contributor Agreement.
- [ x ] I ran the tests, and all new and existing tests passed.
- [ x ] My changes don't require a change to the documentation, or if they do, I've added all required information.
