### PR TITLE
Fix bug in Language.evaluate for components without .pipe

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -678,7 +678,7 @@ class Language(object):
             kwargs = component_cfg.get(name, {})
             kwargs.setdefault("batch_size", batch_size)
             if not hasattr(pipe, "pipe"):
-                docs = _pipe(pipe, docs, kwargs)
+                docs = _pipe(docs, pipe, kwargs)
             else:
                 docs = pipe.pipe(docs, **kwargs)
         for doc, gold in zip(docs, golds):

--- a/spacy/tests/test_language.py
+++ b/spacy/tests/test_language.py
@@ -65,6 +65,20 @@ def test_language_evaluate(nlp):
         nlp.evaluate([text, gold])
 
 
+def test_evaluate_no_pipe(nlp):
+    """Test that docs are processed correctly within Language.pipe if the
+    component doesn't expose a .pipe method."""
+
+    def pipe(doc):
+        return doc
+
+    text = "hello world"
+    annots = {"cats": {"POSITIVE": 1.0, "NEGATIVE": 0.0}}
+    nlp = Language(Vocab())
+    nlp.add_pipe(pipe)
+    nlp.evaluate([(text, annots)])
+
+
 def vector_modification_pipe(doc):
     doc.vector += 1
     return doc


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

The arguments were swapped, so evaluating components without `.pipe` would fail.

### Types of change
bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
