### PR TITLE
fix bug in EL predict

### DIFF
--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -1302,7 +1302,7 @@ class EntityLinker(Pipe):
             if len(doc) > 0:
                 # Looping through each sentence and each entity
                 # This may go wrong if there are entities across sentences - because they might not get a KB ID
-                for sent in doc.ents:
+                for sent in doc.sents:
                     sent_doc = sent.as_doc()
                     # currently, the context is the same for each entity in a sentence (should be refined)
                     sentence_encoding = self.model([sent_doc])[0]


### PR DESCRIPTION
## Description

Fixed typo bug in the EntityLinkers's `predict` function - hopefully by fixing this the EL results will become more meaningful (will run experiments to test this hopeful hypothesis).

Fixes #4772 - thanks to @lilysikes  for the report and fix!

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
