### PR TITLE
Auto-add language-specific dependencies from extras_require to meta

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,10 @@ ko =
     natto-py==0.9.0
 th =
     pythainlp>=2.0
+ru =
+    pymorphy2==0.8
+vi =
+    pyvi>=0.0.9
 
 [bdist_wheel]
 universal = false

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -223,6 +223,9 @@ class Language(object):
         }
         self._meta["pipeline"] = self.pipe_names
         self._meta["labels"] = self.pipe_labels
+        self._meta.setdefault("requirements", [])
+        lang_requirements = util.PKG_EXTRAS.get(self._meta["lang"], [])
+        self._meta["requirements"].extend(lang_requirements)
         return self._meta
 
     @meta.setter

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -6,7 +6,7 @@ import importlib
 import re
 from pathlib import Path
 import random
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from thinc.neural._classes.model import Model
 from thinc.neural.ops import NumpyOps
 import functools
@@ -29,6 +29,7 @@ from .symbols import ORTH
 from .compat import cupy, CudaStream, path2str, basestring_, unicode_
 from .compat import import_file, importlib_metadata
 from .errors import Errors, Warnings, deprecation_warning
+from . import about
 
 
 LANGUAGES = {}
@@ -40,6 +41,17 @@ _PRINT_ENV = False
 # NB: Ony ever call this once! If called more than ince within the
 # function, test_issue1506 hangs and it's not 100% clear why.
 AVAILABLE_ENTRY_POINTS = importlib_metadata.entry_points()
+
+# Build a dict based on the extras_require (see setup.cfg) so we can
+# automatically populate the nlp.meta["requirements"] for languages with
+# external dependencies. This will also be reflected in model packages that
+# users build.
+PKG_EXTRAS = defaultdict(list)
+extras_pattern = re.compile(r'(.+); extra == "(.+)"')
+for req in importlib_metadata.requires(about.__title__):
+    if "extra ==" in req:
+        pkg, extra = extras_pattern.match(req).group(1, 2)
+        PKG_EXTRAS[extra].append(pkg)
 
 
 class ENTRY_POINTS(object):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Based on the suggestion in #4447. Use `importlib_metadata` to get all language-specific dependencies (via `extras_require`) and auto-populate `nlp.meta["requirements"]` if packages are found for the current language.

Mostly intended to show how this could work. I'm really not sure if it's worth it – this seems to be the only way to implement that kind of feature and it feels really hacky and brittle.

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
