### PR TITLE
Set extensions when write_conllu() is called in UD train script

### DIFF
--- a/bin/ud/ud_train.py
+++ b/bin/ud/ud_train.py
@@ -221,12 +221,12 @@ def evaluate(nlp, text_loc, gold_loc, sys_loc, limit=None):
 
 
 def write_conllu(docs, file_):
-    try:
+    if not Token.has_extension("get_conllu_lines"):
         Token.set_extension("get_conllu_lines", method=get_token_conllu)
+    if not Token.has_extension("begins_fused"):
         Token.set_extension("begins_fused", default=False)
+    if not Token.has_extension("inside_fused"):
         Token.set_extension("inside_fused", default=False)
-    except:
-        pass
 
     merger = Matcher(docs[0].vocab)
     merger.add("SUBTOK", None, [{"DEP": "subtok", "op": "+"}])

--- a/bin/ud/ud_train.py
+++ b/bin/ud/ud_train.py
@@ -221,6 +221,13 @@ def evaluate(nlp, text_loc, gold_loc, sys_loc, limit=None):
 
 
 def write_conllu(docs, file_):
+    try:
+        Token.set_extension("get_conllu_lines", method=get_token_conllu)
+        Token.set_extension("begins_fused", default=False)
+        Token.set_extension("inside_fused", default=False)
+    except:
+        pass
+
     merger = Matcher(docs[0].vocab)
     merger.add("SUBTOK", None, [{"DEP": "subtok", "op": "+"}])
     for i, doc in enumerate(docs):


### PR DESCRIPTION
## Description

`run_eval.py` uses the `write_conllu()` function from `ud_train.py` by itself, so it needs to set the token extensions if necessary.

<!--- Provide a general summary of your changes in the title. -->


<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bugfix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
