### PR TITLE
Add guillemets/chevrons to German orth variants

### DIFF
--- a/spacy/lang/de/__init__.py
+++ b/spacy/lang/de/__init__.py
@@ -29,8 +29,8 @@ class GermanDefaults(Language.Defaults):
     resources = {"lemma_lookup": "lemma_lookup.json"}
     single_orth_variants = [{"tags": ["$("], "variants": ["…", "..."]},
             {"tags": ["$("], "variants": ["-", "—", "–", "--", "---", "——"]}]
-    paired_orth_variants = [{"tags": ["$("], "variants": [("'", "'"), (",", "'"), ("‚", "‘")]},
-            {"tags": ["$("], "variants": [("``", "''"), ('"', '"'), ("„", "“")]}]
+    paired_orth_variants = [{"tags": ["$("], "variants": [("'", "'"), (",", "'"), ("‚", "‘"), ("›", "‹"), ("‹", "›")]},
+            {"tags": ["$("], "variants": [("``", "''"), ('"', '"'), ("„", "“"), ("»", "«"), ("«", "»")]}]
 
 
 class German(Language):


### PR DESCRIPTION
## Description

Add guillemets/chevrons to German orth variants with both German/Austrian
and Swiss conventions.

I noticed that a number of people mentioned them in tokenizer/tagger bug reports.

### Types of change

Enhancement.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
