### PR TITLE
Fix gold.docs_to_json() to match JSON train format

### DIFF
--- a/spacy/gold.pyx
+++ b/spacy/gold.pyx
@@ -647,7 +647,7 @@ def docs_to_json(docs, id=0):
                 json_sent["tokens"].append(json_token)
             json_para["sentences"].append(json_sent)
         json_doc["paragraphs"].append(json_para)
-    return json_doc
+    return [json_doc]
 
 
 def biluo_tags_from_offsets(doc, entities, missing="O"):

--- a/spacy/tests/test_gold.py
+++ b/spacy/tests/test_gold.py
@@ -7,6 +7,7 @@ from spacy.gold import spans_from_biluo_tags, GoldParse
 from spacy.gold import GoldCorpus, docs_to_json
 from spacy.lang.en import English
 from spacy.tokens import Doc
+from .util import make_tempdir
 
 
 def test_gold_biluo_U(en_vocab):
@@ -81,12 +82,12 @@ def test_docs_to_json_roundtrip(tmpdir):
     for i in range(1, len(doc)):
         doc[i].is_sent_start = False
 
-    json_str = srsly.json_dumps(docs_to_json(doc))
-    json_file = tmpdir.mkdir("docs_to_json_roundtrip").join("flew.json")
-    with open(json_file, "w") as fileh:
-        fileh.write(json_str)
+    with make_tempdir() as tmpdir:
+        json_file = tmpdir / "flew.json"
+        srsly.write_json(json_file, docs_to_json(doc))
 
-    goldcorpus = GoldCorpus(str(json_file), str(json_file))
+        goldcorpus = GoldCorpus(json_file, json_file)
+
     (reloaded_doc, goldparse) = next(goldcorpus.train_docs(nlp))
 
     assert goldcorpus.count_train() == len(doc)


### PR DESCRIPTION
The output of `gold.docs_to_json()` was missing the outer list brackets and
couldn't be loaded by GoldCorpus.

* added brackets
* added roundtrip test of `gold.docs_to_json()` / GoldCorpus

Also, `docs_to_json()` puts each doc in its own paragraph rather than its own document. Is this intentional?