### PR TITLE
Add tag_map CLI argument and make_tag_map CLI command

### DIFF
--- a/spacy/__main__.py
+++ b/spacy/__main__.py
@@ -10,6 +10,7 @@ if __name__ == "__main__":
     from wasabi import msg
     from spacy.cli import download, link, info, package, train, pretrain, convert
     from spacy.cli import init_model, profile, evaluate, validate, debug_data
+    from spacy.cli import make_tag_map
 
     commands = {
         "download": download,
@@ -24,6 +25,7 @@ if __name__ == "__main__":
         "init-model": init_model,
         "profile": profile,
         "validate": validate,
+        "make_tag_map": make_tag_map,
     }
     if len(sys.argv) == 1:
         msg.info("Available commands", ", ".join(commands), exits=1)

--- a/spacy/cli/__init__.py
+++ b/spacy/cli/__init__.py
@@ -10,3 +10,4 @@ from .evaluate import evaluate  # noqa: F401
 from .convert import convert  # noqa: F401
 from .init_model import init_model  # noqa: F401
 from .validate import validate  # noqa: F401
+from .make_tag_map import make_tag_map # noqa: F401

--- a/spacy/cli/debug_data.py
+++ b/spacy/cli/debug_data.py
@@ -26,6 +26,7 @@ BLANK_MODEL_THRESHOLD = 2000
     lang=("model language", "positional", None, str),
     train_path=("location of JSON-formatted training data", "positional", None, Path),
     dev_path=("location of JSON-formatted development data", "positional", None, Path),
+    tag_map_path=("Location of JSON-formatted tag map", "option", "tm", Path),
     base_model=("name of model to update (optional)", "option", "b", str),
     pipeline=(
         "Comma-separated names of pipeline components to train",
@@ -41,6 +42,7 @@ def debug_data(
     lang,
     train_path,
     dev_path,
+    tag_map_path=None,
     base_model=None,
     pipeline="tagger,parser,ner",
     ignore_warnings=False,
@@ -60,6 +62,10 @@ def debug_data(
     if not dev_path.exists():
         msg.fail("Development data not found", dev_path, exits=1)
 
+    tag_map = {}
+    if tag_map_path is not None:
+        tag_map = srsly.read_json(tag_map_path)
+
     # Initialize the model and pipeline
     pipeline = [p.strip() for p in pipeline.split(",")]
     if base_model:
@@ -67,6 +73,8 @@ def debug_data(
     else:
         lang_cls = get_lang_class(lang)
         nlp = lang_cls()
+    # Update tag map with provided mapping
+    nlp.vocab.morphology.tag_map.update(tag_map)
 
     msg.divider("Data format validation")
 
@@ -329,7 +337,7 @@ def debug_data(
     if "tagger" in pipeline:
         msg.divider("Part-of-speech Tagging")
         labels = [label for label in gold_train_data["tags"]]
-        tag_map = nlp.Defaults.tag_map
+        tag_map = nlp.vocab.morphology.tag_map
         msg.info(
             "{} {} in data ({} {} in tag map)".format(
                 len(labels),

--- a/spacy/cli/make_tag_map.py
+++ b/spacy/cli/make_tag_map.py
@@ -1,0 +1,83 @@
+# coding: utf8
+from __future__ import unicode_literals, print_function
+
+from pathlib import Path
+import plac
+import sys
+import srsly
+from wasabi import Printer
+from spacy.morphology import FEATURES
+
+
+@plac.annotations(
+    train_path=("location of JSON-formatted training data", "positional", None, Path),
+    tag_map_path=("Location of JSON-formatted tag map", "positional", None, Path),
+)
+def make_tag_map(
+    train_path,
+    tag_map_path,
+):
+    """
+    Generate a JSON tag map from tags in JSON-formatted training data.
+    """
+    msg = Printer()
+
+    # Make sure all files and paths exists if they are needed
+    if not train_path.exists():
+        msg.fail("Training data not found", train_path, exits=1)
+
+    data = srsly.read_json(train_path)
+
+    tags = set()
+    for doc in data:
+        for para in doc["paragraphs"]:
+            for sent in para["sentences"]:
+                for token in sent["tokens"]:
+                    tags.add(token["tag"])
+
+    UD_TAGS = [
+        "ADJ",
+        "ADP",
+        "ADV",
+        "AUX",
+        "CCONJ",
+        "DET",
+        "INTJ",
+        "NOUN",
+        "NUM",
+        "PART",
+        "PRON",
+        "PROPN",
+        "PUNCT",
+        "SCONJ",
+        "SYM",
+        "VERB",
+        "X",
+    ]
+
+    VAL_NORM_MAP = {
+        "0": "None",
+        "1": "One",
+        "2": "Two",
+        "3": "Three",
+    }
+
+    tag_map = {}
+    for tag in tags:
+        tagparts = tag.split("__")
+        pos = tagparts[0]
+        posparts = pos.split("_")
+        if posparts[0] not in UD_TAGS:
+            msg.fail("Can't automatically map the following tag to a UD coarse-grained POS: " + tag, exits=1)
+        tag_map[tag] = {"POS": posparts[0]}
+        if len(tagparts) > 1:
+            for morph in tagparts[1].split("|"):
+                morph_feat, morph_val = morph.split("=")
+                if morph_val in VAL_NORM_MAP:
+                    morph_val = VAL_NORM_MAP[morph_val]
+                feature_name = morph_feat + "_" + morph_val.lower()
+                if feature_name not in FEATURES:
+                    msg.fail("Unsupported morphological feature " + feature_name + ": " + tag, exits=1)
+                tag_map[tag][morph_feat] = morph_val
+
+    srsly.write_json(tag_map_path, tag_map)

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -48,6 +48,7 @@ from .. import about
     textcat_multilabel=("Textcat classes aren't mutually exclusive (multilabel)", "flag", "TML", bool),
     textcat_arch=("Textcat model architecture", "option", "ta", str),
     textcat_positive_label=("Textcat positive label for binary classes with two labels", "option", "tpl", str),
+    tag_map_path=("Location of JSON-formatted tag map", "option", "tm", Path),
     verbose=("Display more information for debug", "flag", "VV", bool),
     debug=("Run data diagnostics before training", "flag", "D", bool),
     # fmt: on
@@ -78,6 +79,7 @@ def train(
     textcat_multilabel=False,
     textcat_arch="bow",
     textcat_positive_label=None,
+    tag_map_path=None,
     verbose=False,
     debug=False,
 ):
@@ -118,6 +120,9 @@ def train(
     if not output_path.exists():
         output_path.mkdir()
 
+    tag_map = {}
+    if tag_map_path is not None:
+        tag_map = srsly.read_json(tag_map_path)
     # Take dropout and batch size as generators of values -- dropout
     # starts high and decays sharply, to force the optimizer to explore.
     # Batch size starts at 1 and grows, so that we make updates quickly
@@ -208,6 +213,9 @@ def train(
             else:
                 pipe_cfg = {}
             nlp.add_pipe(nlp.create_pipe(pipe, config=pipe_cfg))
+
+    # Update tag map with provided mapping
+    nlp.vocab.morphology.tag_map.update(tag_map)
 
     if vectors:
         msg.text("Loading vector from model '{}'".format(vectors))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

* Add `--tag-map-path` argument to CLI `debug-data` and `train`: Add an argument for a path to a JSON-formatted tag map, which is used to update and extend the default language tag map.

* Add a `make_tag_map` CLI command: Add a make_tag_map CLI command that generates a tag map from JSON-formatted training data with `tag` values in the form of `POS1_POS2__Feat1=Val1|Feat2=Val2` where POS are UD POS tags and `Feat=Val` are morphological features. POS maps to `POS1` for merged subtokens. Aborts if unsupported POS tags (UD v2) or morphological features (spacy's morphology `FEATURES`) are found.

Fixes #4714.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Enhancement.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
