### PR TITLE
Fix ValueError exception on empty Korean text.

### DIFF
--- a/spacy/lang/ko/__init__.py
+++ b/spacy/lang/ko/__init__.py
@@ -58,7 +58,8 @@ def check_spaces(text, tokens):
             yield prev_end != idx
         prev_end = idx + len(token)
         start = prev_end
-    yield False
+    if start > 0:
+        yield False
 
 
 class KoreanTokenizer(DummyTokenizer):

--- a/spacy/tests/lang/ko/test_tokenizer.py
+++ b/spacy/tests/lang/ko/test_tokenizer.py
@@ -45,3 +45,8 @@ def test_ko_tokenizer_full_tags(ko_tokenizer, text, expected_tags):
 def test_ko_tokenizer_pos(ko_tokenizer, text, expected_pos):
     pos = [token.pos_ for token in ko_tokenizer(text)]
     assert pos == expected_pos.split()
+
+
+def test_ko_empty_doc(ko_tokenizer):
+    tokens = ko_tokenizer("")
+    assert len(tokens) == 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Fixed check_spaces method to return a generator of length 0 instead of 1 on empty string.


This fixes the following error issue. 

> File ".../spacy/lang/ko/__init__.py", line 72, in \_\_call\_\_
doc = Doc(self.vocab, words=surfaces, spaces=list(check_spaces(text, surfaces)))
File "doc.pyx", line 209, in spacy.tokens.doc.Doc.\_\_init\_\_
ValueError: [E027] Arguments 'words' and 'spaces' should be sequences of the same length, or 'spaces' should be left default at None. spaces should be a sequence of booleans, with True meaning that the word owns a ' ' character following it.


### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
