### PR TITLE
Provide more info in cycle error message E069

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -242,7 +242,8 @@ class Errors(object):
             "Tag sequence:\n{tags}")
     E068 = ("Invalid BILUO tag: '{tag}'.")
     E069 = ("Invalid gold-standard parse tree. Found cycle between word "
-            "IDs: {cycle}")
+            "IDs: {cycle} (tokens: {cycle_tokens}) in the document starting "
+            "with tokens: {doc_tokens}.")
     E070 = ("Invalid gold-standard data. Number of documents ({n_docs}) "
             "does not align with number of annotations ({n_annots}).")
     E071 = ("Error creating lexeme: specified orth ID ({orth}) does not "

--- a/spacy/gold.pyx
+++ b/spacy/gold.pyx
@@ -590,7 +590,7 @@ cdef class GoldParse:
 
         cycle = nonproj.contains_cycle(self.heads)
         if cycle is not None:
-            raise ValueError(Errors.E069.format(cycle=cycle))
+            raise ValueError(Errors.E069.format(cycle=cycle, cycle_tokens=" ".join(["'{}'".format(self.words[tok_id]) for tok_id in cycle]), doc_tokens=" ".join(words[:50])))
 
     def __len__(self):
         """Get the number of gold-standard tokens.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Provide the tokens in the cycle and the first 50 tokens from document in the error message so it's easier to track down the location of the cycle in the data.

Addresses feature request in #3698.

The error message now looks like this:

```
ValueError: [E069] Invalid gold-standard parse tree. Found cycle between word 
IDs: {0, 1} (tokens: 'In'  'the') in the document starting with tokens: In the 
summer of 2005 , a picture that people have long been looking forward to started 
emerging with frequency in various major Hong Kong media . With their unique charm 
, these well - known cartoon images once again caused Hong Kong to be a focus 
of worldwide attention.
```

The document ID could be added to GoldParse at some point, but with the current training format you really need a non-existent paragraph ID, so I think this simpler solution should provide enough information for users to track down cycles in typical training data.

### Types of change

Enhancement.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
