### PR TITLE
Fix PhraseMatcher callback and add tests

### DIFF
--- a/spacy/matcher/phrasematcher.pyx
+++ b/spacy/matcher/phrasematcher.pyx
@@ -225,7 +225,7 @@ cdef class PhraseMatcher:
         for i in range(c_matches.size()):
             matches.append((c_matches[i].match_id, c_matches[i].start, c_matches[i].end))
         for i, (ent_id, start, end) in enumerate(matches):
-            on_match = self._callbacks.get(ent_id)
+            on_match = self._callbacks.get(self.vocab.strings[ent_id])
             if on_match is not None:
                 on_match(self, doc, i, matches)
         return matches

--- a/spacy/tests/matcher/test_matcher_api.py
+++ b/spacy/tests/matcher/test_matcher_api.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import pytest
 import re
+from mock import Mock
 from spacy.matcher import Matcher, DependencyMatcher
 from spacy.tokens import Doc, Token
 
@@ -418,3 +419,13 @@ def test_matcher_valid_callback(en_vocab):
     with pytest.raises(ValueError):
         matcher.add("TEST", [], [{"TEXT": "test"}])
     matcher(Doc(en_vocab, words=["test"]))
+
+
+def test_matcher_callback(en_vocab):
+    mock = Mock()
+    matcher = Matcher(en_vocab)
+    pattern = [{"ORTH": "test"}]
+    matcher.add("Rule", mock, pattern)
+    doc = Doc(en_vocab, words=["This", "is", "a", "test", "."])
+    matches = matcher(doc)
+    mock.assert_called_once_with(matcher, doc, 0, matches)

--- a/spacy/tests/matcher/test_phrase_matcher.py
+++ b/spacy/tests/matcher/test_phrase_matcher.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import pytest
+from mock import Mock
 from spacy.matcher import PhraseMatcher
 from spacy.tokens import Doc
 from ..util import get_doc
@@ -215,3 +216,13 @@ def test_attr_pipeline_checks(en_vocab):
     matcher.add("TEST3", None, doc3)
     matcher = PhraseMatcher(en_vocab, attr="TEXT")
     matcher.add("TEST3", None, doc3)
+
+
+def test_phrase_matcher_callback(en_vocab):
+    mock = Mock()
+    doc = Doc(en_vocab, words=["I", "like", "Google", "Now", "best"])
+    pattern = Doc(en_vocab, words=["Google", "Now"])
+    matcher = PhraseMatcher(en_vocab)
+    matcher.add("COMPANY", mock, pattern)
+    matches = matcher(doc)
+    mock.assert_called_once_with(matcher, doc, 0, matches)


### PR DESCRIPTION
## Description

* Fix callback lookup in PhraseMatcher (string key rather than hash key)
* Add callback tests for Matcher and PhraseMatcher

Fixes #4397.

### Types of change

Bugfix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
