### PR TITLE
Add registry for model creation functions ('architectures')

### DIFF
--- a/spacy/__init__.py
+++ b/spacy/__init__.py
@@ -14,6 +14,7 @@ from .glossary import explain
 from .about import __version__
 from .errors import Errors, Warnings, deprecation_warning
 from . import util
+from .util import register_architecture, get_architecture
 
 
 if sys.maxunicode == 65535:

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -495,6 +495,7 @@ class Errors(object):
     E173 = ("As of v2.2, the Lemmatizer is initialized with an instance of "
             "Lookups containing the lemmatization tables. See the docs for "
             "details: https://spacy.io/api/lemmatizer#init")
+    E174 = ("Architecture {name} not found in registry. Available names: {names}")
 
 
 @add_codes

--- a/spacy/tests/test_register_architecture.py
+++ b/spacy/tests/test_register_architecture.py
@@ -1,0 +1,19 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+import pytest
+from spacy import register_architecture
+from spacy import get_architecture
+from thinc.v2v import Affine
+
+
+@register_architecture("my_test_function")
+def create_model(nr_in, nr_out):
+    return Affine(nr_in, nr_out)
+
+
+def test_get_architecture():
+    arch = get_architecture("my_test_function")
+    assert arch is create_model
+    with pytest.raises(KeyError):
+        get_architecture("not_an_existing_key")


### PR DESCRIPTION
Components have a `Model` class method, that's used to instantiate their statistical model. This `Model` classmethod hard-codes the architecture. This makes it pretty awkward to plug in a different model architecture --- you have to subclass. Technically you can work around this, but it's messy.

This PR brings in a technique we experimented with in `spacy-pytorch-transformers`, that seems to be working pretty well. The idea is to register creation functions, so that the component config can fetch the creation function by name. This avoids the problem of passing in a function --- if you pass a function in you can't serialise it, leading to all sorts of trouble.

I've introduced a new term, **architecture**, for the types of functions we're registering. The problem is that *model* is too ambiguous: we tend to use it for a binary with the weights and config, but it can also be the object that does the prediction. That ambiguity is bad enough --- if we start calling the functions that create the models "models" as well, we'll really be in trouble.

I think architecture is a nice term because it can't be confused for the thing itself, and people do use it in this sort of sense. It's a bit long, which is disappointing, and some might find it difficult to spell. But I don't have any better suggestions. 

I've tried to set up the entry points as well, but I might have gotten this wrong. Once we fix the config system so that you can pass a config json to `spacy train`, the effect should be pretty good. The idea is that you should be able to write your own architecture and install it as a package, and then pass the config to `spacy train` and everything should work.

Another neat thing is that architectures can naturally be nested. Architectures often have choices for the various layers inside them. This should make it easy to write models where you can swap out just the embedding strategy, or change the CNN for a BiLSTM, etc.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
