### PR TITLE
Small retokenizer fix

### DIFF
--- a/spacy/tokens/_retokenize.pyx
+++ b/spacy/tokens/_retokenize.pyx
@@ -388,6 +388,7 @@ def _split(Doc doc, int token_index, orths, heads, attrs):
     cdef const LexemeC* lex
     cdef TokenC* token
     cdef TokenC orig_token = doc.c[token_index]
+    cdef int orig_length = len(doc)
 
     if(len(heads) != nb_subtokens):
         raise ValueError(Errors.E115)
@@ -408,7 +409,7 @@ def _split(Doc doc, int token_index, orths, heads, attrs):
     if to_process_tensor:
         xp = get_array_module(doc.tensor)
         doc.tensor = xp.append(doc.tensor, xp.zeros((nb_subtokens,doc.tensor.shape[1]), dtype="float32"), axis=0)
-    for token_to_move in range(doc.length - 1, token_index, -1):
+    for token_to_move in range(orig_length - 1, token_index, -1):
         doc.c[token_to_move + nb_subtokens - 1] = doc.c[token_to_move]
         if to_process_tensor:
             doc.tensor[token_to_move + nb_subtokens - 1] = doc.tensor[token_to_move]


### PR DESCRIPTION
## Description

This doesn't address a current bug, but it's a patch to avoid future problems.

The `_split()` function in `_retokenize.pyx` doubles the length of a `doc` and then moves tokens to create space for the new tokens. When it does, it accesses `doc.c[token_to_move]` in a loop, but the `token_to_move` variable was being defined on the **new** length of the `doc` - meaning that it was occassionally accessing data out of memory. I patched it here by making sure it's only reading tokens that actually existed in the original `doc` by introducing a new variable `orig_length`.

### Types of change
small fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
