### PR TITLE
Make vectors.find() return keys in correct order

### DIFF
--- a/spacy/vectors.pyx
+++ b/spacy/vectors.pyx
@@ -265,17 +265,13 @@ cdef class Vectors:
             rows = [self.key2row.get(key, -1.) for key in keys]
             return xp.asarray(rows, dtype="i")
         else:
+            row2key = {row: key for key, row in self.key2row.items()}
             targets = set()
             if row is not None:
-                targets.add(row)
+                return row2key[row]
             else:
-                targets.update(rows)
-            results = []
-            for key, row in self.key2row.items():
-                if row in targets:
-                    results.append(key)
-                    targets.remove(row)
-            return xp.asarray(results, dtype="uint64")
+                results = [row2key[row] for row in rows]
+                return xp.asarray(results, dtype="uint64")
 
     def add(self, key, *, vector=None, row=None):
         """Add a key to the table. Keys can be mapped to an existing vector

--- a/spacy/vectors.pyx
+++ b/spacy/vectors.pyx
@@ -266,7 +266,6 @@ cdef class Vectors:
             return xp.asarray(rows, dtype="i")
         else:
             row2key = {row: key for key, row in self.key2row.items()}
-            targets = set()
             if row is not None:
                 return row2key[row]
             else:


### PR DESCRIPTION
`vectors.find()` accepts several input types. One of them is a sequence of rows, which are mapped into a sequence of corresponding keys. This function returned the keys out of order.

- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
