### PR TITLE
Fix get_token_attr for NORM

### DIFF
--- a/spacy/tests/regression/test_issue4002.py
+++ b/spacy/tests/regression/test_issue4002.py
@@ -6,7 +6,6 @@ from spacy.matcher import PhraseMatcher
 from spacy.tokens import Doc
 
 
-@pytest.mark.xfail
 def test_issue4002(en_vocab):
     """Test that the PhraseMatcher can match on overwritten NORM attributes.
     """

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -49,6 +49,10 @@ cdef int bounds_check(int i, int length, int padding) except -1:
 cdef attr_t get_token_attr(const TokenC* token, attr_id_t feat_name) nogil:
     if feat_name == LEMMA:
         return token.lemma
+    elif feat_name == NORM:
+        if not token.norm:
+            return token.lex.norm
+        return token.norm
     elif feat_name == POS:
         return token.pos
     elif feat_name == TAG:


### PR DESCRIPTION
Fix for Issue #4002 , where the `PhraseMatcher` was not correctly matching `norm` attributes.

## Description
The `Token` property `norm` either returns `self.c.norm`, or `self.c.lex.norm` if the former equals `0`, cf [`token.pyx`](https://github.com/explosion/spaCy/blob/master/spacy/tokens/token.pyx#L301).

For consistency, the `get_token_attr` from `Doc` then needs to implement a similar logic when querying the `NORM` attribute.

This fixes the failing unit test previously implemented by @ines, and hopefully also fixes the original issue described in #4002.

### Types of change
Bug fix

## Checklist 
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
