### PR TITLE
Make the emoticon list a raw string

### DIFF
--- a/spacy/lang/tokenizer_exceptions.py
+++ b/spacy/lang/tokenizer_exceptions.py
@@ -109,7 +109,7 @@ for orth in [
 
 
 emoticons = set(
-    """
+    r"""
 :)
 :-)
 :))


### PR DESCRIPTION
While working on an unrelated task I got warnings about an unsupported
escape sequence (`"\("`) in the tokenizer exceptions. Making the
tokenizer exceptions a raw string makes this warning go away.

The specific string that triggered this is `¯\(ツ)/¯`.

<!--- Provide a general summary of your changes in the title. -->


### Types of change

I guess this is a minor bug fix?

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and no results changed
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
