### PR TITLE
Fix multiprocessing for as_tuples=True

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -769,6 +769,7 @@ class Language(object):
                 texts,
                 batch_size=batch_size,
                 disable=disable,
+                n_process=n_process,
                 component_cfg=component_cfg,
             )
             for doc, context in izip(docs, contexts):


### PR DESCRIPTION
We weren't passing the `n_process` setting through when we have `nlp.pipe(as_tuples=True)`.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
