### PR TITLE
Make enabling/disabling jupyter mode more explicit

### DIFF
--- a/website/docs/usage/visualizers.md
+++ b/website/docs/usage/visualizers.md
@@ -201,11 +201,14 @@ doc2 = nlp(LONG_NEWS_ARTICLE)
 displacy.render(doc2, style="ent")
 ```
 
-> #### Enabling or disabling Jupyter mode
->
-> To explicitly enable or disable "Jupyter mode", you can use the jupyter`
-> keyword argument – e.g. to return raw HTML in a notebook, or to force Jupyter
-> rendering if auto-detection fails.
+<Infobox variant="warning" title="Important note">
+
+To explicitly enable or disable "Jupyter mode", you can use the jupyter`
+keyword argument – e.g. to return raw HTML in a notebook, or to force Jupyter
+rendering if auto-detection fails.
+
+</Infobox>
+
 
 ![displaCy visualizer in a Jupyter notebook](../images/displacy_jupyter.jpg)
 
@@ -281,7 +284,7 @@ nlp = spacy.load("en_core_web_sm")
 sentences = [u"This is an example.", u"This is another one."]
 for sent in sentences:
     doc = nlp(sent)
-    svg = displacy.render(doc, style="dep")
+    svg = displacy.render(doc, style="dep", jupyter=False)
     file_name = '-'.join([w.text for w in doc if not w.is_punct]) + ".svg"
     output_path = Path("/images/" + file_name)
     output_path.open("w", encoding="utf-8").write(svg)

--- a/website/docs/usage/visualizers.md
+++ b/website/docs/usage/visualizers.md
@@ -203,7 +203,7 @@ displacy.render(doc2, style="ent")
 
 <Infobox variant="warning" title="Important note">
 
-To explicitly enable or disable "Jupyter mode", you can use the jupyter`
+To explicitly enable or disable "Jupyter mode", you can use the `jupyter`
 keyword argument – e.g. to return raw HTML in a notebook, or to force Jupyter
 rendering if auto-detection fails.
 


### PR DESCRIPTION
To avoid a commonly reported error, make the enabling/disabling of `jupyter` mode more explicit in the docs + in the longer example code snippet.

### Types of change
change to the documentation

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
