### PR TITLE
Auto-exclude disabled when calling from_disk during load

### DIFF
--- a/spacy/tests/regression/test_issue4707.py
+++ b/spacy/tests/regression/test_issue4707.py
@@ -1,0 +1,23 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+from spacy.util import load_model_from_path
+from spacy.lang.en import English
+
+from ..util import make_tempdir
+
+
+def test_issue4707():
+    """Tests that disabled component names are also excluded from nlp.from_disk
+    by default when loading a model.
+    """
+    nlp = English()
+    nlp.add_pipe(nlp.create_pipe("sentencizer"))
+    nlp.add_pipe(nlp.create_pipe("entity_ruler"))
+    assert nlp.pipe_names == ["sentencizer", "entity_ruler"]
+    exclude = ["tokenizer", "sentencizer"]
+    with make_tempdir() as tmpdir:
+        nlp.to_disk(tmpdir, exclude=exclude)
+        new_nlp = load_model_from_path(tmpdir, disable=exclude)
+    assert "sentencizer" not in new_nlp.pipe_names
+    assert "entity_ruler" in new_nlp.pipe_names

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -208,7 +208,7 @@ def load_model_from_path(model_path, meta=False, **overrides):
             factory = factories.get(name, name)
             component = nlp.create_pipe(factory, config=config)
             nlp.add_pipe(component, name=name)
-    return nlp.from_disk(model_path)
+    return nlp.from_disk(model_path, exclude=disable)
 
 
 def load_model_from_init_py(init_file, **overrides):


### PR DESCRIPTION
Fixes #4707.

## Description

When you `disable` a component when loading a model, it should also be excluded when calling `nlp.from_disk` afterwards to load the individual components (especially the tokenizer, which will otherwise raise an error).

### Types of change
bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
