### PR TITLE
Recreate en_vocab fixture in some tests

### DIFF
--- a/spacy/tests/matcher/test_matcher_logic.py
+++ b/spacy/tests/matcher/test_matcher_logic.py
@@ -6,6 +6,15 @@ import re
 from spacy.matcher import Matcher
 from spacy.tokens import Doc, Span
 
+# Moving this here and avoiding session scope to try to work out the "ghost match"
+# bug. It's troublesome to have state between executions when working through
+# this.
+@pytest.fixture
+def en_vocab():
+    return get_lang_class("en").Defaults.create_vocab()
+
+
+
 
 pattern1 = [{"ORTH": "A", "OP": "1"}, {"ORTH": "A", "OP": "*"}]
 pattern2 = [{"ORTH": "A", "OP": "*"}, {"ORTH": "A", "OP": "1"}]

--- a/spacy/tests/matcher/test_matcher_logic.py
+++ b/spacy/tests/matcher/test_matcher_logic.py
@@ -5,6 +5,7 @@ import pytest
 import re
 from spacy.matcher import Matcher
 from spacy.tokens import Doc, Span
+from spacy.util import get_lang_class
 
 # Moving this here and avoiding session scope to try to work out the "ghost match"
 # bug. It's troublesome to have state between executions when working through

--- a/spacy/tests/regression/test_issue1501-2000.py
+++ b/spacy/tests/regression/test_issue1501-2000.py
@@ -15,6 +15,7 @@ from spacy.tokens import Doc, Span, Token
 from spacy.pipeline import Tagger, EntityRecognizer
 from spacy.attrs import HEAD, DEP
 from spacy.matcher import Matcher
+from spacy.util import get_lang_class
 
 from ..util import make_tempdir
 

--- a/spacy/tests/regression/test_issue1501-2000.py
+++ b/spacy/tests/regression/test_issue1501-2000.py
@@ -18,6 +18,13 @@ from spacy.matcher import Matcher
 
 from ..util import make_tempdir
 
+# Moving this here and avoiding session scope to try to work out the "ghost match"
+# bug. It's troublesome to have state between executions when working through
+# this.
+@pytest.fixture
+def en_vocab():
+    return get_lang_class("en").Defaults.create_vocab()
+
 
 def test_issue1506():
     def string_generator():

--- a/spacy/tests/regression/test_issue2001-2500.py
+++ b/spacy/tests/regression/test_issue2001-2500.py
@@ -9,6 +9,7 @@ from spacy.displacy import render
 from spacy.gold import iob_to_biluo
 from spacy.lang.it import Italian
 from spacy.lang.en import English
+from spacy.util import get_lang_class
 
 from ..util import add_vecs_to_vocab, get_doc
 

--- a/spacy/tests/regression/test_issue2001-2500.py
+++ b/spacy/tests/regression/test_issue2001-2500.py
@@ -13,6 +13,14 @@ from spacy.lang.en import English
 from ..util import add_vecs_to_vocab, get_doc
 
 
+# Moving this here and avoiding session scope to try to work out the "ghost match"
+# bug. It's troublesome to have state between executions when working through
+# this.
+@pytest.fixture
+def en_vocab():
+    return get_lang_class("en").Defaults.create_vocab()
+
+
 @pytest.mark.xfail
 def test_issue2070():
     """Test that checks that a dot followed by a quote is handled

--- a/spacy/tests/regression/test_issue3839.py
+++ b/spacy/tests/regression/test_issue3839.py
@@ -1,6 +1,7 @@
 # coding: utf8
 from __future__ import unicode_literals
 
+import pytest
 from spacy.matcher import Matcher
 from spacy.tokens import Doc
 from spacy.util import get_lang_class

--- a/spacy/tests/regression/test_issue3839.py
+++ b/spacy/tests/regression/test_issue3839.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from spacy.matcher import Matcher
 from spacy.tokens import Doc
+from spacy.util import get_lang_class
 
 # Moving this here and avoiding session scope to try to work out the "ghost match"
 # bug. It's troublesome to have state between executions when working through

--- a/spacy/tests/regression/test_issue3839.py
+++ b/spacy/tests/regression/test_issue3839.py
@@ -4,6 +4,13 @@ from __future__ import unicode_literals
 from spacy.matcher import Matcher
 from spacy.tokens import Doc
 
+# Moving this here and avoiding session scope to try to work out the "ghost match"
+# bug. It's troublesome to have state between executions when working through
+# this.
+@pytest.fixture
+def en_vocab():
+    return get_lang_class("en").Defaults.create_vocab()
+
 
 def test_issue3839(en_vocab):
     """Test that match IDs returned by the matcher are correct, are in the string """


### PR DESCRIPTION
Many of our tests use the session-scoped en_vocab fixture. While we
debug the "ghost match" issue (#4098), let's make the affected tests use
a new fixture each test, to avoid inter-test state.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
