### PR TITLE
Added RONEC to universe.json

### DIFF
--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -1601,7 +1601,7 @@
                 "website": "https://explosion.ai"
             }
         },
-                {
+        {
             "id": "negspacy",
             "title": "negspaCy",
             "slogan": "spaCy pipeline object for negating concepts in text based on the NegEx algorithm.",
@@ -1630,7 +1630,27 @@
                 "github": "jenojp",
                 "twitter": "jenojp"
             }
-        }
+        },
+		{
+			"id": "RONEC-v1.0",
+            "title": "RONEC - Romanian Named Entity Corpus",
+            "slogan": "Named Entity Recognition corpus for Romanian language.",
+            "github": "dumitrescustefan/ronec",
+            "url": "https://github.com/dumitrescustefan/ronec",
+            "description": "The corpus holds 5127 sentences, annotated with 16 classes, with a total of 26376 annotated entities. The corpus comes into two formats: BRAT and CONLLUP.",
+            "category": ["standalone"],
+            "tags": ["ner", "romanian"],
+            "thumb":"https://github.com/dumitrescustefan/ronec/blob/master/res/thumb.png",
+            "code_example": [
+                "python3 convert_spacy.py ronec/conllup/ronec.conllup output",
+				"python3 -m spacy train ro models output/train_ronec.json output/train_ronec.json -p ent"
+            ],
+            "author": "Stefan Daniel Dumitrescu, Andrei-Marius Avram",
+            "author_links": {
+                "github": "dumitrescustefan",
+                "github": "avramandrei"
+            }
+		}
     ],
 
     "categories": [


### PR DESCRIPTION
Added RONEC (Romanian Named Entity Corpus) to resources in spaCy's universe.

## Description

Version 1.0 of this free corpus holds 5127 sentences, annotated with 16 classes, with a total of 26376 annotated entities. The corpus comes into two formats: BRAT and CONLLUP. The CONLLUP file is annotated with lemma, POSes and dependency parsing information with NLP-Cube. 

More information at: https://github.com/dumitrescustefan/ronec

## Integration with spaCy

Created a script that converts the corpus to json spaCy's format. Trained and evaluated a model.

More information at: https://github.com/dumitrescustefan/ronec/tree/master/spacy

## Checklist

- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
