### PR TITLE
Initialize low data warning for debug-data parser

### DIFF
--- a/spacy/cli/debug_data.py
+++ b/spacy/cli/debug_data.py
@@ -348,6 +348,7 @@ def debug_data(
             )
 
     if "parser" in pipeline:
+        has_low_data_warning = False
         msg.divider("Dependency Parsing")
 
         # profile sentence length


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Initialize low data warning for debug-data parser, which resulted in an error if you only checked `-p parser` rather than all components.

### Types of change

Bugfix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
