### PR TITLE
Make pos/tag distinction more clear in docs

### DIFF
--- a/website/docs/usage/101/_pos-deps.md
+++ b/website/docs/usage/101/_pos-deps.md
@@ -3,7 +3,16 @@ the statistical model comes in, which enables spaCy to **make a prediction** of
 which tag or label most likely applies in this context. A model consists of
 binary data and is produced by showing a system enough examples for it to make
 predictions that generalize across the language – for example, a word following
-"the" in English is most likely a noun.
+"the" in English is most likely a noun. spaCy assigns tags on two different levels
+of granularity: `Tag` is a more fine-grained, and `POS` is a more simple version.
+
+<Infobox title="📖 Part-of-speech tag scheme">
+
+For a list of the fine-grained and coarse-grained part-of-speech tags assigned
+by spaCy's models across different languages, see the
+[POS tag scheme documentation](/api/annotation#pos-tagging).
+
+</Infobox>
 
 Linguistic annotations are available as
 [`Token` attributes](/api/token#attributes). Like many NLP libraries, spaCy

--- a/website/docs/usage/101/_pos-deps.md
+++ b/website/docs/usage/101/_pos-deps.md
@@ -3,16 +3,7 @@ the statistical model comes in, which enables spaCy to **make a prediction** of
 which tag or label most likely applies in this context. A model consists of
 binary data and is produced by showing a system enough examples for it to make
 predictions that generalize across the language – for example, a word following
-"the" in English is most likely a noun. spaCy assigns tags on two different levels
-of granularity: `Tag` is a more fine-grained, and `POS` is a more simple version.
-
-<Infobox title="📖 Part-of-speech tag scheme">
-
-For a list of the fine-grained and coarse-grained part-of-speech tags assigned
-by spaCy's models across different languages, see the
-[POS tag scheme documentation](/api/annotation#pos-tagging).
-
-</Infobox>
+"the" in English is most likely a noun.
 
 Linguistic annotations are available as
 [`Token` attributes](/api/token#attributes). Like many NLP libraries, spaCy

--- a/website/docs/usage/linguistic-features.md
+++ b/website/docs/usage/linguistic-features.md
@@ -26,6 +26,14 @@ import PosDeps101 from 'usage/101/\_pos-deps.md'
 
 <PosDeps101 />
 
+<Infobox title="📖 Part-of-speech tag scheme">
+
+For a list of the fine-grained and coarse-grained part-of-speech tags assigned
+by spaCy's models across different languages, see the
+[POS tag scheme documentation](/api/annotation#pos-tagging).
+
+</Infobox>
+
 ### Rule-based morphology {#rule-based-morphology}
 
 Inflectional morphology is the process by which a root form of a word is

--- a/website/docs/usage/linguistic-features.md
+++ b/website/docs/usage/linguistic-features.md
@@ -61,14 +61,7 @@ of the two. The system works as follows:
    morphological information, without consulting the context of the token. The
    lemmatizer also accepts list-based exception files, acquired from
    [WordNet](https://wordnet.princeton.edu/).
-
-<Infobox title="📖 Part-of-speech tag scheme">
-
-For a list of the fine-grained and coarse-grained part-of-speech tags assigned
-by spaCy's models across different languages, see the
-[POS tag scheme documentation](/api/annotation#pos-tagging).
-
-</Infobox>
+   
 
 ## Dependency Parsing {#dependency-parse model="parser"}
 
@@ -289,7 +282,7 @@ for token in doc:
 
 For a list of the syntactic dependency labels assigned by spaCy's models across
 different languages, see the
-[dependency label scheme documentation](/api/annotation#pos-tagging).
+[dependency label scheme documentation](/api/annotation#dependency-parsing).
 
 </Infobox>
 


### PR DESCRIPTION
## Description
* Moved the "Part-of-speech tag scheme" infobox up on the page https://spacy.io/usage/linguistic-features
* Corrected one link to the dependencies doc (was pointing to POS doc)

### Types of change
Change to the documentation, closes #4242 

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
