### PR TITLE
Modify retokenizer to use span root attributes

### DIFF
--- a/spacy/tests/doc/test_retokenize_merge.py
+++ b/spacy/tests/doc/test_retokenize_merge.py
@@ -230,7 +230,18 @@ def test_doc_retokenize_spans_entity_merge_iob(en_vocab):
     assert doc[2].ent_iob_ == "I"
     assert doc[3].ent_iob_ == "B"
     with doc.retokenize() as retokenizer:
-        retokenizer.merge(doc[0:1])
+        retokenizer.merge(doc[0:2])
+    assert len(doc) == len(words) - 1
+    assert doc[0].ent_iob_ == "B"
+    assert doc[1].ent_iob_ == "I"
+
+    # Test that IOB stays consistent with provided IOB
+    words = ["a", "b", "c", "d", "e"]
+    doc = Doc(Vocab(), words=words)
+    with doc.retokenize() as retokenizer:
+        attrs = {"ent_type": "ent-abc", "ent_iob": 1}
+        retokenizer.merge(doc[0:3], attrs=attrs)
+        retokenizer.merge(doc[3:5], attrs=attrs)
     assert doc[0].ent_iob_ == "B"
     assert doc[1].ent_iob_ == "I"
 

--- a/spacy/tests/doc/test_retokenize_merge.py
+++ b/spacy/tests/doc/test_retokenize_merge.py
@@ -99,6 +99,41 @@ def test_doc_retokenize_spans_merge_tokens(en_tokenizer):
     assert doc[0].ent_type_ == "GPE"
 
 
+def test_doc_retokenize_spans_merge_tokens_default_attrs(en_tokenizer):
+    text = "The players start."
+    heads = [1, 1, 0, -1]
+    tokens = en_tokenizer(text)
+    doc = get_doc(tokens.vocab, words=[t.text for t in tokens], tags=["DT", "NN", "VBZ", "."], pos=["DET", "NOUN", "VERB", "PUNCT"], heads=heads)
+    assert len(doc) == 4
+    assert doc[0].text == "The"
+    assert doc[0].tag_ == "DT"
+    assert doc[0].pos_ == "DET"
+    with doc.retokenize() as retokenizer:
+        retokenizer.merge(doc[0:2])
+    assert len(doc) == 3
+    assert doc[0].text == "The players"
+    assert doc[0].tag_ == "NN"
+    assert doc[0].pos_ == "NOUN"
+    assert doc[0].lemma_ == "The players"
+    doc = get_doc(tokens.vocab, words=[t.text for t in tokens], tags=["DT", "NN", "VBZ", "."], pos=["DET", "NOUN", "VERB", "PUNCT"], heads=heads)
+    assert len(doc) == 4
+    assert doc[0].text == "The"
+    assert doc[0].tag_ == "DT"
+    assert doc[0].pos_ == "DET"
+    with doc.retokenize() as retokenizer:
+        retokenizer.merge(doc[0:2])
+        retokenizer.merge(doc[2:4])
+    assert len(doc) == 2
+    assert doc[0].text == "The players"
+    assert doc[0].tag_ == "NN"
+    assert doc[0].pos_ == "NOUN"
+    assert doc[0].lemma_ == "The players"
+    assert doc[1].text == "start ."
+    assert doc[1].tag_ == "VBZ"
+    assert doc[1].pos_ == "VERB"
+    assert doc[1].lemma_ == "start ."
+
+
 def test_doc_retokenize_spans_merge_heads(en_tokenizer):
     text = "I found a pilates class near work."
     heads = [1, 0, 2, 1, -3, -1, -1, -6]

--- a/spacy/tests/doc/test_retokenize_merge.py
+++ b/spacy/tests/doc/test_retokenize_merge.py
@@ -234,6 +234,8 @@ def test_doc_retokenize_spans_entity_merge_iob(en_vocab):
     assert doc[0].ent_iob_ == "B"
     assert doc[1].ent_iob_ == "I"
 
+    # if no parse/heads, the first word in the span is the root and provides
+    # default values
     words = ["a", "b", "c", "d", "e", "f", "g", "h", "i"]
     doc = Doc(Vocab(), words=words)
     doc.ents = [
@@ -250,11 +252,11 @@ def test_doc_retokenize_spans_entity_merge_iob(en_vocab):
         retokenizer.merge(doc[7:9])
     assert len(doc) == 6
     assert doc[3].ent_iob_ == "B"
+    assert doc[3].ent_type_ == "ent-de"
     assert doc[4].ent_iob_ == "B"
+    assert doc[4].ent_type_ == "ent-fg"
 
-    # check that entities not aligned with spans are assigned using span.root
-    # (note the unwanted behavior that now there are two ent-de ents rather
-    # than one)
+    # if there is a parse, span.root provides default values
     words = ["a", "b", "c", "d", "e", "f", "g", "h", "i"]
     heads = [ 0,  -1,   1,  -3,  -4,  -5,  -1,  -7,  -8 ]
     ents =  [
@@ -266,6 +268,8 @@ def test_doc_retokenize_spans_entity_merge_iob(en_vocab):
     en_vocab.strings.add("ent-fg")
     en_vocab.strings.add("dep")
     doc = get_doc(en_vocab, words=words, heads=heads, deps=deps, ents=ents)
+    assert doc[2:4].root == doc[3] # root of 'c d' is d
+    assert doc[4:6].root == doc[4] # root is 'e f' is e
     with doc.retokenize() as retokenizer:
         retokenizer.merge(doc[2:4])
         retokenizer.merge(doc[4:6])
@@ -273,7 +277,7 @@ def test_doc_retokenize_spans_entity_merge_iob(en_vocab):
     assert len(doc) == 6
     assert doc[2].ent_iob_ == "B"
     assert doc[2].ent_type_ == "ent-de"
-    assert doc[3].ent_iob_ == "B"
+    assert doc[3].ent_iob_ == "I"
     assert doc[3].ent_type_ == "ent-de"
     assert doc[4].ent_iob_ == "B"
     assert doc[4].ent_type_ == "ent-fg"
@@ -292,7 +296,7 @@ def test_doc_retokenize_spans_entity_merge_iob(en_vocab):
         retokenizer.merge(doc[5:7])
     assert len(doc) == 7
     assert doc[3].ent_iob_ == "B"
-    assert doc[4].ent_type_ == "ent-de"
+    assert doc[3].ent_type_ == "ent-de"
     assert doc[4].ent_iob_ == "B"
     assert doc[4].ent_type_ == "ent-de"
 

--- a/spacy/tokens/_retokenize.pyx
+++ b/spacy/tokens/_retokenize.pyx
@@ -171,6 +171,20 @@ def _merge(Doc doc, int start, int end, attributes):
     token.tag = doc.c[span.root.i].tag
     token.pos = doc.c[span.root.i].pos
     token.morph = doc.c[span.root.i].morph
+    token.ent_iob = doc.c[span.root.i].ent_iob
+    token.ent_type = doc.c[span.root.i].ent_type
+    # If span root is part of an entity, merged token is B-ENT
+    if token.ent_iob in (1, 3):
+        token.ent_iob = 3
+        # Unless start token is not B-ENT and previous token is of the same
+        # type, then I-ENT
+        if doc.c[start].ent_iob != 3 \
+                and doc.c[start].ent_type != token.ent_type \
+                and doc.c[start - 1].ent_type == token.ent_type:
+            token.ent_iob = 1
+    # If following token is part of a different entity, following token is B
+    if end < len(doc) and doc.c[end].ent_iob in (1, 3) and doc.c[end].ent_type != token.ent_type:
+        doc.c[end].ent_iob = 3
     # Unset attributes that don't match new token
     token.lemma = 0
     token.norm = 0
@@ -267,6 +281,20 @@ def _bulk_merge(Doc doc, merges):
         token.tag = doc.c[span.root.i].tag
         token.pos = doc.c[span.root.i].pos
         token.morph = doc.c[span.root.i].morph
+        token.ent_iob = doc.c[span.root.i].ent_iob
+        token.ent_type = doc.c[span.root.i].ent_type
+        # If span root is part of an entity, merged token is B-ENT
+        if token.ent_iob in (1, 3):
+            token.ent_iob = 3
+            # Unless start token is not B-ENT and previous token is of the same
+            # type, then I-ENT
+            if doc.c[start].ent_iob != 3 \
+                    and doc.c[start].ent_type != token.ent_type \
+                    and doc.c[start - 1].ent_type == token.ent_type:
+                token.ent_iob = 1
+        # If following token is part of a different entity, following token is B
+        if end < len(doc) and doc.c[end].ent_iob in (1, 3) and doc.c[end].ent_type != token.ent_type:
+            doc.c[end].ent_iob = 3
         # Unset attributes that don't match new token
         token.lemma = 0
         token.norm = 0

--- a/spacy/tokens/_retokenize.pyx
+++ b/spacy/tokens/_retokenize.pyx
@@ -200,8 +200,6 @@ def _merge(Doc doc, int start, int end, attributes):
             # If an attribute name is not valid, set_struct_attr will ignore it.
             Token.set_struct_attr(token, attr_name, attr_value)
             Lexeme.set_struct_attr(<LexemeC*>lex, attr_name, attr_value)
-    # Make sure ent_iob remains consistent
-    make_iob_consistent(doc.c, doc.length)
     # Begin by setting all the head indices to absolute token positions
     # This is easier to work with for now than the offsets
     # Before thinking of something simpler, beware the case where a
@@ -239,6 +237,8 @@ def _merge(Doc doc, int start, int end, attributes):
         doc.c[i].head -= i
     # Set the left/right children, left/right edges
     set_children_from_heads(doc.c, doc.length)
+    # Make sure ent_iob remains consistent
+    make_iob_consistent(doc.c, doc.length)
     # Return the merged Python object
     return doc[start]
 
@@ -512,5 +512,6 @@ cdef make_iob_consistent(TokenC* tokens, int length):
     if tokens[0].ent_iob == 1:
         tokens[0].ent_iob = 3
     for i in range(1, length):
+        print(tokens[i].ent_iob, tokens[i].ent_type)
         if tokens[i].ent_iob == 1 and tokens[i - 1].ent_type != tokens[i].ent_type:
             tokens[i].ent_iob = 3

--- a/spacy/tokens/_retokenize.pyx
+++ b/spacy/tokens/_retokenize.pyx
@@ -109,13 +109,8 @@ cdef class Retokenizer:
 
     def __exit__(self, *args):
         # Do the actual merging here
-        if len(self.merges) > 1:
-            _bulk_merge(self.doc, self.merges)
-        elif len(self.merges) == 1:
-            (span, attrs) = self.merges[0]
-            start = span.start
-            end = span.end
-            _merge(self.doc, start, end, attrs)
+        if len(self.merges) >= 1:
+            _merge(self.doc, self.merges)
         # Iterate in order, to keep things simple.
         for start_char, orths, heads, attrs in sorted(self.splits):
             # Resolve token index
@@ -140,110 +135,7 @@ cdef class Retokenizer:
             _split(self.doc, token_index, orths, head_indices, attrs)
 
 
-def _merge(Doc doc, int start, int end, attributes):
-    """Retokenize the document, such that the span at
-    `doc.text[start_idx : end_idx]` is merged into a single token. If
-    `start_idx` and `end_idx `do not mark start and end token boundaries,
-    the document remains unchanged.
-    start_idx (int): Character index of the start of the slice to merge.
-    end_idx (int): Character index after the end of the slice to merge.
-    **attributes: Attributes to assign to the merged token. By default,
-        attributes are inherited from the syntactic root of the span.
-    RETURNS (Token): The newly merged token, or `None` if the start and end
-        indices did not fall at token boundaries.
-    """
-    cdef Span span = doc[start:end]
-    cdef int start_char = span.start_char
-    cdef int end_char = span.end_char
-    # Resize the doc.tensor, if it's set. Let the last row for each token stand
-    # for the merged region. To do this, we create a boolean array indicating
-    # whether the row is to be deleted, then use numpy.delete
-    if doc.tensor is not None and doc.tensor.size != 0:
-        doc.tensor = _resize_tensor(doc.tensor, [(start, end)])
-    # Get LexemeC for newly merged token
-    new_orth = ''.join([t.text_with_ws for t in span])
-    if span[-1].whitespace_:
-        new_orth = new_orth[:-len(span[-1].whitespace_)]
-    cdef const LexemeC* lex = doc.vocab.get(doc.mem, new_orth)
-    # House the new merged token where it starts
-    cdef TokenC* token = &doc.c[start]
-    # Initially set attributes to attributes of span root
-    token.tag = doc.c[span.root.i].tag
-    token.pos = doc.c[span.root.i].pos
-    token.morph = doc.c[span.root.i].morph
-    token.ent_iob = doc.c[span.root.i].ent_iob
-    token.ent_type = doc.c[span.root.i].ent_type
-    merged_iob = token.ent_iob
-    # If span root is part of an entity, merged token is B-ENT
-    if token.ent_iob in (1, 3):
-        merged_iob = 3
-        # If start token is I-ENT and previous token is of the same
-        # type, then I-ENT (could check I-ENT from start to span root)
-        if doc.c[start].ent_iob == 1 \
-                and doc.c[start].ent_type == token.ent_type \
-                and doc.c[start - 1].ent_type == token.ent_type:
-            merged_iob = 1
-    token.ent_iob = merged_iob
-    # Unset attributes that don't match new token
-    token.lemma = 0
-    token.norm = 0
-    token.spacy = doc.c[end-1].spacy
-    for attr_name, attr_value in attributes.items():
-        if attr_name == "_":  # Set extension attributes
-            for ext_attr_key, ext_attr_value in attr_value.items():
-                doc[start]._.set(ext_attr_key, ext_attr_value)
-        elif attr_name == TAG:
-            doc.vocab.morphology.assign_tag(token, attr_value)
-        else:
-            # Set attributes on both token and lexeme to take care of token
-            # attribute vs. lexical attribute without having to enumerate them.
-            # If an attribute name is not valid, set_struct_attr will ignore it.
-            Token.set_struct_attr(token, attr_name, attr_value)
-            Lexeme.set_struct_attr(<LexemeC*>lex, attr_name, attr_value)
-    # Begin by setting all the head indices to absolute token positions
-    # This is easier to work with for now than the offsets
-    # Before thinking of something simpler, beware the case where a
-    # dependency bridges over the entity. Here the alignment of the
-    # tokens changes.
-    span_root = span.root.i
-    token.dep = span.root.dep
-    # We update token.lex after keeping span root and dep, since
-    # setting token.lex will change span.start and span.end properties
-    # as it modifies the character offsets in the doc
-    token.lex = lex
-    for i in range(doc.length):
-        doc.c[i].head += i
-    # Set the head of the merged token, and its dep relation, from the Span
-    token.head = doc.c[span_root].head
-    # Adjust deps before shrinking tokens
-    # Tokens which point into the merged token should now point to it
-    # Subtract the offset from all tokens which point to >= end
-    offset = (end - start) - 1
-    for i in range(doc.length):
-        head_idx = doc.c[i].head
-        if start <= head_idx < end:
-            doc.c[i].head = start
-        elif head_idx >= end:
-            doc.c[i].head -= offset
-    # Now compress the token array
-    for i in range(end, doc.length):
-        doc.c[i - offset] = doc.c[i]
-    for i in range(doc.length - offset, doc.length):
-        memset(&doc.c[i], 0, sizeof(TokenC))
-        doc.c[i].lex = &EMPTY_LEXEME
-    doc.length -= offset
-    for i in range(doc.length):
-        # ...And, set heads back to a relative position
-        doc.c[i].head -= i
-    # Set the left/right children, left/right edges
-    set_children_from_heads(doc.c, doc.length)
-    # Make sure ent_iob remains consistent
-    make_iob_consistent(doc.c, doc.length)
-    # Return the merged Python object
-    return doc[start]
-
-
-def _bulk_merge(Doc doc, merges):
+def _merge(Doc doc, merges):
     """Retokenize the document, such that the spans described in 'merges'
      are merged into a single token. This method assumes that the merges
      are in the same order at which they appear in the doc, and that merges

--- a/spacy/tokens/_retokenize.pyx
+++ b/spacy/tokens/_retokenize.pyx
@@ -167,6 +167,13 @@ def _merge(Doc doc, int start, int end, attributes):
     cdef const LexemeC* lex = doc.vocab.get(doc.mem, new_orth)
     # House the new merged token where it starts
     cdef TokenC* token = &doc.c[start]
+    # Initially set attributes to attributes of span root
+    token.tag = doc.c[span.root.i].tag
+    token.pos = doc.c[span.root.i].pos
+    token.morph = doc.c[span.root.i].morph
+    # Unset attributes that don't match new token
+    token.lemma = 0
+    token.norm = 0
     token.spacy = doc.c[end-1].spacy
     for attr_name, attr_value in attributes.items():
         if attr_name == "_":  # Set extension attributes

--- a/spacy/tokens/_retokenize.pyx
+++ b/spacy/tokens/_retokenize.pyx
@@ -173,17 +173,19 @@ def _merge(Doc doc, int start, int end, attributes):
     token.morph = doc.c[span.root.i].morph
     token.ent_iob = doc.c[span.root.i].ent_iob
     token.ent_type = doc.c[span.root.i].ent_type
+    merged_iob = token.ent_iob
     # If span root is part of an entity, merged token is B-ENT
     if token.ent_iob in (1, 3):
-        token.ent_iob = 3
-        # Unless start token is not B-ENT and previous token is of the same
-        # type, then I-ENT
-        if doc.c[start].ent_iob != 3 \
-                and doc.c[start].ent_type != token.ent_type \
+        merged_iob = 3
+        # If start token is I-ENT and previous token is of the same
+        # type, then I-ENT (could check I-ENT from start to span root)
+        if doc.c[start].ent_iob == 1 \
+                and doc.c[start].ent_type == token.ent_type \
                 and doc.c[start - 1].ent_type == token.ent_type:
-            token.ent_iob = 1
-    # If following token is part of a different entity, following token is B
-    if end < len(doc) and doc.c[end].ent_iob in (1, 3) and doc.c[end].ent_type != token.ent_type:
+            merged_iob = 1
+    token.ent_iob = merged_iob
+    # If following token has a different entity type, following token is B
+    if doc.c[end].ent_iob in (1, 3) and doc.c[end].ent_type != token.ent_type:
         doc.c[end].ent_iob = 3
     # Unset attributes that don't match new token
     token.lemma = 0
@@ -283,17 +285,19 @@ def _bulk_merge(Doc doc, merges):
         token.morph = doc.c[span.root.i].morph
         token.ent_iob = doc.c[span.root.i].ent_iob
         token.ent_type = doc.c[span.root.i].ent_type
+        merged_iob = token.ent_iob
         # If span root is part of an entity, merged token is B-ENT
         if token.ent_iob in (1, 3):
-            token.ent_iob = 3
-            # Unless start token is not B-ENT and previous token is of the same
-            # type, then I-ENT
-            if doc.c[start].ent_iob != 3 \
-                    and doc.c[start].ent_type != token.ent_type \
+            merged_iob = 3
+            # If start token is I-ENT and previous token is of the same
+            # type, then I-ENT (could check I-ENT from start to span root)
+            if doc.c[start].ent_iob == 1 \
+                    and doc.c[start].ent_type == token.ent_type \
                     and doc.c[start - 1].ent_type == token.ent_type:
-                token.ent_iob = 1
-        # If following token is part of a different entity, following token is B
-        if end < len(doc) and doc.c[end].ent_iob in (1, 3) and doc.c[end].ent_type != token.ent_type:
+                merged_iob = 1
+        token.ent_iob = merged_iob
+        # If following token has a different entity type, following token is B
+        if doc.c[end].ent_iob in (1, 3) and doc.c[end].ent_type != token.ent_type:
             doc.c[end].ent_iob = 3
         # Unset attributes that don't match new token
         token.lemma = 0

--- a/spacy/tokens/_retokenize.pyx
+++ b/spacy/tokens/_retokenize.pyx
@@ -256,6 +256,13 @@ def _bulk_merge(Doc doc, merges):
         spans.append(span)
         # House the new merged token where it starts
         token = &doc.c[start]
+        # Initially set attributes to attributes of span root
+        token.tag = doc.c[span.root.i].tag
+        token.pos = doc.c[span.root.i].pos
+        token.morph = doc.c[span.root.i].morph
+        # Unset attributes that don't match new token
+        token.lemma = 0
+        token.norm = 0
         tokens[merge_index] = token
     # Resize the doc.tensor, if it's set. Let the last row for each token stand
     # for the merged region. To do this, we create a boolean array indicating

--- a/spacy/tokens/_retokenize.pyx
+++ b/spacy/tokens/_retokenize.pyx
@@ -512,6 +512,5 @@ cdef make_iob_consistent(TokenC* tokens, int length):
     if tokens[0].ent_iob == 1:
         tokens[0].ent_iob = 3
     for i in range(1, length):
-        print(tokens[i].ent_iob, tokens[i].ent_type)
         if tokens[i].ent_iob == 1 and tokens[i - 1].ent_type != tokens[i].ent_type:
             tokens[i].ent_iob = 3

--- a/spacy/tokens/_retokenize.pyx
+++ b/spacy/tokens/_retokenize.pyx
@@ -175,7 +175,7 @@ def _merge(Doc doc, merges):
             merged_iob = 3
             # If start token is I-ENT and previous token is of the same
             # type, then I-ENT (could check I-ENT from start to span root)
-            if doc.c[start].ent_iob == 1 \
+            if doc.c[start].ent_iob == 1 and start > 0 \
                     and doc.c[start].ent_type == token.ent_type \
                     and doc.c[start - 1].ent_type == token.ent_type:
                 merged_iob = 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

* tag/pos/morph are set to root tag/pos/morph initially (can be overridden by attrs later)

* lemma and norm are reset and end up as orth (not ideal, but better than orth of first token)

Fixes #4051.

### Types of change

Bugfix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
