### PR TITLE
Docs: bufsize instead of buffsize

### DIFF
--- a/website/docs/api/top-level.md
+++ b/website/docs/api/top-level.md
@@ -639,7 +639,7 @@ Yield an infinite series of linearly decaying values.
 
 Shuffle an iterator. This works by holding `bufsize` items back and yielding
 them sometime later. Obviously, this is not unbiased – but should be good enough
-for batching. Larger `buffsize` means less bias.
+for batching. Larger `bufsize` means less bias.
 
 > #### Example
 >
@@ -648,11 +648,11 @@ for batching. Larger `buffsize` means less bias.
 > shuffled = itershuffle(values)
 > ```
 
-| Name       | Type     | Description            |
-| ---------- | -------- | ---------------------- |
-| `iterable` | iterable | Iterator to shuffle.   |
-| `buffsize` | int      | Items to hold back.    |
-| **YIELDS** | iterable | The shuffled iterator. |
+| Name       | Type     | Description                           |
+| ---------- | -------- | ------------------------------------- |
+| `iterable` | iterable | Iterator to shuffle.                  |
+| `bufsize`  | int      | Items to hold back (default: 1000).   |
+| **YIELDS** | iterable | The shuffled iterator.                |
 
 ### util.filter_spans {#util.filter_spans tag="function" new="2.1.4"}
 


### PR DESCRIPTION
Corrected small typo in the docs

### Types of change
change to the documentation

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
