### PR TITLE
Update GoldParse attributes in API docs

### DIFF
--- a/website/docs/api/goldparse.md
+++ b/website/docs/api/goldparse.md
@@ -45,10 +45,11 @@ Whether the provided syntactic annotations form a projective dependency tree.
 
 | Name                              | Type | Description                                                                                                                                              |
 | --------------------------------- | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `words`                           | list | The words.                                                                                                                                               |
 | `tags`                            | list | The part-of-speech tag annotations.                                                                                                                      |
 | `heads`                           | list | The syntactic head annotations.                                                                                                                          |
 | `labels`                          | list | The syntactic relation-type annotations.                                                                                                                 |
-| `ents`                            | list | The named entity annotations.                                                                                                                            |
+| `ner`                             | list | The named entity annotations as BILUO tags.                                                                                                              |
 | `cand_to_gold`                    | list | The alignment from candidate tokenization to gold tokenization.                                                                                          |
 | `gold_to_cand`                    | list | The alignment from gold tokenization to candidate tokenization.                                                                                          |
 | `cats` <Tag variant="new">2</Tag> | list | Entries in the list should be either a label, or a `(start, end, label)` triple. The tuple form is used for categories applied to spans of the document. |


### PR DESCRIPTION
## Description

* add `words`
* update name of entity list to `ner`

I think it might be a bit more consistent to have `ner` named `entities` or `ents` (and `ents` is actually set somewhere to `None`, which is a bit confusing), but it looks like renaming it would be a non-trivial decision.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Documentation.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
