### PR TITLE
Support span._. in component decorator attrs

### DIFF
--- a/spacy/analysis.py
+++ b/spacy/analysis.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from collections import OrderedDict
 from wasabi import Printer
 
-from .tokens import Doc, Token
+from .tokens import Doc, Token, Span
 from .errors import Errors, Warnings, user_warning
 
 
@@ -78,12 +78,15 @@ def validate_attrs(values):
     RETURNS (iterable): The checked attributes.
     """
     data = dot_to_dict(values)
-    objs = {"doc": Doc, "token": Token}
+    objs = {"doc": Doc, "token": Token, "span": Span}
     for obj_key, attrs in data.items():
-        if obj_key not in objs:  # first element is not doc/token
-            if obj_key == "span":
-                span_attrs = [attr for attr in values if attr.startswith("span.")]
+        if obj_key == "span":
+            # Support Span only for custom extension attributes
+            span_attrs = [attr for attr in values if attr.startswith("span.")]
+            span_attrs = [attr for attr in span_attrs if not attr.startswith("span._.")]
+            if span_attrs:
                 raise ValueError(Errors.E180.format(attrs=", ".join(span_attrs)))
+        if obj_key not in objs:  # first element is not doc/token/span
             invalid_attrs = ", ".join(a for a in values if a.startswith(obj_key))
             raise ValueError(Errors.E181.format(obj=obj_key, attrs=invalid_attrs))
         if not isinstance(attrs, dict):  # attr is something like "doc"

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -515,7 +515,8 @@ class Errors(object):
             "in a list. For example: matcher.add('{key}', [doc])")
     E180 = ("Span attributes can't be declared as required or assigned by "
             "components, since spans are only views of the Doc. Use Doc and "
-            "Token attributes only and remove the following: {attrs}")
+            "Token attributes (or custom extension attributes) only and remove "
+            "the following: {attrs}")
     E181 = ("Received invalid attributes for unkown object {obj}: {attrs}. "
             "Only Doc and Token attributes are supported.")
     E182 = ("Received invalid attribute declaration: {attr}\nDid you forget "

--- a/spacy/tests/pipeline/test_analysis.py
+++ b/spacy/tests/pipeline/test_analysis.py
@@ -121,7 +121,7 @@ def test_component_factories_from_nlp():
 
 
 def test_analysis_validate_attrs_valid():
-    attrs = ["doc.sents", "doc.ents", "token.tag", "token._.xyz"]
+    attrs = ["doc.sents", "doc.ents", "token.tag", "token._.xyz", "span._.xyz"]
     assert validate_attrs(attrs)
     for attr in attrs:
         assert validate_attrs([attr])
@@ -139,6 +139,7 @@ def test_analysis_validate_attrs_valid():
         "token.tag_",
         "token.tag.xyz",
         "token._.xyz.abc",
+        "span.label",
     ],
 )
 def test_analysis_validate_attrs_invalid(attr):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

While it doesn't really make sense to have the `@component` decorator specify attributes like `span.label_` as requirements, user may still want to set extension attributes like `span._.custom_label`. This PR allows this.

### Types of change
bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
