### PR TITLE
Improve Morphology errors

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -474,6 +474,7 @@ class Errors(object):
             "morphological features. If you're using a pre-trained model, make "
             "sure that your models are up to date:\npython -m spacy validate")
     E168 = ("Unknown field: {field}")
+    E169 = ("Can't find module: {module}")
 
 
 @add_codes

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -475,6 +475,7 @@ class Errors(object):
             "sure that your models are up to date:\npython -m spacy validate")
     E168 = ("Unknown field: {field}")
     E169 = ("Can't find module: {module}")
+    E170 = ("Cannot apply transition {name}: invalid for the current state.")
 
 
 @add_codes

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -469,6 +469,11 @@ class Errors(object):
             "that case.")
     E166 = ("Can only merge DocBins with the same pre-defined attributes.\n"
             "Current DocBin: {current}\nOther DocBin: {other}")
+    E167 = ("Unknown morphological feature: '{feat}' ({feat_id}). This can "
+            "happen if the tagger was trained with a different set of "
+            "morphological features. If you're using a pre-trained model, make "
+            "sure that your models are up to date:\npython -m spacy validate")
+    E168 = ("Unknown field: {field}")
 
 
 @add_codes

--- a/spacy/morphology.pyx
+++ b/spacy/morphology.pyx
@@ -197,7 +197,7 @@ cdef class Morphology:
         cdef attr_t feature
         for feature in features:
             if feature != 0 and feature not in self._feat_map.id2feat:
-                raise KeyError("Unknown feature: %s" % self.strings[feature])
+                raise ValueError(Errors.E167.format(feat=self.strings[feature], feat_id=feature))
         cdef MorphAnalysisC tag
         tag = create_rich_tag(features)
         cdef hash_t key = self.insert(tag)
@@ -531,7 +531,7 @@ cdef attr_t get_field(const MorphAnalysisC* tag, int field_id) nogil:
     elif field == Field_VerbType:
         return tag.verb_type
     else:
-        raise ValueError("Unknown field: (%d)" % field_id)
+        raise ValueError(Errors.E168.format(field=field_id))
 
 
 cdef int check_feature(const MorphAnalysisC* tag, attr_t feature) nogil:
@@ -726,7 +726,7 @@ cdef int set_feature(MorphAnalysisC* tag,
     elif field == Field_VerbType:
         tag.verb_type = value_
     else:
-        raise ValueError("Unknown feature: %s (%d)" % (FEATURE_NAMES.get(feature), feature))
+        raise ValueError(Errors.E167.format(field=FEATURE_NAMES.get(feature), field_id=feature))
 
 
 FIELDS = {

--- a/spacy/syntax/transition_system.pyx
+++ b/spacy/syntax/transition_system.pyx
@@ -96,8 +96,7 @@ cdef class TransitionSystem:
 
     def apply_transition(self, StateClass state, name):
         if not self.is_valid(state, name):
-            raise ValueError(
-                "Cannot apply transition {name}: invalid for the current state.".format(name=name))
+            raise ValueError(Errors.E170.format(name=name))
         action = self.lookup_transition(name)
         action.do(state.c, action.label)
 

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -136,7 +136,7 @@ def load_language_data(path):
 
 def get_module_path(module):
     if not hasattr(module, "__module__"):
-        raise ValueError("Can't find module {}".format(repr(module)))
+        raise ValueError(Errors.E169.format(module=repr(module)))
     return Path(sys.modules[module.__module__].__file__).parent
 
 


### PR DESCRIPTION
## Description

Move messages to `spacy.errors` and add more information to the "Unknown feature" error. This is one that users may hit if they forget to upgrade a model to v2.2, so we might as well mention that in the message.

Example that produces the error if run with spaCy v2.2 and the v2.1 model:

```python
import spacy
nlp = spacy.load("de_core_news_sm")
doc = nlp("Some text hello world")
```

### Types of change
enhancement, ux

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
