### PR TITLE
Allow affixes as tokenizer special cases

### DIFF
--- a/spacy/tests/tokenizer/test_tokenizer.py
+++ b/spacy/tests/tokenizer/test_tokenizer.py
@@ -120,3 +120,18 @@ def test_tokenizer_add_special_case_tag(text, tokens):
     assert doc[0].tag_ == tokens[0]["tag"]
     assert doc[0].pos_ == "NOUN"
     assert doc[1].text == tokens[1]["orth"]
+
+@pytest.mark.parametrize(
+    "text,tokens",
+    [
+        ("»", [{"orth": '"'}]),
+        ("»", [{"orth": '"'}, {"orth": "'"}]),
+        (".", [{"orth": '。'}]),
+        ("。", [{"orth": '.'}]),
+    ]
+)
+def test_tokenizer_affix_as_special_case(tokenizer, text, tokens):
+    tokenizer.add_special_case(text, tokens)
+    doc = tokenizer(text)
+    for i in range(len(doc)):
+        assert doc[i].text == tokens[i]["orth"]

--- a/spacy/tokenizer.pxd
+++ b/spacy/tokenizer.pxd
@@ -25,6 +25,7 @@ cdef class Tokenizer:
     cpdef Doc tokens_from_list(self, list strings)
 
     cdef int _try_cache(self, hash_t key, Doc tokens) except -1
+    cdef int _push_back_affix(self, Pool mem, unicode affix, vector[const LexemeC*] *affixes) except -1
     cdef int _tokenize(self, Doc tokens, unicode span, hash_t key) except -1
     cdef unicode _split_affixes(self, Pool mem, unicode string, vector[LexemeC*] *prefixes,
                              vector[LexemeC*] *suffixes, int* has_special)


### PR DESCRIPTION
## Description

Modify the tokenizer to additionally check whether prefixes and suffixes are special cases.

Prefixes and suffixes are stored as LexemeC, so only the lexeme attributes are affected, other token attributes are ignored.

Related to #3944.

### Types of change

Bugfix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
