### PR TITLE
modified gold.align to handle space tokens

### DIFF
--- a/spacy/gold.pyx
+++ b/spacy/gold.pyx
@@ -127,6 +127,14 @@ def align(tokens_a, tokens_b):
             offset_a = offset_b = 0
             i += 1
             j += 1
+        elif a == "":
+            assert offset_a == 0
+            cost += 1
+            i += 1
+        elif b == "":
+            assert offset_b == 0
+            cost += 1
+            j += 1
         elif b.startswith(a):
             cost += 1
             if offset_a == 0:

--- a/spacy/tests/test_gold.py
+++ b/spacy/tests/test_gold.py
@@ -197,6 +197,7 @@ def test_roundtrip_docs_to_json():
             ["a", "b", "c", "d"],
             (3, [0, 1, -1], [0, 1, -1, -1], {}, {2: 2, 3: 2}),
         ),
+        ([" ", "a"], ["a"], (1, [-1, 0], [1], {}, {})),
     ],
 )
 def test_align(tokens_a, tokens_b, expected):
@@ -206,3 +207,11 @@ def test_align(tokens_a, tokens_b, expected):
     cost, a2b, b2a, a2b_multi, b2a_multi = align(tokens_b, tokens_a)
     assert (cost, list(b2a), list(a2b), b2a_multi, a2b_multi) == expected
 
+
+def test_goldparse_startswith_space(en_tokenizer):
+    text = " a"
+    doc = en_tokenizer(text)
+    g = GoldParse(doc, words=["a"], entities=["U-DATE"], deps=["ROOT"], heads=[0])
+    assert g.words == [" ", "a"]
+    assert g.ner == [None, "U-DATE"]
+    assert g.labels == [None, "ROOT"]


### PR DESCRIPTION
Please see https://github.com/explosion/spaCy/pull/4526#issuecomment-546739757

This bug is due to space normalized to `""` and `string.startswith("")` returning `True`.
So I changed the `gold.align` to just consume `""`.