### PR TITLE
Fix xpassing tests

### DIFF
--- a/spacy/tests/regression/test_issue3001-3500.py
+++ b/spacy/tests/regression/test_issue3001-3500.py
@@ -328,6 +328,7 @@ def test_issue3449():
     assert t3[5].text == "I"
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_issue3456():
     # this crashed because of a padding error in layer.ops.unflatten in thinc
     nlp = English()

--- a/spacy/tests/regression/test_issue3001-3500.py
+++ b/spacy/tests/regression/test_issue3001-3500.py
@@ -177,7 +177,6 @@ def test_issue3328(en_vocab):
     assert matched_texts == ["Hello", "how", "you", "doing"]
 
 
-@pytest.mark.xfail
 def test_issue3331(en_vocab):
     """Test that duplicate patterns for different rules result in multiple
     matches, one per rule.

--- a/spacy/tests/regression/test_issue3880.py
+++ b/spacy/tests/regression/test_issue3880.py
@@ -2,8 +2,10 @@
 from __future__ import unicode_literals
 
 from spacy.lang.en import English
+import pytest
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_issue3880():
     """Test that `nlp.pipe()` works when an empty string ends the batch.
 

--- a/spacy/tests/regression/test_issue4348.py
+++ b/spacy/tests/regression/test_issue4348.py
@@ -3,8 +3,10 @@ from __future__ import unicode_literals
 
 from spacy.lang.en import English
 from spacy.util import minibatch, compounding
+import pytest
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_issue4348():
     """Test that training the tagger with empty data, doesn't throw errors"""
 

--- a/spacy/tests/test_gold.py
+++ b/spacy/tests/test_gold.py
@@ -177,8 +177,7 @@ def test_roundtrip_docs_to_json():
     assert cats["BAKING"] == goldparse.cats["BAKING"]
 
 
-# xfail while we have backwards-compatible alignment
-@pytest.mark.xfail
+@pytest.mark.skip(reason="skip while we have backwards-compatible alignment")
 @pytest.mark.parametrize(
     "tokens_a,tokens_b,expected",
     [

--- a/spacy/tests/tokenizer/test_urls.py
+++ b/spacy/tests/tokenizer/test_urls.py
@@ -55,10 +55,8 @@ URLS_SHOULD_MATCH = [
     pytest.param(
         "chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai", marks=pytest.mark.xfail()
     ),
-    pytest.param("http://foo.com/blah_blah_(wikipedia)", marks=pytest.mark.xfail()),
-    pytest.param(
-        "http://foo.com/blah_blah_(wikipedia)_(again)", marks=pytest.mark.xfail()
-    ),
+    "http://foo.com/blah_blah_(wikipedia)",
+    "http://foo.com/blah_blah_(wikipedia)_(again)",
     pytest.param("http://⌘.ws", marks=pytest.mark.xfail()),
     pytest.param("http://⌘.ws/", marks=pytest.mark.xfail()),
     pytest.param("http://☺.damowmow.com/", marks=pytest.mark.xfail()),
@@ -105,8 +103,8 @@ URLS_SHOULD_NOT_MATCH = [
     "NASDAQ:GOOG",
     "http://-a.b.co",
     pytest.param("foo.com", marks=pytest.mark.xfail()),
-    pytest.param("http://1.1.1.1.1", marks=pytest.mark.xfail()),
-    pytest.param("http://www.foo.bar./", marks=pytest.mark.xfail()),
+    "http://1.1.1.1.1",
+    "http://www.foo.bar./",
 ]
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

This PR checks whether xpassing tests can be un-xfailed (e.g. because the underlying problem was fixed) or whether the xfail marker was used to  disable them (e.g. because the test was unreliable). In that case, we should skip the test with a `reason` instead of using xfail (which can easily get confusing, because it's later unclear whether the test was actually expected to fail and if so, where etc.)

I also added warning filters to the tests that currently raise our own warnings (for legitimate reasons, just expected in those cases).

### Types of change
tests

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
