### PR TITLE
Adding double match for optional operator at the end

### DIFF
--- a/spacy/matcher/matcher.pxd
+++ b/spacy/matcher/matcher.pxd
@@ -17,6 +17,7 @@ cdef enum action_t:
     RETRY_ADVANCE = 0110
     MATCH_EXTEND = 1001
     MATCH_REJECT = 2000
+    MATCH_DOUBLE = 3000
 
 
 cdef enum quantifier_t:

--- a/spacy/tests/regression/test_issue4120.py
+++ b/spacy/tests/regression/test_issue4120.py
@@ -6,15 +6,15 @@ from spacy.matcher import Matcher
 from spacy.tokens import Doc
 
 
-@pytest.mark.xfail
 def test_issue4120(en_vocab):
     """Test that matches without a final {OP: ?} token are returned."""
     matcher = Matcher(en_vocab)
     matcher.add("TEST", None, [{"ORTH": "a"}, {"OP": "?"}])
     doc1 = Doc(en_vocab, words=["a"])
     assert len(matcher(doc1)) == 1  # works
+
     doc2 = Doc(en_vocab, words=["a", "b", "c"])
-    assert len(matcher(doc2)) == 2  # doesn't work
+    assert len(matcher(doc2)) == 2  # fixed
 
     matcher = Matcher(en_vocab)
     matcher.add("TEST", None, [{"ORTH": "a"}, {"OP": "?"}, {"ORTH": "b"}])
@@ -24,4 +24,4 @@ def test_issue4120(en_vocab):
     matcher = Matcher(en_vocab)
     matcher.add("TEST", None, [{"ORTH": "a"}, {"OP": "?"}, {"ORTH": "b", "OP": "?"}])
     doc4 = Doc(en_vocab, words=["a", "b", "b", "c"])
-    assert len(matcher(doc4)) == 3  # doesn't work
+    assert len(matcher(doc4)) == 3  # fixed


### PR DESCRIPTION
## Description
In the matching code, there was no explicit reasoning for when the pattern has a final `{OP: ?}` token, as reported by @adrianeboyd in Issue #4120.

To remedy this, I added a new type of matching `MATCH_DOUBLE` for when we're matching (`is_match`) at the end of the string (`is_final`) for this type of quantifier `ZERO_ONE`.

When this happens, two matches are added to the results: one with the last token, and one without. We need to specifically check that the length of the match is not zero though, otherwise the [unit test](https://github.com/explosion/spaCy/blob/master/spacy/tests/regression/test_issue2001-2500.py#L127) for Issue #2464 will include 0-0 and 1-1 matches and thus fail with a total count of 5 instead of 3 (hooray for that unit test!).

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
