### PR TITLE
Fix documentation for the docs_to_json function

### DIFF
--- a/spacy/gold.pyx
+++ b/spacy/gold.pyx
@@ -743,7 +743,8 @@ def docs_to_json(docs, id=0):
 
     docs (iterable / Doc): The Doc object(s) to convert.
     id (int): Id for the JSON.
-    RETURNS (list): The data in spaCy's JSON format.
+    RETURNS (dict): The data in spaCy's JSON format 
+        - each input doc will be treated as a paragraph in the output doc
     """
     if isinstance(docs, Doc):
         docs = [docs]

--- a/website/docs/api/goldparse.md
+++ b/website/docs/api/goldparse.md
@@ -62,7 +62,7 @@ Whether the provided syntactic annotations form a projective dependency tree.
 
 Convert a list of Doc objects into the
 [JSON-serializable format](/api/annotation#json-input) used by the
-[`spacy train`](/api/cli#train) command.
+[`spacy train`](/api/cli#train) command. Each input doc will be treated as a 'paragraph' in the output doc.
 
 > #### Example
 >
@@ -77,7 +77,7 @@ Convert a list of Doc objects into the
 | ----------- | ---------------- | ------------------------------------------ |
 | `docs`      | iterable / `Doc` | The `Doc` object(s) to convert.            |
 | `id`        | int              | ID to assign to the JSON. Defaults to `0`. |
-| **RETURNS** | list             | The data in spaCy's JSON format.           |
+| **RETURNS** | dict             | The data in spaCy's JSON format.           |
 
 ### gold.align {#align tag="function"}
 


### PR DESCRIPTION
Update documentation for the docs_to_gold function.

## Description
The

### Types of change
The `docs_to_json` function returns a dict not a list - i've updated the description to reflext the actual function of the code.

This is a PR for: https://github.com/explosion/spaCy/issues/4452

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x ] I have submitted the spaCy Contributor Agreement.
- [x ] My changes don't require a change to the documentation, or if they do, I've added all required information.
