### PR TITLE
add meta to Defaults

### DIFF
--- a/spacy/lang/ja/__init__.py
+++ b/spacy/lang/ja/__init__.py
@@ -111,6 +111,7 @@ class JapaneseDefaults(Language.Defaults):
     stop_words = STOP_WORDS
     tag_map = TAG_MAP
     writing_system = {"direction": "ltr", "has_case": False, "has_letters": False}
+    meta = {"requirements": ["mecab-python3"]}
 
     @classmethod
     def create_tokenizer(cls, nlp=None):

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1,10 +1,8 @@
 # coding: utf8
 from __future__ import absolute_import, unicode_literals
 
-import atexit
 import random
 import itertools
-from warnings import warn
 from spacy.util import minibatch
 import weakref
 import functools
@@ -123,6 +121,7 @@ class BaseDefaults(object):
     writing_system = {"direction": "ltr", "has_case": True, "has_letters": True}
     single_orth_variants = []
     paired_orth_variants = []
+    meta = {}
 
 
 class Language(object):
@@ -157,7 +156,7 @@ class Language(object):
     }
 
     def __init__(
-        self, vocab=True, make_doc=True, max_length=10 ** 6, meta={}, **kwargs
+        self, vocab=True, make_doc=True, max_length=10 ** 6, meta=None, **kwargs
     ):
         """Initialise a Language object.
 
@@ -180,7 +179,10 @@ class Language(object):
         """
         user_factories = util.get_entry_points(util.ENTRY_POINTS.factories)
         self.factories.update(user_factories)
-        self._meta = dict(meta)
+        if meta:
+            self._meta = dict(meta)
+        else:
+            self._meta = meta = deepcopy(self.Defaults.meta)
         self._path = None
         if vocab is True:
             factory = self.Defaults.create_vocab

--- a/spacy/tests/serialize/test_serialize_language.py
+++ b/spacy/tests/serialize/test_serialize_language.py
@@ -20,6 +20,7 @@ def meta_data():
         "url": "url-in-fixture",
         "license": "license-in-fixture",
         "vectors": {"width": 0, "vectors": 0, "keys": 0, "name": None},
+        "requirements": ["requirement-in-fixture"],
     }
 
 


### PR DESCRIPTION
Add `nlp.meta` field to `language.Defaults` so that `Language` interface users can provide default meta information, e.g. requirements.

For example, `ja.Japanese` requires `mecab-python3` package, so this class should add the package name into `meta["requirements"]`. (`ja.Japanese` is also modified in this PR as an example.)

### Types of change

Enhancement.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
