### PR TITLE
Ensure that doc.ents preserves kb_id annotations

### DIFF
--- a/spacy/tests/doc/test_add_entities.py
+++ b/spacy/tests/doc/test_add_entities.py
@@ -22,18 +22,6 @@ def test_doc_add_entities_set_ents_iob(en_vocab):
     assert [w.ent_iob_ for w in doc] == ["B", "I", "", ""]
 
 
-def test_ents_reset(en_vocab):
-    text = ["This", "is", "a", "lion"]
-    doc = get_doc(en_vocab, text)
-    ner = EntityRecognizer(en_vocab)
-    ner.begin_training([])
-    ner(doc)
-    print()
-    assert [t.ent_iob_ for t in doc] == (["O"] * len(doc))
-    doc.ents = list(doc.ents)
-    assert [t.ent_iob_ for t in doc] == (["O"] * len(doc))
-
-
 def test_add_overlapping_entities(en_vocab):
     text = ["Louisiana", "Office", "of", "Conservation"]
     doc = get_doc(en_vocab, text)

--- a/spacy/tests/doc/test_add_entities.py
+++ b/spacy/tests/doc/test_add_entities.py
@@ -22,6 +22,18 @@ def test_doc_add_entities_set_ents_iob(en_vocab):
     assert [w.ent_iob_ for w in doc] == ["B", "I", "", ""]
 
 
+def test_ents_reset(en_vocab):
+    text = ["This", "is", "a", "lion"]
+    doc = get_doc(en_vocab, text)
+    ner = EntityRecognizer(en_vocab)
+    ner.begin_training([])
+    ner(doc)
+    print()
+    assert [t.ent_iob_ for t in doc] == (["O"] * len(doc))
+    doc.ents = list(doc.ents)
+    assert [t.ent_iob_ for t in doc] == (["O"] * len(doc))
+
+
 def test_add_overlapping_entities(en_vocab):
     text = ["Louisiana", "Office", "of", "Conservation"]
     doc = get_doc(en_vocab, text)

--- a/spacy/tests/pipeline/test_entity_linker.py
+++ b/spacy/tests/pipeline/test_entity_linker.py
@@ -180,8 +180,7 @@ def test_preserving_links_ents(nlp):
     doc = nlp(text)
     assert len(list(doc.ents)) == 0
 
-    LOC = doc.vocab.strings["LOC"]
-    boston_ent = Span(doc, 3, 4, label=LOC, kb_id="Q1")
+    boston_ent = Span(doc, 3, 4, label="LOC", kb_id="Q1")
     doc.ents = [boston_ent]
     assert len(list(doc.ents)) == 1
     assert list(doc.ents)[0].label_ == "LOC"

--- a/spacy/tests/pipeline/test_entity_linker.py
+++ b/spacy/tests/pipeline/test_entity_linker.py
@@ -6,6 +6,7 @@ import pytest
 from spacy.kb import KnowledgeBase
 from spacy.lang.en import English
 from spacy.pipeline import EntityRuler
+from spacy.tokens import Span
 
 
 @pytest.fixture
@@ -171,3 +172,17 @@ def test_preserving_links_asdoc(nlp):
         for s_ent in sent_doc.ents:
             if s_ent.text == orig_text:
                 assert s_ent.kb_id_ == orig_kb_id
+
+
+def test_preserving_links_ents(nlp):
+    """Test that doc.ents preserves KB annotations"""
+    text = "She lives in Boston. He lives in Denver."
+    doc = nlp(text)
+    assert len(list(doc.ents)) == 0
+
+    LOC = doc.vocab.strings["LOC"]
+    boston_ent = Span(doc, 3, 4, label=LOC, kb_id="Q1")
+    doc.ents = [boston_ent]
+    assert len(list(doc.ents)) == 1
+    assert list(doc.ents)[0].label_ == "LOC"
+    assert list(doc.ents)[0].kb_id_ == "Q1"

--- a/spacy/tests/pipeline/test_entity_linker.py
+++ b/spacy/tests/pipeline/test_entity_linker.py
@@ -185,3 +185,18 @@ def test_preserving_links_ents(nlp):
     assert len(list(doc.ents)) == 1
     assert list(doc.ents)[0].label_ == "LOC"
     assert list(doc.ents)[0].kb_id_ == "Q1"
+
+
+def test_preserving_links_ents_2(nlp):
+    """Test that doc.ents preserves KB annotations"""
+    text = "She lives in Boston. He lives in Denver."
+    doc = nlp(text)
+    assert len(list(doc.ents)) == 0
+
+    loc = doc.vocab.strings.add("LOC")
+    q1 = doc.vocab.strings.add("Q1")
+
+    doc.ents = [(loc, q1, 3, 4)]
+    assert len(list(doc.ents)) == 1
+    assert list(doc.ents)[0].label_ == "LOC"
+    assert list(doc.ents)[0].kb_id_ == "Q1"

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -1256,6 +1256,9 @@ def get_entity_info(ent_info):
         ent_kb_id = ent_info.kb_id
         start = ent_info.start
         end = ent_info.end
+    elif len(ent_info) == 3:
+        ent_type, start, end = ent_info
+        ent_kb_id = 0
     elif len(ent_info) == 4:
         ent_type, ent_kb_id, start, end = ent_info
     else:

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -534,7 +534,7 @@ cdef class Doc:
             cdef attr_t entity_type
             cdef int ent_start, ent_end
             for ent_info in ents:
-                entity_type, ent_start, ent_end = get_entity_info(ent_info)
+                entity_type, kb_id, ent_start, ent_end = get_entity_info(ent_info)
                 for token_index in range(ent_start, ent_end):
                     if token_index in tokens_in_ents.keys():
                         raise ValueError(Errors.E103.format(
@@ -542,7 +542,7 @@ cdef class Doc:
                                    tokens_in_ents[token_index][1],
                                    self.vocab.strings[tokens_in_ents[token_index][2]]),
                             span2=(ent_start, ent_end, self.vocab.strings[entity_type])))
-                    tokens_in_ents[token_index] = (ent_start, ent_end, entity_type)
+                    tokens_in_ents[token_index] = (ent_start, ent_end, entity_type, kb_id)
             cdef int i
             for i in range(self.length):
                 self.c[i].ent_type = 0
@@ -551,16 +551,18 @@ cdef class Doc:
             cdef attr_t ent_type
             cdef int start, end
             for ent_info in ents:
-                ent_type, start, end = get_entity_info(ent_info)
+                ent_type, ent_kb_id, start, end = get_entity_info(ent_info)
                 if ent_type is None or ent_type < 0:
                     # Mark as O
                     for i in range(start, end):
                         self.c[i].ent_type = 0
+                        self.c[i].ent_kb_id = 0
                         self.c[i].ent_iob = 2
                 else:
                     # Mark (inside) as I
                     for i in range(start, end):
                         self.c[i].ent_type = ent_type
+                        self.c[i].ent_kb_id = ent_kb_id
                         self.c[i].ent_iob = 1
                     # Set start as B
                     self.c[start].ent_iob = 3
@@ -1251,10 +1253,11 @@ def fix_attributes(doc, attributes):
 def get_entity_info(ent_info):
     if isinstance(ent_info, Span):
         ent_type = ent_info.label
+        ent_kb_id = ent_info.kb_id
         start = ent_info.start
         end = ent_info.end
-    elif len(ent_info) == 3:
-        ent_type, start, end = ent_info
+    elif len(ent_info) == 4:
+        ent_type, ent_kb_id, start, end = ent_info
     else:
-        ent_id, ent_type, start, end = ent_info
-    return ent_type, start, end
+        ent_id, ent_kb_id, ent_type, start, end = ent_info
+    return ent_type, ent_kb_id, start, end


### PR DESCRIPTION
When setting `doc.ents`, the KB identifiers were not preserved. Fixed + unit test. 

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
