### PR TITLE
Make entity_ruler ent_id resolution 2x faster and add docs for "id" in patterns

### DIFF
--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -19,6 +19,7 @@ class EntityRuler(object):
     `EntityRecognizer` to boost accuracy, or used on its own to implement a
     purely rule-based entity recognition system. After initialization, the
     component is typically added to the pipeline using `nlp.add_pipe`.
+
     DOCS: https://spacy.io/api/entityruler
     USAGE: https://spacy.io/usage/rule-based-matching#entityruler
     """
@@ -121,10 +122,10 @@ class EntityRuler(object):
         all_labels = set(self.token_patterns.keys())
         all_labels.update(self.phrase_patterns.keys())
         return tuple(all_labels)
-    
+
     @property
     def ent_ids(self):
-        """All entity ids present in the match patterns meta dicts.
+        """All entity ids present in the match patterns `id` properties
         RETURNS (set): The string entity ids.
         DOCS: https://spacy.io/api/entityruler#ent_ids
         """
@@ -183,7 +184,7 @@ class EntityRuler(object):
                     label = self._create_label(label, entry["id"])
                     key = self.matcher._normalize_key(label)
                     self._ent_ids[key] = (ent_label, entry["id"])
-                    
+
                 pattern = entry["pattern"]
                 if isinstance(pattern, basestring_):
                     self.phrase_patterns[label].append(self.nlp(pattern))

--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -31,6 +31,7 @@ class EntityRuler(object):
         need to be a list of dictionaries with a `"label"` and `"pattern"`
         key. A pattern can either be a token pattern (list) or a phrase pattern
         (string). For example: `{'label': 'ORG', 'pattern': 'Apple'}`.
+
         nlp (Language): The shared nlp object to pass the vocab to the matchers
             and process phrase patterns.
         phrase_matcher_attr (int / unicode): Token attribute to match on, passed
@@ -43,6 +44,7 @@ class EntityRuler(object):
         **cfg: Other config parameters. If pipeline component is loaded as part
             of a model pipeline, this will include all keyword arguments passed
             to `spacy.load`.
+
         RETURNS (EntityRuler): The newly constructed object.
         DOCS: https://spacy.io/api/entityruler#init
         """
@@ -79,7 +81,9 @@ class EntityRuler(object):
 
     def __call__(self, doc):
         """Find matches in document and add them as entities.
+
         doc (Doc): The Doc object in the pipeline.
+
         RETURNS (Doc): The Doc with added entities, if available.
         DOCS: https://spacy.io/api/entityruler#call
         """
@@ -116,6 +120,7 @@ class EntityRuler(object):
     @property
     def labels(self):
         """All labels present in the match patterns.
+
         RETURNS (set): The string labels.
         DOCS: https://spacy.io/api/entityruler#labels
         """
@@ -126,6 +131,7 @@ class EntityRuler(object):
     @property
     def ent_ids(self):
         """All entity ids present in the match patterns `id` properties
+
         RETURNS (set): The string entity ids.
         DOCS: https://spacy.io/api/entityruler#ent_ids
         """
@@ -139,6 +145,7 @@ class EntityRuler(object):
     @property
     def patterns(self):
         """Get all patterns that were added to the entity ruler.
+
         RETURNS (list): The original patterns, one dictionary per pattern.
         DOCS: https://spacy.io/api/entityruler#patterns
         """
@@ -166,6 +173,7 @@ class EntityRuler(object):
         {'label': 'ORG', 'pattern': 'Apple'}
         {'label': 'GPE', 'pattern': [{'lower': 'san'}, {'lower': 'francisco'}]}
         patterns (list): The patterns to add.
+
         DOCS: https://spacy.io/api/entityruler#add_patterns
         """
         # disable the nlp components after this one in case they hadn't been initialized / deserialised yet
@@ -199,6 +207,7 @@ class EntityRuler(object):
 
     def _split_label(self, label):
         """Split Entity label into ent_label and ent_id if it contains self.ent_id_sep
+
         RETURNS (tuple): ent_label, ent_id
         """
         if self.ent_id_sep in label:
@@ -211,6 +220,7 @@ class EntityRuler(object):
 
     def _create_label(self, label, ent_id):
         """Join Entity label with ent_id if the pattern has an `id` attribute
+
         RETURNS (str): The ent_label joined with configured `ent_id_sep`
         """
         if isinstance(ent_id, basestring_):
@@ -221,6 +231,7 @@ class EntityRuler(object):
         """Load the entity ruler from a bytestring.
         patterns_bytes (bytes): The bytestring to load.
         **kwargs: Other config paramters, mostly for consistency.
+
         RETURNS (EntityRuler): The loaded entity ruler.
         DOCS: https://spacy.io/api/entityruler#from_bytes
         """
@@ -240,6 +251,7 @@ class EntityRuler(object):
 
     def to_bytes(self, **kwargs):
         """Serialize the entity ruler patterns to a bytestring.
+
         RETURNS (bytes): The serialized patterns.
         DOCS: https://spacy.io/api/entityruler#to_bytes
         """

--- a/website/docs/api/entityruler.md
+++ b/website/docs/api/entityruler.md
@@ -202,6 +202,14 @@ All labels present in the match patterns.
 | ----------- | ----- | ------------------ |
 | **RETURNS** | tuple | The string labels. |
 
+## EntityRuler.ent_ids {#labels tag="property"}
+
+All entity ids present in the match patterns `id` properties
+
+| Name        | Type  | Description        |
+| ----------- | ----- | ------------------ |
+| **RETURNS** | tuple | The string ent_ids. |
+
 ## EntityRuler.patterns {#patterns tag="property"}
 
 Get all patterns that were added to the entity ruler.

--- a/website/docs/usage/rule-based-matching.md
+++ b/website/docs/usage/rule-based-matching.md
@@ -986,6 +986,33 @@ doc = nlp("Apple is opening its first big office in San Francisco.")
 print([(ent.text, ent.label_) for ent in doc.ents])
 ```
 
+### Adding ids to patterns {#entityruler-ent-ids}
+
+The [`EntityRuler`](/api/entityruler) can also accept an `id` attribute for each pattern. Using the `id` attribute allows multiple patterns to be associated with the same entity.
+
+```python
+### {executable="true"}
+from spacy.lang.en import English
+from spacy.pipeline import EntityRuler
+
+nlp = English()
+ruler = EntityRuler(nlp)
+patterns = [{"label": "ORG", "pattern": "Apple", "id": "apple"},
+            {"label": "GPE", "pattern": [{"LOWER": "san"}, {"LOWER": "francisco"}], "id": "san-francisco"},
+            {"label": "GPE", "pattern": [{"LOWER": "san"}, {"LOWER": "fran"}], "id": "san-francisco"}]
+ruler.add_patterns(patterns)
+nlp.add_pipe(ruler)
+
+doc1 = nlp("Apple is opening its first big office in San Francisco.")
+print([(ent.text, ent.label_, ent.ent_id_) for ent in doc1.ents])
+
+doc2 = nlp("Apple is opening its first big office in San Fran.")
+print([(ent.text, ent.label_, ent.ent_id_) for ent in doc2.ents])
+```
+
+If the `id` attribute is included in the [`EntityRuler`](/api/entityruler) patterns, the `ent_id_` property of the matched entity is set to the `id` given in the patterns. So in the example above it's easy to identify that "San Francisco" and "San Fran" are both the same entity.
+
+
 The entity ruler is designed to integrate with spaCy's existing statistical
 models and enhance the named entity recognizer. If it's added **before the
 `"ner"` component**, the entity recognizer will respect the existing entity


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

Make entity_ruler ent_id resolution 2x faster and add docs for "id" in patterns

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Create a mapping dict for the ent_ids so resolution of ent_ids is a dict lookup instead of a vocab lookup and string split. In some rough experiments this makes the entityruler run 2x faster.

Also adding initial docs for the "id" property in patterns.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

enhancement and documentation

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x ] I have submitted the spaCy Contributor Agreement.
- [x ] I ran the tests, and all new and existing tests passed.
- [x ] My changes don't require a change to the documentation, or if they do, I've added all required information.
