### PR TITLE
Improve gold alignment

### DIFF
--- a/spacy/_align.pyx
+++ b/spacy/_align.pyx
@@ -103,8 +103,8 @@ def align(S, T):
 
     fill_matrix(<int*>matrix.data,
         <const int*>S_arr.data, m, <const int*>T_arr.data, n)
-    fill_i2j(i2j, matrix)
-    fill_j2i(j2i, matrix)
+    fill_alignment(i2j, matrix)
+    fill_alignment(j2i, matrix.transpose())
     for i in range(i2j.shape[0]):
         if i2j[i] >= 0 and len(S[i]) != len(T[i2j[i]]):
             i2j[i] = -1
@@ -229,7 +229,7 @@ cdef void fill_matrix(int* D,
             D[i1_j1] = best
 
 
-cdef void fill_i2j(np.ndarray i2j, np.ndarray D) except *:
+cdef void fill_alignment(np.ndarray i2j, np.ndarray D) except *:
     j = D.shape[1]-2
     cdef int i = D.shape[0]-2
     while i >= 0:
@@ -241,16 +241,3 @@ cdef void fill_i2j(np.ndarray i2j, np.ndarray D) except *:
             i2j[i] = j
             j -= 1
         i -= 1
-
-cdef void fill_j2i(np.ndarray j2i, np.ndarray D) except *:
-    i = D.shape[0]-2
-    cdef int j = D.shape[1]-2
-    while j >= 0:
-        while D[i, j+1] < D[i+1, j+1]:
-            i -= 1
-        if D[i+1, j] < D[i+1, j+1]:
-            j2i[j] = -1
-        else:
-            j2i[j] = i
-            i -= 1
-        j -= 1

--- a/spacy/tests/test_align.py
+++ b/spacy/tests/test_align.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import pytest
+import numpy as np
 from spacy._align import align, multi_align
 
 
@@ -75,5 +76,81 @@ def test_align_many_to_one():
     assert i2j_multi[5] == 3
     assert i2j_multi[6] == 3
 
-    assert j2i_multi[0] == 1
-    assert j2i_multi[1] == 3
+    assert j2i_multi == {}
+
+
+def test_align_one_to_many():
+    # should be the same as many_to_one except i/j swapped
+    words1 = ["ab", "bc", "e", "fg", "h"]
+    words2 = ["a", "b", "c", "d", "e", "f", "g", "h"]
+    cost, i2j, j2i, matrix = align(words1, words2)
+    assert list(j2i) == [-1, -1, -1, -1, 2, -1, -1, 4]
+    lengths1 = [len(w) for w in words1]
+    lengths2 = [len(w) for w in words2]
+    i2j_multi, j2i_multi = multi_align(i2j, j2i, lengths1, lengths2)
+
+    assert i2j_multi == {}
+
+    assert j2i_multi[0] == 0
+    assert j2i_multi[1] == 0
+    assert j2i_multi[2] == 1
+    assert j2i_multi[3] == 1
+    assert j2i_multi[3] == 1
+    assert j2i_multi[5] == 3
+    assert j2i_multi[6] == 3
+
+
+def test_align_whitespace():
+    words1 = [" ", "a", "b"]
+    words2 = ["a", "b"]
+    cost, i2j, j2i, matrix = align(words1, words2)
+    assert list(i2j) == [-1, 0, 1]
+    assert list(j2i) == [1, 2]
+
+    words1 = ["a", " ", "b"]
+    words2 = ["a", "b"]
+    cost, i2j, j2i, matrix = align(words1, words2)
+    assert list(i2j) == [0, -1, 1]
+    assert list(j2i) == [0, 2]
+
+    words1 = ["a", "b"]
+    words2 = ["a", " ", "b"]
+    cost, i2j, j2i, matrix = align(words1, words2)
+    assert list(i2j) == [0, 2]
+    assert list(j2i) == [0, -1, 1]
+
+    words1 = ["a", "b", " "]
+    words2 = ["a", "b"]
+    cost, i2j, j2i, matrix = align(words1, words2)
+    assert list(i2j) == [0, 1, -1]
+    assert list(j2i) == [0, 1]
+
+    words1 = ["\n", "a", "\n\n", "b"]
+    words2 = ["a", "b"]
+    cost, i2j, j2i, matrix = align(words1, words2)
+    assert list(i2j) == [-1, 0, -1, 1]
+    assert list(j2i) == [1, 3]
+
+
+def test_align_is_symmetric():
+    words1 = ["a", " ", "b"]
+    words2 = ["a", "B", "\n"]
+    cost_a, i2j_a, j2i_a, matrix_a = align(words1, words2)
+    cost_b, i2j_b, j2i_b, matrix_b = align(words2, words1)
+    assert cost_a == cost_b
+    assert np.array_equal(i2j_a, j2i_b)
+    assert np.array_equal(j2i_a, i2j_b)
+    assert np.array_equal(matrix_a, np.transpose(matrix_b))
+
+
+def test_multi_align_is_symmetric():
+    words1 = ["a", "b", "cd"]
+    words2 = ["ab", "c", "d"]
+    cost_a, i2j_a, j2i_a, matrix_a = align(words1, words2)
+    cost_b, i2j_b, j2i_b, matrix_b = align(words2, words1)
+    lengths1 = [len(w) for w in words1]
+    lengths2 = [len(w) for w in words2]
+    i2j_multi_a, j2i_multi_a = multi_align(i2j_a, j2i_a, lengths1, lengths2)
+    i2j_multi_b, j2i_multi_b = multi_align(i2j_b, j2i_b, lengths2, lengths1)
+    assert np.array_equal(i2j_multi_a, j2i_multi_b)
+    assert np.array_equal(j2i_multi_a, i2j_multi_b)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Improve gold alignment functions:

* Fix `j2i_multi`. Fixes #4525 in original align implementation.

* Add tests symmetry of `align()` and `multi_align()`

* Clean up redundant code.

To do:

- [ ] clarify/improve substitution behavior
- [ ] refine tests (currently xfailed) with desired behavior

See #4554.

### Types of change

Bugfixes, enhancements.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
