### PR TITLE
💫 Improve error message when model.from_bytes() dies

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -406,6 +406,8 @@ class Errors(object):
     E141 = ("Entity vectors should be of length {required} instead of the provided {found}.")
     E142 = ("Unsupported loss_function '{loss_func}'. Use either 'L2' or 'cosine'")
     E143 = ("Labels for component '{name}' not initialized. Did you forget to call add_label()?")
+    E144 = ("Error deserializing model. Check that the config used to create the "
+            "component matches the model being loaded.")
 
 
 @add_codes

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -1332,7 +1332,7 @@ class EntityLinker(Pipe):
             try: 
                 self.model.from_bytes(p.open("rb").read())
             except AttributeError:
-                raise ValueError(Errors.E144)
+                raise ValueError(Errors.E149)
 
         def load_kb(p):
             kb = KnowledgeBase(vocab=self.vocab, entity_vector_length=self.cfg["entity_width"])

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -168,7 +168,10 @@ class Pipe(object):
                 self.cfg["pretrained_vectors"] = self.vocab.vectors.name
             if self.model is True:
                 self.model = self.Model(**self.cfg)
-            self.model.from_bytes(b)
+            try:
+                self.model.from_bytes(b)
+            except AttributeError:
+                raise ValueError(Errors.E144)
 
         deserialize = OrderedDict()
         deserialize["cfg"] = lambda b: self.cfg.update(srsly.json_loads(b))
@@ -197,7 +200,10 @@ class Pipe(object):
                 self.cfg["pretrained_vectors"] = self.vocab.vectors.name
             if self.model is True:
                 self.model = self.Model(**self.cfg)
-            self.model.from_bytes(p.open("rb").read())
+            try:
+                self.model.from_bytes(p.open("rb").read())
+            except AttributeError:
+                raise ValueError(Errors.E144)
 
         deserialize = OrderedDict()
         deserialize["cfg"] = lambda p: self.cfg.update(_load_cfg(p))
@@ -563,7 +569,10 @@ class Tagger(Pipe):
                     "token_vector_width",
                     self.cfg.get("token_vector_width", 96))
                 self.model = self.Model(self.vocab.morphology.n_tags, **self.cfg)
-            self.model.from_bytes(b)
+            try:
+                self.model.from_bytes(b)
+            except AttributeError:
+                raise ValueError(Errors.E144)
 
         def load_tag_map(b):
             tag_map = srsly.msgpack_loads(b)
@@ -601,7 +610,10 @@ class Tagger(Pipe):
             if self.model is True:
                 self.model = self.Model(self.vocab.morphology.n_tags, **self.cfg)
             with p.open("rb") as file_:
-                self.model.from_bytes(file_.read())
+                try:
+                    self.model.from_bytes(file_.read())
+                except AttributeError:
+                    raise ValueError(Errors.E144)
 
         def load_tag_map(p):
             tag_map = srsly.read_msgpack(p)
@@ -1295,9 +1307,12 @@ class EntityLinker(Pipe):
 
     def from_disk(self, path, exclude=tuple(), **kwargs):
         def load_model(p):
-             if self.model is True:
+            if self.model is True:
                 self.model = self.Model(**self.cfg)
-             self.model.from_bytes(p.open("rb").read())
+            try: 
+                self.model.from_bytes(p.open("rb").read())
+            except AttributeError:
+                raise ValueError(Errors.E144)
 
         def load_kb(p):
             kb = KnowledgeBase(vocab=self.vocab, entity_vector_length=self.cfg["entity_width"])

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -170,7 +170,7 @@ class Pipe(object):
             try:
                 self.model.from_bytes(b)
             except AttributeError:
-                raise ValueError(Errors.E144)
+                raise ValueError(Errors.E149)
 
         deserialize = OrderedDict()
         deserialize["cfg"] = lambda b: self.cfg.update(srsly.json_loads(b))

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -612,7 +612,7 @@ class Tagger(Pipe):
                 try:
                     self.model.from_bytes(file_.read())
                 except AttributeError:
-                    raise ValueError(Errors.E144)
+                    raise ValueError(Errors.E149)
 
         def load_tag_map(p):
             tag_map = srsly.read_msgpack(p)

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -571,7 +571,7 @@ class Tagger(Pipe):
             try:
                 self.model.from_bytes(b)
             except AttributeError:
-                raise ValueError(Errors.E144)
+                raise ValueError(Errors.E149)
 
         def load_tag_map(b):
             tag_map = srsly.msgpack_loads(b)

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -202,7 +202,7 @@ class Pipe(object):
             try:
                 self.model.from_bytes(p.open("rb").read())
             except AttributeError:
-                raise ValueError(Errors.E144)
+                raise ValueError(Errors.E149)
 
         deserialize = OrderedDict()
         deserialize["cfg"] = lambda p: self.cfg.update(_load_cfg(p))

--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -669,6 +669,6 @@ cdef class Parser:
                 try:
                     self.model.from_bytes(msg['model'])
                 except AttributeError:
-                    raise ValueError(Errors.E144)
+                    raise ValueError(Errors.E149)
             self.cfg.update(cfg)
         return self

--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -634,7 +634,7 @@ cdef class Parser:
             try:
                 self.model.from_bytes(bytes_data)
             except AttributeError:
-                raise ValueError(Errors.E144)
+                raise ValueError(Errors.E149)
             self.cfg.update(cfg)
         return self
 

--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -631,7 +631,10 @@ cdef class Parser:
                 cfg = {}
             with (path / 'model').open('rb') as file_:
                 bytes_data = file_.read()
-            self.model.from_bytes(bytes_data)
+            try:
+                self.model.from_bytes(bytes_data)
+            except AttributeError:
+                raise ValueError(Errors.E144)
             self.cfg.update(cfg)
         return self
 
@@ -663,6 +666,9 @@ cdef class Parser:
             else:
                 cfg = {}
             if 'model' in msg:
-                self.model.from_bytes(msg['model'])
+                try:
+                    self.model.from_bytes(msg['model'])
+                except AttributeError:
+                    raise ValueError(Errors.E144)
             self.cfg.update(cfg)
         return self


### PR DESCRIPTION
When Thinc's model.from_bytes() is called with a mismatched model, often
we get a particularly ungraceful error,

e.g. "AttributeError: FunctionLayer has no attribute G"

This is because we're trying to load the parameters for something like
a LayerNorm layer, and the model architecture has some other layer there
instead. This is obviously terrible, especially since the error *type*
is wrong.

I've changed it to raise a ValueError. The error message is still
probably a bit terse, but it's hard to be sure exactly what's gone
wrong.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
