### PR TITLE
Fix GoldParse init

### DIFF
--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -607,7 +607,7 @@ cdef class Parser:
                     ids, words, tags, heads, deps, ents = annots
                     doc_sample.append(Doc(self.vocab, words=words))
                     gold_sample.append(GoldParse(doc_sample[-1], words=words, tags=tags,
-                                                 heads=heads, deps=deps, ents=ents))
+                                                 heads=heads, deps=deps, entities=ents))
             self.model.begin_training(doc_sample, gold_sample)
             if pipeline is not None:
                 self.init_multitask_objectives(get_gold_tuples, pipeline, sgd=sgd, **cfg)


### PR DESCRIPTION
The `GoldParse` init constructor has a catch-all `**_` which seems to have led to a subtle bug in `nn_parser.pyx`.

Personally I would prefer removing `**_` from the constructor, but this may break people's scripts (though the breaking might be informational). We can also remove it as part of the v.3.0 release. Unless there is a reason to keep this?

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
