### PR TITLE
Remove lemma attrs on BaseDefaults

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -112,10 +112,6 @@ class BaseDefaults(object):
     tag_map = dict(TAG_MAP)
     tokenizer_exceptions = {}
     stop_words = set()
-    lemma_rules = {}
-    lemma_exc = {}
-    lemma_index = {}
-    lemma_lookup = {}
     morph_rules = {}
     lex_attr_getters = LEX_ATTRS
     syntax_iterators = {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Also see #4426: Because the attributes like `lemma_lookup` are still available on the base defaults, user code that writes to them still works, even though they're not used anymore (and have been replaced by the lookups via `nlp.vocab.lookups`).

Open questions: Should we raise an error here instead, and if so, how should this be implemented? Should we make the attributes properties with a setter that raises an error?

### Types of change
enhancements

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
