### PR TITLE
💫 Require downloaded model in pkg_resources so it can be used in same session

### DIFF
--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -6,6 +6,7 @@ import requests
 import os
 import subprocess
 import sys
+import pkg_resources
 from wasabi import Printer
 
 from .link import link
@@ -67,6 +68,16 @@ def download(model, direct=False, *pip_args):
                     "the model via its full package name: "
                     "nlp = spacy.load('{}')".format(model, model_name),
                 )
+        # If a model is downloaded and then loaded within the same process, our
+        # is_package check currently fails, because pkg_resources.working_set
+        # is not refreshed automatically (see #3923). We're trying to work
+        # around this here be requiring the package explicitly.
+        try:
+            pkg_resources.working_set.require(model_name)
+        except:  # noqa: E722
+            # Maybe it's possible to remove this – mostly worried about cross-
+            # platform and cross-Python copmpatibility here
+            pass
 
 
 def get_json(url, desc):


### PR DESCRIPTION
Resolves #3923.

## Description

This PR attempts to resolve an inconvenience of the `download` command. If a model is downloaded and then loaded within the same process, our `is_package` check currently fails, because `pkg_resources.working_set` is not refreshed automatically (see #3923). This can commonly happen in Jupyter notebooks if you do something like:

```
In [1]: !python -m spacy download de_core_news_sm
In [2]: import spacy
        nlp = spacy.load("de_core_news_sm")
```

To work around this, we can try and require the newly installed package explicitly using `pkg_resources.working_set.require`. 

The following test case works without the code proposed in this PR (if you want to try it, make sure the model isn't installed):

```python
from spacy.cli import download
from spacy.util import is_package
import pkg_resources

model = "de_core_news_sm"

download(model)
print(is_package(model))  # False
pkg_resources.working_set.require(model)
print(is_package(model))  # True
```

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
