### PR TITLE
Replace function registries with catalogue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,12 @@ blis>=0.4.0,<0.5.0
 murmurhash>=0.28.0,<1.1.0
 wasabi>=0.4.0,<1.1.0
 srsly>=0.1.0,<1.1.0
+catalogue>=0.0.7,<1.1.0
 # Third party dependencies
 numpy>=1.15.0
 requests>=2.13.0,<3.0.0
 plac>=0.9.6,<1.2.0
 pathlib==1.0.1; python_version < "3.4"
-importlib_metadata>=0.20; python_version < "3.8"
 # Optional dependencies
 jsonschema>=2.6.0,<3.1.0
 # Development dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,13 +48,13 @@ install_requires =
     blis>=0.4.0,<0.5.0
     wasabi>=0.4.0,<1.1.0
     srsly>=0.1.0,<1.1.0
+    catalogue>=0.0.7,<1.1.0
     # Third-party dependencies
     setuptools
     numpy>=1.15.0
     plac>=0.9.6,<1.2.0
     requests>=2.13.0,<3.0.0
     pathlib==1.0.1; python_version < "3.4"
-    importlib_metadata>=0.20; python_version < "3.8"
 
 [options.extras_require]
 lookups =

--- a/spacy/__init__.py
+++ b/spacy/__init__.py
@@ -15,7 +15,7 @@ from .glossary import explain
 from .about import __version__
 from .errors import Errors, Warnings, deprecation_warning
 from . import util
-from .util import register_architecture, get_architecture
+from .util import registry
 from .language import component
 
 

--- a/spacy/compat.py
+++ b/spacy/compat.py
@@ -36,11 +36,6 @@ try:
 except ImportError:
     cupy = None
 
-try:  # Python 3.8
-    import importlib.metadata as importlib_metadata
-except ImportError:
-    import importlib_metadata  # noqa: F401
-
 try:
     from thinc.neural.optimizers import Optimizer  # noqa: F401
 except ImportError:

--- a/spacy/displacy/render.py
+++ b/spacy/displacy/render.py
@@ -5,7 +5,7 @@ import uuid
 
 from .templates import TPL_DEP_SVG, TPL_DEP_WORDS, TPL_DEP_ARCS, TPL_ENTS
 from .templates import TPL_ENT, TPL_ENT_RTL, TPL_FIGURE, TPL_TITLE, TPL_PAGE
-from ..util import minify_html, escape_html, get_entry_points, ENTRY_POINTS
+from ..util import minify_html, escape_html, registry
 from ..errors import Errors
 
 
@@ -242,7 +242,7 @@ class EntityRenderer(object):
             "CARDINAL": "#e4e7d2",
             "PERCENT": "#e4e7d2",
         }
-        user_colors = get_entry_points(ENTRY_POINTS.displacy_colors)
+        user_colors = registry.displacy_colors.get_all()
         for user_color in user_colors.values():
             colors.update(user_color)
         colors.update(options.get("colors", {}))

--- a/spacy/lang/en/__init__.py
+++ b/spacy/lang/en/__init__.py
@@ -13,7 +13,7 @@ from ..tokenizer_exceptions import BASE_EXCEPTIONS
 from ..norm_exceptions import BASE_NORMS
 from ...language import Language
 from ...attrs import LANG, NORM
-from ...util import update_exc, add_lookups
+from ...util import update_exc, add_lookups, registry
 
 
 def _return_en(_):
@@ -42,6 +42,7 @@ class EnglishDefaults(Language.Defaults):
     ]
 
 
+@registry.languages.register("en")
 class English(Language):
     lang = "en"
     Defaults = EnglishDefaults

--- a/spacy/lang/en/__init__.py
+++ b/spacy/lang/en/__init__.py
@@ -13,7 +13,7 @@ from ..tokenizer_exceptions import BASE_EXCEPTIONS
 from ..norm_exceptions import BASE_NORMS
 from ...language import Language
 from ...attrs import LANG, NORM
-from ...util import update_exc, add_lookups, registry
+from ...util import update_exc, add_lookups
 
 
 def _return_en(_):
@@ -42,7 +42,6 @@ class EnglishDefaults(Language.Defaults):
     ]
 
 
-@registry.languages.register("en")
 class English(Language):
     lang = "en"
     Defaults = EnglishDefaults

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -35,7 +35,7 @@ from . import util
 from . import about
 
 
-ENABLE_PIPELINE_ANALYSIS = False
+ENABLE_PIPELINE_ANALYSIS = True
 
 
 class BaseDefaults(object):
@@ -51,8 +51,8 @@ class BaseDefaults(object):
         filenames = {name: root / filename for name, filename in cls.resources}
         if LANG in cls.lex_attr_getters:
             lang = cls.lex_attr_getters[LANG](None)
-            user_lookups = util.get_entry_point(util.ENTRY_POINTS.lookups, lang, {})
-            filenames.update(user_lookups)
+            if lang in util.registry.lookups:
+                filenames.update(util.registry.lookups.get(lang))
         lookups = Lookups()
         for name, filename in filenames.items():
             data = util.load_language_data(filename)
@@ -155,7 +155,7 @@ class Language(object):
             100,000 characters in one text.
         RETURNS (Language): The newly constructed object.
         """
-        user_factories = util.get_entry_points(util.ENTRY_POINTS.factories)
+        user_factories = util.registry.factories.get_all()
         self.factories.update(user_factories)
         self._meta = dict(meta)
         self._path = None

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -35,7 +35,7 @@ from . import util
 from . import about
 
 
-ENABLE_PIPELINE_ANALYSIS = True
+ENABLE_PIPELINE_ANALYSIS = False
 
 
 class BaseDefaults(object):

--- a/spacy/ml/common.py
+++ b/spacy/ml/common.py
@@ -3,10 +3,10 @@ from __future__ import unicode_literals
 from thinc.api import chain
 from thinc.v2v import Maxout
 from thinc.misc import LayerNorm
-from ..util import register_architecture, make_layer
+from ..util import registry, make_layer
 
 
-@register_architecture("thinc.FeedForward.v1")
+@registry.architectures.register("thinc.FeedForward.v1")
 def FeedForward(config):
     layers = [make_layer(layer_cfg) for layer_cfg in config["layers"]]
     model = chain(*layers)
@@ -14,7 +14,7 @@ def FeedForward(config):
     return model
 
 
-@register_architecture("spacy.LayerNormalizedMaxout.v1")
+@registry.architectures.register("spacy.LayerNormalizedMaxout.v1")
 def LayerNormalizedMaxout(config):
     width = config["width"]
     pieces = config["pieces"]

--- a/spacy/ml/tok2vec.py
+++ b/spacy/ml/tok2vec.py
@@ -6,11 +6,11 @@ from thinc.v2v import Maxout, Model
 from thinc.i2v import HashEmbed, StaticVectors
 from thinc.t2t import ExtractWindow
 from thinc.misc import Residual, LayerNorm, FeatureExtracter
-from ..util import make_layer, register_architecture
+from ..util import make_layer, registry
 from ._wire import concatenate_lists
 
 
-@register_architecture("spacy.Tok2Vec.v1")
+@registry.architectures.register("spacy.Tok2Vec.v1")
 def Tok2Vec(config):
     doc2feats = make_layer(config["@doc2feats"])
     embed = make_layer(config["@embed"])
@@ -24,13 +24,13 @@ def Tok2Vec(config):
     return tok2vec
 
 
-@register_architecture("spacy.Doc2Feats.v1")
+@registry.architectures.register("spacy.Doc2Feats.v1")
 def Doc2Feats(config):
     columns = config["columns"]
     return FeatureExtracter(columns)
 
 
-@register_architecture("spacy.MultiHashEmbed.v1")
+@registry.architectures.register("spacy.MultiHashEmbed.v1")
 def MultiHashEmbed(config):
     # For backwards compatibility with models before the architecture registry,
     # we have to be careful to get exactly the same model structure. One subtle
@@ -78,7 +78,7 @@ def MultiHashEmbed(config):
     return layer
 
 
-@register_architecture("spacy.CharacterEmbed.v1")
+@registry.architectures.register("spacy.CharacterEmbed.v1")
 def CharacterEmbed(config):
     from .. import _ml
 
@@ -94,7 +94,7 @@ def CharacterEmbed(config):
     return model
 
 
-@register_architecture("spacy.MaxoutWindowEncoder.v1")
+@registry.architectures.register("spacy.MaxoutWindowEncoder.v1")
 def MaxoutWindowEncoder(config):
     nO = config["width"]
     nW = config["window_size"]
@@ -110,7 +110,7 @@ def MaxoutWindowEncoder(config):
     return model
 
 
-@register_architecture("spacy.MishWindowEncoder.v1")
+@registry.architectures.register("spacy.MishWindowEncoder.v1")
 def MishWindowEncoder(config):
     from thinc.v2v import Mish
 
@@ -124,12 +124,12 @@ def MishWindowEncoder(config):
     return model
 
 
-@register_architecture("spacy.PretrainedVectors.v1")
+@registry.architectures.register("spacy.PretrainedVectors.v1")
 def PretrainedVectors(config):
     return StaticVectors(config["vectors_name"], config["width"], config["column"])
 
 
-@register_architecture("spacy.TorchBiLSTMEncoder.v1")
+@registry.architectures.register("spacy.TorchBiLSTMEncoder.v1")
 def TorchBiLSTMEncoder(config):
     import torch.nn
     from thinc.extra.wrappers import PyTorchWrapperRNN

--- a/spacy/tests/test_architectures.py
+++ b/spacy/tests/test_architectures.py
@@ -2,18 +2,17 @@
 from __future__ import unicode_literals
 
 import pytest
-from spacy import register_architecture
-from spacy import get_architecture
+from spacy import registry
 from thinc.v2v import Affine
 
 
-@register_architecture("my_test_function")
+@registry.architectures.register("my_test_function")
 def create_model(nr_in, nr_out):
     return Affine(nr_in, nr_out)
 
 
 def test_get_architecture():
-    arch = get_architecture("my_test_function")
+    arch = registry.architectures.get("my_test_function")
     assert arch is create_model
     with pytest.raises(KeyError):
-        get_architecture("not_an_existing_key")
+        registry.architectures.get("not_an_existing_key")

--- a/spacy/tests/test_architectures.py
+++ b/spacy/tests/test_architectures.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import pytest
 from spacy import registry
 from thinc.v2v import Affine
+from catalogue import RegistryError
 
 
 @registry.architectures.register("my_test_function")
@@ -14,5 +15,5 @@ def create_model(nr_in, nr_out):
 def test_get_architecture():
     arch = registry.architectures.get("my_test_function")
     assert arch is create_model
-    with pytest.raises(KeyError):
+    with pytest.raises(RegistryError):
         registry.architectures.get("not_an_existing_key")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

This PR replaces our function registries (e.g. `@register_architecture`) and entry point handling with our new library, [`catalogue`](https://github.com/explosion/catalogue) that was designed for exactly this purpose.

We're able to remove a lot of code and helper functions, and streamline the way users can register custom functions. 

```python
@registry.architectures.register("xy")
class my_custom_architecture():
    # ...

@registry.languages.register("xy")
class MyCustomLanguage(Language):
    # ...

registry.displacy_colors.register("colors", func={"XY": "green"})
```

```python
# Will check both registered functions and entry points
all_architectures = registry.architectures.get_all()
custom_architecture = registry.architectures.get("custom_architecture")
```

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
