### PR TITLE
💫 Fix bug in Parser.labels and add test

### DIFF
--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -1063,7 +1063,7 @@ cdef class DependencyParser(Parser):
     @property
     def labels(self):
         # Get the labels from the model by looking at the available moves
-        return tuple(set(move.split("-")[1] for move in self.move_names))
+        return tuple(set(move.split("-")[1] for move in self.move_names if "-" in move))
 
 
 cdef class EntityRecognizer(Parser):

--- a/spacy/tests/parser/test_add_label.py
+++ b/spacy/tests/parser/test_add_label.py
@@ -68,3 +68,20 @@ def test_add_label_deserializes_correctly():
     assert ner1.moves.n_moves == ner2.moves.n_moves
     for i in range(ner1.moves.n_moves):
         assert ner1.moves.get_class_name(i) == ner2.moves.get_class_name(i)
+
+
+@pytest.mark.parametrize(
+    "pipe_cls,n_moves", [(DependencyParser, 5), (EntityRecognizer, 4)]
+)
+def test_add_label_get_label(pipe_cls, n_moves):
+    """Test that added labels are returned correctly. This test was added to
+    test for a bug in DependencyParser.labels that'd cause it to fail when
+    splitting the move names.
+    """
+    labels = ["A", "B", "C"]
+    pipe = pipe_cls(Vocab())
+    for label in labels:
+        pipe.add_label(label)
+    assert len(pipe.move_names) == len(labels) * n_moves
+    pipe_labels = sorted(list(pipe.labels))
+    assert pipe_labels == labels


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
`DependencsParser.labels` would fail because some of the labels don't include a `-`.

### Types of change
bugfix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
