### PR TITLE
Fix serialization of extension attr values in DocBin

### DIFF
--- a/spacy/tests/regression/test_issue4528.py
+++ b/spacy/tests/regression/test_issue4528.py
@@ -1,11 +1,9 @@
 # coding: utf8
 from __future__ import unicode_literals
 
-import pytest
 from spacy.tokens import Doc, DocBin
 
 
-@pytest.mark.xfail
 def test_issue4528(en_vocab):
     """Test that user_data is correctly serialized in DocBin."""
     doc = Doc(en_vocab, words=["hello", "world"])

--- a/spacy/tokens/_serialize.py
+++ b/spacy/tokens/_serialize.py
@@ -103,7 +103,8 @@ class DocBin(object):
             doc = Doc(vocab, words=words, spaces=spaces)
             doc = doc.from_array(self.attrs, tokens)
             if self.store_user_data:
-                doc.user_data.update(srsly.msgpack_loads(self.user_data[i]))
+                user_data = srsly.msgpack_loads(self.user_data[i], use_list=False)
+                doc.user_data.update(user_data)
             yield doc
 
     def merge(self, other):


### PR DESCRIPTION
Fixes #4528.

## Description

Extension attribute values are stored in the `doc.user_data` dictionary, keyed by a tuple. This caused serialization issues if `use_list=False` wasn't set on `srlsy.msgpack_loads`.

### Types of change
bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
