### PR TITLE
Check for is_tagged/is_parsed for Matcher attrs

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -441,11 +441,11 @@ class Errors(object):
             "patterns. Please use the option validate=True with Matcher, "
             "PhraseMatcher, or EntityRuler for more details.")
     E155 = ("The pipeline needs to include a tagger in order to use "
-            "PhraseMatcher with the attributes POS, TAG, or LEMMA. Try using "
-            "nlp() instead of nlp.make_doc() or list(nlp.pipe()) instead of "
-            "list(nlp.tokenizer.pipe()).")
+            "Matcher or PhraseMatcher with the attributes POS, TAG, or LEMMA. "
+            "Try using nlp() instead of nlp.make_doc() or list(nlp.pipe()) "
+            "instead of list(nlp.tokenizer.pipe()).")
     E156 = ("The pipeline needs to include a parser in order to use "
-            "PhraseMatcher with the attribute DEP. Try using "
+            "Matcher or PhraseMatcher with the attribute DEP. Try using "
             "nlp() instead of nlp.make_doc() or list(nlp.pipe()) instead of "
             "list(nlp.tokenizer.pipe()).")
     E157 = ("Can't render negative values for dependency arc start or end. "

--- a/spacy/matcher/matcher.pxd
+++ b/spacy/matcher/matcher.pxd
@@ -67,3 +67,4 @@ cdef class Matcher:
     cdef public object _callbacks
     cdef public object _extensions
     cdef public object _extra_predicates
+    cdef public object _seen_attrs

--- a/spacy/tests/matcher/test_matcher_api.py
+++ b/spacy/tests/matcher/test_matcher_api.py
@@ -344,3 +344,39 @@ def test_dependency_matcher_compile(dependency_matcher):
 #     assert matches[0][1] == [[3, 1, 2]]
 #     assert matches[1][1] == [[4, 3, 3]]
 #     assert matches[2][1] == [[4, 3, 2]]
+
+
+def test_attr_pipeline_checks(en_vocab):
+    doc1 = Doc(en_vocab, words=["Test"])
+    doc1.is_parsed = True
+    doc2 = Doc(en_vocab, words=["Test"])
+    doc2.is_tagged = True
+    doc3 = Doc(en_vocab, words=["Test"])
+    # DEP requires is_parsed
+    matcher = Matcher(en_vocab)
+    matcher.add("TEST", None, [{"DEP": "a"}])
+    matcher(doc1)
+    with pytest.raises(ValueError):
+        matcher(doc2)
+    with pytest.raises(ValueError):
+        matcher(doc3)
+    # TAG, POS, LEMMA require is_tagged
+    for attr in ("TAG", "POS", "LEMMA"):
+        matcher = Matcher(en_vocab)
+        matcher.add("TEST", None, [{attr: "a"}])
+        matcher(doc2)
+        with pytest.raises(ValueError):
+            matcher(doc1)
+        with pytest.raises(ValueError):
+            matcher(doc3)
+    # TEXT/ORTH only require tokens
+    matcher = Matcher(en_vocab)
+    matcher.add("TEST", None, [{"ORTH": "a"}])
+    matcher(doc1)
+    matcher(doc2)
+    matcher(doc3)
+    matcher = Matcher(en_vocab)
+    matcher.add("TEST", None, [{"TEXT": "a"}])
+    matcher(doc1)
+    matcher(doc2)
+    matcher(doc3)


### PR DESCRIPTION
## Description

Check for relevant components in the pipeline when Matcher is called, similar to the checks for PhraseMatcher in #4105.

* Matcher keeps track of attributes seen in added patterns

* when Matcher is called on a doc, check for is_tagged for LEMMA, TAG, POS and for is_parsed for DEP

Addresses issues like #4156.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Enhancement.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
