### PR TITLE
Fix PhraseMatcher.remove for overlapping patterns

### DIFF
--- a/spacy/matcher/phrasematcher.pyx
+++ b/spacy/matcher/phrasematcher.pyx
@@ -102,8 +102,10 @@ cdef class PhraseMatcher:
         cdef vector[MapStruct*] path_nodes
         cdef vector[key_t] path_keys
         cdef key_t key_to_remove
-        for keyword in self._docs[key]:
+        for keyword in sorted(self._docs[key], key=lambda x: len(x), reverse=True):
             current_node = self.c_map
+            path_nodes.clear()
+            path_keys.clear()
             for token in keyword:
                 result = map_get(current_node, token)
                 if result:

--- a/spacy/tests/matcher/test_phrase_matcher.py
+++ b/spacy/tests/matcher/test_phrase_matcher.py
@@ -226,3 +226,13 @@ def test_phrase_matcher_callback(en_vocab):
     matcher.add("COMPANY", mock, pattern)
     matches = matcher(doc)
     mock.assert_called_once_with(matcher, doc, 0, matches)
+
+
+def test_phrase_matcher_remove_overlapping_patterns(en_vocab):
+    matcher = PhraseMatcher(en_vocab)
+    pattern1 = Doc(en_vocab, words=["this"])
+    pattern2 = Doc(en_vocab, words=["this", "is"])
+    pattern3 = Doc(en_vocab, words=["this", "is", "a"])
+    pattern4 = Doc(en_vocab, words=["this", "is", "a", "word"])
+    matcher.add("THIS", None, pattern1, pattern2, pattern3, pattern4)
+    matcher.remove("THIS")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Fix PhraseMatcher.remove() for overlapping patterns:

* Remove patterns in order of reverse length
* Reset stored path through trie between multiple removes for the same match ID
* Add test

Fixes #4435.

### Types of change

Bugfix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
