### PR TITLE
Fix conllu2json converter to output all sentences when n > 1

### DIFF
--- a/spacy/cli/converters/conllu2json.py
+++ b/spacy/cli/converters/conllu2json.py
@@ -34,6 +34,9 @@ def conllu2json(input_data, n_sents=10, use_morphology=False, lang=None, **_):
             doc = create_doc(sentences, i)
             docs.append(doc)
             sentences = []
+    if sentences:
+        doc = create_doc(sentences, i)
+        docs.append(doc)
     return docs
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Make sure that the last batch of sentences is output when `-n` is greater than 1.

### Types of change

Bugfix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
