### PR TITLE
Add links to tokenizer API docs to refer relevant information.

### DIFF
--- a/website/docs/api/tokenizer.md
+++ b/website/docs/api/tokenizer.md
@@ -5,7 +5,7 @@ tag: class
 source: spacy/tokenizer.pyx
 ---
 
-Segment text, and create `Doc` objects with the discovered segment boundaries. For a deeper understanding read about [how spaCy's tokenizer works](/usage/linguistic-features#how-tokenizer-works).
+Segment text, and create `Doc` objects with the discovered segment boundaries. For a deeper understanding, see the docs on [how spaCy's tokenizer works](/usage/linguistic-features#how-tokenizer-works).
 
 ## Tokenizer.\_\_init\_\_ {#init tag="method"}
 

--- a/website/docs/api/tokenizer.md
+++ b/website/docs/api/tokenizer.md
@@ -5,7 +5,7 @@ tag: class
 source: spacy/tokenizer.pyx
 ---
 
-Segment text, and create `Doc` objects with the discovered segment boundaries.
+Segment text, and create `Doc` objects with the discovered segment boundaries. For a deeper understanding read about [how spaCy's tokenizer works](/usage/linguistic-features#how-tokenizer-works).
 
 ## Tokenizer.\_\_init\_\_ {#init tag="method"}
 
@@ -109,7 +109,7 @@ if no suffix rules match.
 
 Add a special-case tokenization rule. This mechanism is also used to add custom
 tokenizer exceptions to the language data. See the usage guide on
-[adding languages](/usage/adding-languages#tokenizer-exceptions) for more
+[adding languages](/usage/adding-languages#tokenizer-exceptions) and [linguistic features](/usage/linguistic-features#special-cases) for more
 details and examples.
 
 > #### Example


### PR DESCRIPTION
## Description
On [Gitter](https://gitter.im/explosion/spaCy) @johann-petrak asked about some Tokenizer information which are not linked to from the API docs.
This PR adds 2 links to the Tokenizer API docs so relevant information is a bit more accessible.

### Types of change
Doc change

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
