### PR TITLE
adds Croatian lemma_lookup.json, license file and corresponding tests

### DIFF
--- a/spacy/lang/hr/__init__.py
+++ b/spacy/lang/hr/__init__.py
@@ -18,6 +18,7 @@ class CroatianDefaults(Language.Defaults):
     )
     tokenizer_exceptions = update_exc(BASE_EXCEPTIONS)
     stop_words = STOP_WORDS
+    resources = {"lemma_lookup": "lemma_lookup.json"}
 
 
 class Croatian(Language):

--- a/spacy/lang/hr/lemma_lookup_license.txt
+++ b/spacy/lang/hr/lemma_lookup_license.txt
@@ -1,0 +1,6 @@
+This list of Croatian lemmas was adapted from the Croatian lexicon: hrLex (https://reldi.spur.uzh.ch/blog/croatian-lexicon/) (https://www.clarin.si/repository/xmlui/handle/11356/1067#show-files)
+
+The work is licenced under GPL v3.
+
+The lexicon and its construction process have been described in detail in the following paper:
+Nikola Ljubešić, Filip Klubička, Željko Agić, Ivo-Pavao Jazbec (2016). New Inflectional Lexicons and Training Corpora for Improved Morphosyntactic Annotation of Croatian and Serbian. Proceedings of the Tenth International Conference on Language Resources and Evaluation (LREC’16). Portorož, Slovenia

--- a/spacy/tests/conftest.py
+++ b/spacy/tests/conftest.py
@@ -103,6 +103,11 @@ def he_tokenizer():
     return get_lang_class("he").Defaults.create_tokenizer()
 
 
+@pytest.fixture(scope="session")
+def hr_tokenizer():
+    return get_lang_class("hr").Defaults.create_tokenizer()
+
+
 @pytest.fixture
 def hu_tokenizer():
     return get_lang_class("hu").Defaults.create_tokenizer()

--- a/spacy/tests/lang/hr/test_lemma.py
+++ b/spacy/tests/lang/hr/test_lemma.py
@@ -1,0 +1,20 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "string,lemma",
+    [
+        ("trčao", "trčati"),
+        ("adekvatnim", "adekvatan"),
+        ("dekontaminacijama", "dekontaminacija"),
+        ("filologovih", "filologov"),
+        ("je", "on"),
+        ("se", "sebe"),
+    ],
+)
+def test_hr_lemmatizer_lookup_assigns(hr_tokenizer, string, lemma):
+    tokens = hr_tokenizer(string)
+    assert tokens[0].lemma_ == lemma


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->
I have added a Croatian lemmatizer with the corresponding tests and supporting test data.
## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
It adds three new files : the lookup_lemma.json and corresponding licence, the corresponding test and the support fixture in terms of adding a Croatian tokenizer.
### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
This is an enhancement that allows lemmatization of Croatian words. The lemmatizer was adapted from the Croatian lexicon v1.1 which is under a GPL v3 licence. GPL v3 should be compatible with 
the spaCy MIT licence. Let me know if I am mistaken.
## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
