### PR TITLE
Fix Example details for train CLI / pipeline components

### DIFF
--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -341,7 +341,7 @@ def train(
         iter_since_best = 0
         best_score = 0.0
         for i in range(n_iter):
-            train_data = corpus.train_data(
+            train_data = corpus.train_dataset(
                 nlp,
                 noise_level=noise_level,
                 orth_variant_level=orth_variant_level,

--- a/spacy/gold.pxd
+++ b/spacy/gold.pxd
@@ -58,8 +58,6 @@ cdef class Example:
     cdef public object doc
     cdef public list token_annotations
     cdef public DocAnnotation doc_annotation
-    cdef public object make_projective
-    cdef public object ignore_misaligned
     cdef public object goldparse
 
 

--- a/spacy/gold.pyx
+++ b/spacy/gold.pyx
@@ -340,7 +340,7 @@ class GoldCorpus(object):
                                             make_projective=make_projective,
                                             ignore_misaligned=ignore_misaligned)
             for ex in example_golds:
-                if ex.gold is not None:
+                if ex.goldparse is not None:
                     if (not max_length) or len(ex.doc) < max_length:
                         yield ex
 

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -61,7 +61,7 @@ class Pipe(object):
         return cls(nlp.vocab, **cfg)
 
     def _get_doc(self, example):
-        """ Use this method if the `example` method can be both a Doc or an Example """
+        """ Use this method if the `example` can be both a Doc or an Example """
         if isinstance(example, Doc):
             return example
         return example.doc
@@ -102,7 +102,6 @@ class Pipe(object):
         and `set_annotations()` methods.
         """
         for examples in util.minibatch(stream, size=batch_size):
-            examples = list(examples)
             docs = [self._get_doc(ex) for ex in examples]
             predictions = self.predict(docs)
             if isinstance(predictions, tuple) and len(tuple) == 2:
@@ -112,11 +111,11 @@ class Pipe(object):
                 self.set_annotations(docs, predictions)
 
             if as_example:
-                examples = []
+                annotated_examples = []
                 for ex, doc in zip(examples, docs):
                     ex.doc = doc
-                    examples.append(ex)
-                yield from examples
+                    annotated_examples.append(ex)
+                yield from annotated_examples
             else:
                 yield from docs
 
@@ -312,11 +311,11 @@ class Tensorizer(Pipe):
             self.set_annotations(docs, tensors)
 
             if as_example:
-                examples = []
+                annotated_examples = []
                 for ex, doc in zip(examples, docs):
                     ex.doc = doc
-                    examples.append(ex)
-                yield from examples
+                    annotated_examples.append(ex)
+                yield from annotated_examples
             else:
                 yield from docs
 
@@ -434,17 +433,16 @@ class Tagger(Pipe):
 
     def pipe(self, stream, batch_size=128, n_threads=-1, as_example=False):
         for examples in util.minibatch(stream, size=batch_size):
-            examples = list(examples)
             docs = [self._get_doc(ex) for ex in examples]
             tag_ids, tokvecs = self.predict(docs)
             self.set_annotations(docs, tag_ids, tensors=tokvecs)
 
             if as_example:
-                examples = []
+                annotated_examples = []
                 for ex, doc in zip(examples, docs):
                     ex.doc = doc
-                    examples.append(ex)
-                yield from examples
+                    annotated_examples.append(ex)
+                yield from annotated_examples
             else:
                 yield from docs
 
@@ -1000,17 +998,16 @@ class TextCategorizer(Pipe):
 
     def pipe(self, stream, batch_size=128, n_threads=-1, as_example=False):
         for examples in util.minibatch(stream, size=batch_size):
-            examples = list(examples)
             docs = [self._get_doc(ex) for ex in examples]
             scores, tensors = self.predict(docs)
             self.set_annotations(docs, scores, tensors=tensors)
 
             if as_example:
-                examples = []
+                annotated_examples = []
                 for ex, doc in zip(examples, docs):
                     ex.doc = doc
-                    examples.append(ex)
-                yield from examples
+                    annotated_examples.append(ex)
+                yield from annotated_examples
             else:
                 yield from docs
 
@@ -1333,17 +1330,16 @@ class EntityLinker(Pipe):
 
     def pipe(self, stream, batch_size=128, n_threads=-1, as_example=False):
         for examples in util.minibatch(stream, size=batch_size):
-            examples = list(examples)
             docs = [self._get_doc(ex) for ex in examples]
             kb_ids, tensors = self.predict(docs)
             self.set_annotations(docs, kb_ids, tensors=tensors)
 
             if as_example:
-                examples = []
+                annotated_examples = []
                 for ex, doc in zip(examples, docs):
                     ex.doc = doc
-                    examples.append(ex)
-                yield from examples
+                    annotated_examples.append(ex)
+                yield from annotated_examples
             else:
                 yield from docs
 

--- a/spacy/tests/test_gold.py
+++ b/spacy/tests/test_gold.py
@@ -264,10 +264,14 @@ def test_ignore_misaligned(doc):
         srsly.write_jsonl(jsonl_file, data)
         goldcorpus = GoldCorpus(str(jsonl_file), str(jsonl_file))
 
-    train_reloaded_example = next(goldcorpus.train_dataset(nlp,
+    # doesn't raise an AlignmentError, but there is nothing to iterate over
+    # because the only example can't be aligned
+    train_reloaded_example = list(goldcorpus.train_dataset(nlp,
                                   ignore_misaligned=True))
+    assert len(train_reloaded_example) == 0
 
     spacy.gold.USE_NEW_ALIGN = use_new_align
+
 
 # xfail while we have backwards-compatible alignment
 @pytest.mark.xfail

--- a/spacy/tests/test_gold.py
+++ b/spacy/tests/test_gold.py
@@ -5,11 +5,33 @@ from spacy.gold import biluo_tags_from_offsets, offsets_from_biluo_tags, Example
 from spacy.gold import spans_from_biluo_tags, GoldParse, iob_to_biluo
 from spacy.gold import GoldCorpus, docs_to_json, align
 from spacy.lang.en import English
+from spacy.syntax.nonproj import is_nonproj_tree
 from spacy.tokens import Doc
 from spacy.util import compounding, minibatch
 from .util import make_tempdir
 import pytest
 import srsly
+
+@pytest.fixture
+def doc():
+    text = "Sarah's sister flew to Silicon Valley via London."
+    tags = ['NNP', 'POS', 'NN', 'VBD', 'IN', 'NNP', 'NNP', 'IN', 'NNP', '.']
+    # head of '.' is intentionally nonprojective for testing
+    heads = [2, 0, 3, 3, 3, 6, 4, 3, 7, 5]
+    deps = ['poss', 'case', 'nsubj', 'ROOT', 'prep', 'compound', 'pobj', 'prep', 'pobj', 'punct']
+    biluo_tags = ["U-PERSON", "O", "O", "O", "O", "B-LOC", "L-LOC", "O", "U-GPE", "O"]
+    cats = {"TRAVEL": 1.0, "BAKING": 0.0}
+    nlp = English()
+    doc = nlp(text)
+    for i in range(len(tags)):
+        doc[i].tag_ = tags[i]
+        doc[i].dep_ = deps[i]
+        doc[i].head = doc[heads[i]]
+    doc.ents = spans_from_biluo_tags(doc, biluo_tags)
+    doc.cats = cats
+    doc.is_tagged = True
+    doc.is_parsed = True
+    return doc
 
 
 def test_gold_biluo_U(en_vocab):
@@ -98,23 +120,14 @@ def test_iob_to_biluo():
         iob_to_biluo(bad_iob)
 
 
-def test_roundtrip_docs_to_json():
-    text = "I flew to Silicon Valley via London."
-    tags = ["PRP", "VBD", "IN", "NNP", "NNP", "IN", "NNP", "."]
-    heads = [1, 1, 1, 4, 2, 1, 5, 1]
-    deps = ["nsubj", "ROOT", "prep", "compound", "pobj", "prep", "pobj", "punct"]
-    biluo_tags = ["O", "O", "O", "B-LOC", "L-LOC", "O", "U-GPE", "O"]
-    cats = {"TRAVEL": 1.0, "BAKING": 0.0}
+def test_roundtrip_docs_to_json(doc):
     nlp = English()
-    doc = nlp(text)
-    for i in range(len(tags)):
-        doc[i].tag_ = tags[i]
-        doc[i].dep_ = deps[i]
-        doc[i].head = doc[heads[i]]
-    doc.ents = spans_from_biluo_tags(doc, biluo_tags)
-    doc.cats = cats
-    doc.is_tagged = True
-    doc.is_parsed = True
+    text = doc.text
+    tags = [t.tag_ for t in doc]
+    deps = [t.dep_ for t in doc]
+    heads = [t.head.i for t in doc]
+    biluo_tags = iob_to_biluo([t.ent_iob_ + "-" + t.ent_type_ if t.ent_type_ else "O" for t in doc])
+    cats = doc.cats
 
     # roundtrip to JSON
     with make_tempdir() as tmpdir:
@@ -122,7 +135,7 @@ def test_roundtrip_docs_to_json():
         srsly.write_json(json_file, [docs_to_json(doc)])
         goldcorpus = GoldCorpus(train=str(json_file), dev=str(json_file))
 
-    reloaded_example = next(goldcorpus.train_dataset(nlp))
+    reloaded_example = next(goldcorpus.dev_dataset(nlp))
     goldparse = reloaded_example.gold
 
     assert len(doc) == goldcorpus.count_train()
@@ -142,7 +155,7 @@ def test_roundtrip_docs_to_json():
         srsly.write_jsonl(jsonl_file, [docs_to_json(doc)])
         goldcorpus = GoldCorpus(str(jsonl_file), str(jsonl_file))
 
-    reloaded_example = next(goldcorpus.train_dataset(nlp))
+    reloaded_example = next(goldcorpus.dev_dataset(nlp))
     goldparse = reloaded_example.gold
 
     assert len(doc) == goldcorpus.count_train()
@@ -166,7 +179,7 @@ def test_roundtrip_docs_to_json():
         srsly.write_jsonl(jsonl_file, goldcorpus.train_examples)
         goldcorpus = GoldCorpus(str(jsonl_file), str(jsonl_file))
 
-    reloaded_example = next(goldcorpus.train_dataset(nlp))
+    reloaded_example = next(goldcorpus.dev_dataset(nlp))
     goldparse = reloaded_example.gold
 
     assert len(doc) == goldcorpus.count_train()
@@ -179,6 +192,35 @@ def test_roundtrip_docs_to_json():
     assert "BAKING" in goldparse.cats
     assert cats["TRAVEL"] == goldparse.cats["TRAVEL"]
     assert cats["BAKING"] == goldparse.cats["BAKING"]
+
+
+def test_projective_train_vs_nonprojective_dev(doc):
+    nlp = English()
+    text = doc.text
+    deps = [t.dep_ for t in doc]
+    heads = [t.head.i for t in doc]
+
+    with make_tempdir() as tmpdir:
+        jsonl_file = tmpdir / "test.jsonl"
+        # write to JSONL train dicts
+        srsly.write_jsonl(jsonl_file, [docs_to_json(doc)])
+        goldcorpus = GoldCorpus(str(jsonl_file), str(jsonl_file))
+
+    train_reloaded_example = next(goldcorpus.train_dataset(nlp))
+    train_goldparse = train_reloaded_example.gold
+
+    dev_reloaded_example = next(goldcorpus.dev_dataset(nlp))
+    dev_goldparse = dev_reloaded_example.gold
+
+    assert is_nonproj_tree([t.head.i for t in doc]) is True
+    assert is_nonproj_tree(train_goldparse.heads) is False
+    assert heads[:-1] == train_goldparse.heads[:-1]
+    assert heads[-1] != train_goldparse.heads[-1]
+    assert deps[:-1] == train_goldparse.labels[:-1]
+    assert deps[-1] != train_goldparse.labels[-1]
+
+    assert heads == dev_goldparse.heads
+    assert deps == dev_goldparse.labels
 
 
 # xfail while we have backwards-compatible alignment


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Various fixes to get the new `Example` API working with the train CLI and for all pipeline components. Main changes:

* Training examples are projectivized correctly (including a new test)
* Head of `0` is a valid value, not treated as unset
* `pipe()` in all components is updated to accept `as_examples` argument and to yield the annotated examples without clobbering the provided data
* Use `Example.goldparse` in `iter_gold_docs()` instead of `Example.gold` because a `None` `GoldParse` is generated with `ignore_misaligned` and generating it on-the-fly can raise an unwanted `AlignmentError`

### Types of change

Bugfix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
