### PR TITLE
💫 Support custom language factory setting in meta.json

### DIFF
--- a/spacy/util.py
+++ b/spacy/util.py
@@ -160,7 +160,10 @@ def load_model_from_path(model_path, meta=False, **overrides):
     pipeline from meta.json and then calls from_disk() with path."""
     if not meta:
         meta = get_model_meta(model_path)
-    cls = get_lang_class(meta["lang"])
+    # Support language factories registered via entry points (e.g. custom
+    # language subclass) while keeping top-level language identifier "lang"
+    lang = meta.get("lang_factory", meta["lang"])
+    cls = get_lang_class(lang)
     nlp = cls(meta=meta, **overrides)
     pipeline = meta.get("pipeline", [])
     disable = overrides.get("disable", [])


### PR DESCRIPTION
## Description
This PR adds support for an optional `"lang_factory"` name in the `meta.json` that will be used to initialize the base language class on load (instead of `"lang"`).

For instance, imagine an extension package that implements a custom `Language` subclass (e.g. to integrate another machine learning model or library). Models depending on this package can require it in their `setup.py` and if the custom `Language` class is registered as a `spacy_languages` entry point, it can be initialized automatically on load. For example: `xyz = some_package:CustomLanguage`.

However, `Language` subclass != human language. Given the entry point for `xyz`, the model package would now have to specify `"lang": "xyz"` and be called `xyz_model_name`. If the custom subclass is language-agnostic, you'd have to create a bunch of sub-subclasses like `en-xyz`.

This change allows specifying `"lang": "en"` and `"lang_factory": "xyz"` instead. The language factory will get access to the `nlp` object and its `meta`, so it'll be able to be initialize language-specific stuff based on the `meta["lang"]` (e.g. a tokenizer).

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
