### PR TITLE
💫 Support displaCy user colors via entry point

### DIFF
--- a/spacy/displacy/render.py
+++ b/spacy/displacy/render.py
@@ -5,7 +5,7 @@ import uuid
 
 from .templates import TPL_DEP_SVG, TPL_DEP_WORDS, TPL_DEP_ARCS, TPL_ENTS
 from .templates import TPL_ENT, TPL_ENT_RTL, TPL_FIGURE, TPL_TITLE, TPL_PAGE
-from ..util import minify_html, escape_html
+from ..util import minify_html, escape_html, get_entry_points
 
 DEFAULT_LANG = "en"
 DEFAULT_DIR = "ltr"
@@ -237,6 +237,9 @@ class EntityRenderer(object):
             "CARDINAL": "#e4e7d2",
             "PERCENT": "#e4e7d2",
         }
+        user_colors = get_entry_points("spacy_displacy_colors")
+        for user_color in user_colors.values():
+            colors.update(user_color)
         colors.update(options.get("colors", {}))
         self.default_color = "#ddd"
         self.colors = colors


### PR DESCRIPTION
## Description

This PR was inspired by a nice little feature I first saw in @ICLRandD's [Blackstone project](https://github.com/ICLRandD/Blackstone). The library ships with a [custom color theme for displaCy](https://github.com/ICLRandD/Blackstone#visualising-entities) to highlight the new entity types it adds.

This PR adds the ability for third-party packages (including models) to expose `spacy_displacy_colors` [entry points](https://spacy.io/usage/saving-loading#entry-points) to add to or overwrite the built-in color scheme.

### Example

Imagine a package setup like this:

```python
# snek.py
displacy_colors = {"SNEK": "#3dff74"}
```

```python
# setup.py
from setuptools import setup

setup(
    name="snek",
    entry_points={
        "spacy_displacy_colors": ["colors = snek:displacy_colors"],
    },
)
```

The key `colors` here doesn't matter, but it needs *some* key to work. The label `SNEK` will now have the color `#3dff74` assigned, and when displaCy renders an entity with that label, the new custom color will be used. The end user doesn't have to do anything to make this work – but they can override it via the regular `displacy` settings if they want to.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
