### PR TITLE
Fix typo in requirements section of pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools",
-            "wheel>0.32.0.<0.33.0",
+            "wheel>0.32.0,<0.33.0",
             "Cython",
             "cymem>=2.0.2,<2.1.0",
             "preshed>=2.0.1,<2.1.0",


### PR DESCRIPTION
There was a typo in pyproject.toml.  This patch fixes the issue.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ ] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
