### PR TITLE
WIP: attempt 2 to fix nlp deserialization

### DIFF
--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -176,21 +176,28 @@ class EntityRuler(object):
 
         DOCS: https://spacy.io/api/entityruler#add_patterns
         """
-        for entry in patterns:
-            label = entry["label"]
-            if "id" in entry:
-                label = self._create_label(label, entry["id"])
-            pattern = entry["pattern"]
-            if isinstance(pattern, basestring_):
-                self.phrase_patterns[label].append(self.nlp(pattern))
-            elif isinstance(pattern, list):
-                self.token_patterns[label].append(pattern)
-            else:
-                raise ValueError(Errors.E097.format(pattern=pattern))
-        for label, patterns in self.token_patterns.items():
-            self.matcher.add(label, None, *patterns)
-        for label, patterns in self.phrase_patterns.items():
-            self.phrase_matcher.add(label, None, *patterns)
+        # disable the nlp components after this one in case they hadn't been initialized / deserialised yet
+        try:
+            current_index = self.nlp.pipe_names.index(self.name)
+            subsequent_pipes = [pipe for pipe in self.nlp.pipe_names[current_index + 1:]]
+        except ValueError:
+            subsequent_pipes = []
+        with self.nlp.disable_pipes(*subsequent_pipes):
+            for entry in patterns:
+                label = entry["label"]
+                if "id" in entry:
+                    label = self._create_label(label, entry["id"])
+                pattern = entry["pattern"]
+                if isinstance(pattern, basestring_):
+                    self.phrase_patterns[label].append(self.nlp(pattern))
+                elif isinstance(pattern, list):
+                    self.token_patterns[label].append(pattern)
+                else:
+                    raise ValueError(Errors.E097.format(pattern=pattern))
+            for label, patterns in self.token_patterns.items():
+                self.matcher.add(label, None, *patterns)
+            for label, patterns in self.phrase_patterns.items():
+                self.phrase_matcher.add(label, None, *patterns)
 
     def _split_label(self, label):
         """Split Entity label into ent_label and ent_id if it contains self.ent_id_sep

--- a/spacy/tests/regression/test_issue4042.py
+++ b/spacy/tests/regression/test_issue4042.py
@@ -1,0 +1,40 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+import spacy
+from spacy.lang.en import English
+from spacy.pipeline import EntityRuler
+from spacy.tests.util import make_tempdir
+from spacy.util import ensure_path
+
+
+def test_issue4042():
+    """Test that serialization of an EntityRuler before NER works fine."""
+    nlp = English()
+
+    # add ner pipe
+    ner = nlp.create_pipe("ner")
+    ner.add_label("SOME_LABEL")
+    nlp.add_pipe(ner)
+    nlp.begin_training()
+
+    # Add entity ruler
+    ruler = EntityRuler(nlp)
+    patterns = [
+        {"label": "MY_ORG", "pattern": "Apple"},
+        {"label": "MY_GPE", "pattern": [{"lower": "san"}, {"lower": "francisco"}]},
+    ]
+    ruler.add_patterns(patterns)
+    nlp.add_pipe(ruler, before="ner")  # works fine with "after"
+    doc1 = nlp("What do you think about Apple ?")
+    assert doc1.ents[0].label_ == "MY_ORG"
+
+    with make_tempdir() as d:
+        output_dir = ensure_path(d)
+        if not output_dir.exists():
+            output_dir.mkdir()
+        nlp.to_disk(output_dir)
+
+        nlp2 = spacy.load(output_dir)
+        doc2 = nlp2("What do you think about Apple ?")
+        assert doc2.ents[0].label_ == "MY_ORG"


### PR DESCRIPTION
Trying to fix Issue #4042 (alternative) by disabling the subsequent `nlp` pipeline components in the `EntityRuler`.

Does not work yet...

## Description
* In the EntityRuler, when calling `nlp()`, first disable all pipes that are coming after it by checking `self.nlp.pipe_names.index(self.name)`

### Types of change
Bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
