### PR TITLE
Reduce mem usage in training Entity Linker

### DIFF
--- a/bin/wiki_entity_linking/README.md
+++ b/bin/wiki_entity_linking/README.md
@@ -7,16 +7,16 @@ Run  `wikipedia_pretrain_kb.py`
   * WikiData: get `latest-all.json.bz2` from https://dumps.wikimedia.org/wikidatawiki/entities/
   * Wikipedia: get `enwiki-latest-pages-articles-multistream.xml.bz2` from https://dumps.wikimedia.org/enwiki/latest/ (or for any other language)
 * You can set the filtering parameters for KB construction:
-  * `max_per_alias`: (max) number of candidate entities in the KB per alias/synonym
-  * `min_freq`: threshold of number of times an entity should occur in the corpus to be included in the KB
-  * `min_pair`: threshold of number of times an entity+alias combination should occur in the corpus to be included in the KB
+  * `max_per_alias` (`-a`): (max) number of candidate entities in the KB per alias/synonym
+  * `min_freq` (`-f`): threshold of number of times an entity should occur in the corpus to be included in the KB
+  * `min_pair` (`-c`): threshold of number of times an entity+alias combination should occur in the corpus to be included in the KB
 * Further parameters to set:
-  * `descriptions_from_wikipedia`: whether to parse descriptions from Wikipedia (`True`) or Wikidata (`False`)
-  * `entity_vector_length`: length of the pre-trained entity description vectors
-  * `lang`: language for which to fetch Wikidata information (as the dump contains all languages)
+  * `descriptions_from_wikipedia` (`-wp`): whether to parse descriptions from Wikipedia (`True`) or Wikidata (`False`)
+  * `entity_vector_length` (`-v`): length of the pre-trained entity description vectors
+  * `lang` (`-la`): language for which to fetch Wikidata information (as the dump contains all languages)
 
 Quick testing and rerunning: 
-* When trying out the pipeline for a quick test, set `limit_prior`, `limit_train` and/or `limit_wd` to read only parts of the dumps instead of everything. 
+* When trying out the pipeline for a quick test, set `limit_prior` (`-lp`), `limit_train` (`-lt`) and/or `limit_wd` (`-lw`) to read only parts of the dumps instead of everything. 
 * If you only want to (re)run certain parts of the pipeline, just remove the corresponding files and they will be recalculated or reparsed.
 
 
@@ -24,11 +24,13 @@ Quick testing and rerunning:
 
 Run  `wikidata_train_entity_linker.py` 
 * This takes the **KB directory** produced by Step 1, and trains an **Entity Linking model**
+* Specify the output directory (`-o`) in which the final, trained model will be saved
 * You can set the learning parameters for the EL training:
-  * `epochs`: number of training iterations
-  * `dropout`: dropout rate
-  * `lr`: learning rate
-  * `l2`: L2 regularization
-* Specify the number of training and dev testing entities with `train_inst` and `dev_inst` respectively
+  * `epochs` (`-e`): number of training iterations
+  * `dropout` (`-p`): dropout rate
+  * `lr` (`-n`): learning rate
+  * `l2` (`-r`): L2 regularization
+* Specify the number of training and dev testing articles with `train_articles` (`-t`) and `dev_articles` (`-d`) respectively
+  * If not specified, the full dataset will be processed - this may take a LONG time !
 * Further parameters to set:
-  * `labels_discard`: NER label types to discard during training
+  * `labels_discard` (`-l`): NER label types to discard during training

--- a/bin/wiki_entity_linking/entity_linker_evaluation.py
+++ b/bin/wiki_entity_linking/entity_linker_evaluation.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import logging
 import random
 from tqdm import tqdm
-
 from collections import defaultdict
 
 logger = logging.getLogger(__name__)

--- a/bin/wiki_entity_linking/entity_linker_evaluation.py
+++ b/bin/wiki_entity_linking/entity_linker_evaluation.py
@@ -1,5 +1,9 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
 import logging
 import random
+from tqdm import tqdm
 
 from collections import defaultdict
 
@@ -91,126 +95,110 @@ class BaselineResults(object):
         self.random.update_metrics(ent_label, true_entity, random_candidate)
 
 
-def measure_performance(dev_docs, dev_golds, kb, el_pipe, baseline=True, context=True):
-    if baseline:
-        baseline_accuracies, counts = measure_baselines(dev_docs, dev_golds, kb)
-        logger.info("Counts: {}".format({k: v for k, v in sorted(counts.items())}))
-        logger.info(baseline_accuracies.report_performance("random"))
-        logger.info(baseline_accuracies.report_performance("prior"))
-        logger.info(baseline_accuracies.report_performance("oracle"))
-
-    if context:
-        # using only context
-        el_pipe.cfg["incl_context"] = True
-        el_pipe.cfg["incl_prior"] = False
-        results = get_eval_results(dev_docs, dev_golds, el_pipe)
-        logger.info(results.report_metrics("context only"))
-
-        # measuring combined accuracy (prior + context)
-        el_pipe.cfg["incl_context"] = True
-        el_pipe.cfg["incl_prior"] = True
-        results = get_eval_results(dev_docs, dev_golds, el_pipe)
-        logger.info(results.report_metrics("context and prior"))
-
-
-def get_eval_results(docs, golds, el_pipe=None):
-    """
-    Evaluate the ent.kb_id_ annotations against the gold standard.
-    Only evaluate entities that overlap between gold and NER, to isolate the performance of the NEL.
-    If the docs in the data require further processing with an entity linker, set el_pipe.
-    """
-    proc_docs = docs
-    if el_pipe is not None:
-        proc_docs = el_pipe.pipe(docs)
-
-    results = EvaluationResults()
-    for doc, gold in zip(proc_docs, golds):
-        if len(doc) > 0:
-            try:
-                correct_entries_per_article = dict()
-                for entity, kb_dict in gold.links.items():
-                    start, end = entity
-                    for gold_kb, value in kb_dict.items():
-                        if value:
-                            # only evaluating on positive examples
-                            offset = _offset(start, end)
-                            correct_entries_per_article[offset] = gold_kb
-
-                for ent in doc.ents:
-                    ent_label = ent.label_
-                    pred_entity = ent.kb_id_
-                    start = ent.start_char
-                    end = ent.end_char
-                    offset = _offset(start, end)
-                    gold_entity = correct_entries_per_article.get(offset, None)
-                    # the gold annotations are not complete so we can't evaluate missing annotations as 'wrong'
-                    if gold_entity is not None:
-                        results.update_metrics(ent_label, gold_entity, pred_entity)
-
-            except Exception as e:
-                logging.error("Error assessing accuracy " + str(e))
-
-    return results
-
-
-def measure_baselines(docs, golds, kb):
-    """
-    Measure 3 performance baselines: random selection, prior probabilities, and 'oracle' prediction for upper bound.
-    Only evaluate entities that overlap between gold and NER, to isolate the performance of the NEL.
-    Also return a dictionary of counts by entity label.
-    """
-    counts_d = dict()
-
+def measure_performance(dev_data, kb, el_pipe, baseline=True, context=True, dev_limit=None):
+    counts = dict()
     baseline_results = BaselineResults()
+    context_results = EvaluationResults()
+    combo_results = EvaluationResults()
 
-    for doc, gold in zip(docs, golds):
+    for doc, gold in tqdm(dev_data, total=dev_limit, leave=False):
         if len(doc) > 0:
-            correct_entries_per_article = dict()
+            correct_ents = dict()
             for entity, kb_dict in gold.links.items():
                 start, end = entity
                 for gold_kb, value in kb_dict.items():
-                    # only evaluating on positive examples
                     if value:
+                        # only evaluating on positive examples
                         offset = _offset(start, end)
-                        correct_entries_per_article[offset] = gold_kb
+                        correct_ents[offset] = gold_kb
 
-            for ent in doc.ents:
-                ent_label = ent.label_
-                start = ent.start_char
-                end = ent.end_char
-                offset = _offset(start, end)
-                gold_entity = correct_entries_per_article.get(offset, None)
+            if baseline:
+                _add_baseline(baseline_results, counts, doc, correct_ents, kb)
 
-                # the gold annotations are not complete so we can't evaluate missing annotations as 'wrong'
-                if gold_entity is not None:
-                    candidates = kb.get_candidates(ent.text)
-                    oracle_candidate = ""
-                    prior_candidate = ""
-                    random_candidate = ""
-                    if candidates:
-                        scores = []
+            if context:
+                # using only context
+                el_pipe.cfg["incl_context"] = True
+                el_pipe.cfg["incl_prior"] = False
+                _add_eval_result(context_results, doc, correct_ents, el_pipe)
 
-                        for c in candidates:
-                            scores.append(c.prior_prob)
-                            if c.entity_ == gold_entity:
-                                oracle_candidate = c.entity_
+                # measuring combined accuracy (prior + context)
+                el_pipe.cfg["incl_context"] = True
+                el_pipe.cfg["incl_prior"] = True
+                _add_eval_result(combo_results, doc, correct_ents, el_pipe)
 
-                        best_index = scores.index(max(scores))
-                        prior_candidate = candidates[best_index].entity_
-                        random_candidate = random.choice(candidates).entity_
+    if baseline:
+        logger.info("Counts: {}".format({k: v for k, v in sorted(counts.items())}))
+        logger.info(baseline_results.report_performance("random"))
+        logger.info(baseline_results.report_performance("prior"))
+        logger.info(baseline_results.report_performance("oracle"))
 
-                    current_count = counts_d.get(ent_label, 0)
-                    counts_d[ent_label] = current_count+1
+    if context:
+        logger.info(context_results.report_metrics("context only"))
+        logger.info(combo_results.report_metrics("context and prior"))
 
-                    baseline_results.update_baselines(
-                        gold_entity,
-                        ent_label,
-                        random_candidate,
-                        prior_candidate,
-                        oracle_candidate,
-                    )
 
-    return baseline_results, counts_d
+def _add_eval_result(results, doc, correct_ents, el_pipe):
+    """
+    Evaluate the ent.kb_id_ annotations against the gold standard.
+    Only evaluate entities that overlap between gold and NER, to isolate the performance of the NEL.
+    """
+    try:
+        doc = el_pipe(doc)
+        for ent in doc.ents:
+            ent_label = ent.label_
+            start = ent.start_char
+            end = ent.end_char
+            offset = _offset(start, end)
+            gold_entity = correct_ents.get(offset, None)
+            # the gold annotations are not complete so we can't evaluate missing annotations as 'wrong'
+            if gold_entity is not None:
+                pred_entity = ent.kb_id_
+                results.update_metrics(ent_label, gold_entity, pred_entity)
+
+    except Exception as e:
+        logging.error("Error assessing accuracy " + str(e))
+
+
+def _add_baseline(baseline_results, counts, doc, correct_ents, kb):
+    """
+    Measure 3 performance baselines: random selection, prior probabilities, and 'oracle' prediction for upper bound.
+    Only evaluate entities that overlap between gold and NER, to isolate the performance of the NEL.
+    """
+    for ent in doc.ents:
+        ent_label = ent.label_
+        start = ent.start_char
+        end = ent.end_char
+        offset = _offset(start, end)
+        gold_entity = correct_ents.get(offset, None)
+
+        # the gold annotations are not complete so we can't evaluate missing annotations as 'wrong'
+        if gold_entity is not None:
+            candidates = kb.get_candidates(ent.text)
+            oracle_candidate = ""
+            prior_candidate = ""
+            random_candidate = ""
+            if candidates:
+                scores = []
+
+                for c in candidates:
+                    scores.append(c.prior_prob)
+                    if c.entity_ == gold_entity:
+                        oracle_candidate = c.entity_
+
+                best_index = scores.index(max(scores))
+                prior_candidate = candidates[best_index].entity_
+                random_candidate = random.choice(candidates).entity_
+
+            current_count = counts.get(ent_label, 0)
+            counts[ent_label] = current_count+1
+
+            baseline_results.update_baselines(
+                gold_entity,
+                ent_label,
+                random_candidate,
+                prior_candidate,
+                oracle_candidate,
+            )
 
 
 def _offset(start, end):

--- a/bin/wiki_entity_linking/entity_linker_evaluation.py
+++ b/bin/wiki_entity_linking/entity_linker_evaluation.py
@@ -119,16 +119,12 @@ def get_eval_results(docs, golds, el_pipe=None):
     Only evaluate entities that overlap between gold and NER, to isolate the performance of the NEL.
     If the docs in the data require further processing with an entity linker, set el_pipe.
     """
-    from tqdm import tqdm
-
+    proc_docs = docs
     if el_pipe is not None:
-        proc_docs = []
-        for d in tqdm(docs, leave=False, desc='Processing eval docs'):
-            proc_docs.append(el_pipe(d))
-        docs = proc_docs
+        proc_docs = el_pipe.pipe(docs)
 
     results = EvaluationResults()
-    for doc, gold in zip(docs, golds):
+    for doc, gold in zip(proc_docs, golds):
         if len(doc) > 0:
             try:
                 correct_entries_per_article = dict()

--- a/bin/wiki_entity_linking/entity_linker_evaluation.py
+++ b/bin/wiki_entity_linking/entity_linker_evaluation.py
@@ -101,7 +101,7 @@ def measure_performance(dev_data, kb, el_pipe, baseline=True, context=True, dev_
     context_results = EvaluationResults()
     combo_results = EvaluationResults()
 
-    for doc, gold in tqdm(dev_data, total=dev_limit, leave=False):
+    for doc, gold in tqdm(dev_data, total=dev_limit, leave=False, desc='Processing dev data'):
         if len(doc) > 0:
             correct_ents = dict()
             for entity, kb_dict in gold.links.items():

--- a/bin/wiki_entity_linking/wikidata_train_entity_linker.py
+++ b/bin/wiki_entity_linking/wikidata_train_entity_linker.py
@@ -108,9 +108,11 @@ def main(
         optimizer.L2 = l2
 
     logger.info("Dev Baseline Accuracies:")
-    dev_docs, dev_golds = wikipedia_processor.read_el_docs_golds(nlp=nlp, entity_file_path=training_path,
-                                                                 dev=True, line_ids=dev_indices,
-                                                                 kb=kb, labels_discard=labels_discard)
+    with nlp.disable_pipes("entity_linker"):
+        dev_docs, dev_golds = wikipedia_processor.read_el_docs_golds(nlp=nlp, entity_file_path=training_path,
+                                                                     dev=True, line_ids=dev_indices,
+                                                                     kb=kb, labels_discard=labels_discard)
+
     measure_performance(dev_docs, dev_golds, kb, el_pipe, baseline=True, context=False)
 
     for itn in range(epochs):
@@ -128,9 +130,10 @@ def main(
         with tqdm(total=bar_total, leave=False, desc='Epoch ' + str(itn)) as pbar:
             for batch in batches:
                 if not train_art or articles_processed < train_art:
-                    docs, golds = wikipedia_processor.read_el_docs_golds(nlp=nlp, entity_file_path=training_path,
-                                                                         dev=False, line_ids=batch,
-                                                                         kb=kb, labels_discard=labels_discard)
+                    with nlp.disable_pipes("entity_linker"):
+                        docs, golds = wikipedia_processor.read_el_docs_golds(nlp=nlp, entity_file_path=training_path,
+                                                                             dev=False, line_ids=batch,
+                                                                             kb=kb, labels_discard=labels_discard)
                     try:
                         with nlp.disable_pipes(*other_pipes):
                             nlp.update(

--- a/bin/wiki_entity_linking/wikidata_train_entity_linker.py
+++ b/bin/wiki_entity_linking/wikidata_train_entity_linker.py
@@ -69,12 +69,14 @@ def main(
     # STEP 1 : load the NLP object
     logger.info("STEP 1a: Loading model from {}".format(nlp_dir))
     nlp = spacy.load(nlp_dir)
-    logger.info("STEP 1b: Loading KB from {}".format(kb_path))
-    kb = read_kb(nlp, kb_path)
+    logger.info("Original NLP pipeline has following pipeline components: {}".format(nlp.pipe_names))
 
     # check that there is a NER component in the pipeline
     if "ner" not in nlp.pipe_names:
         raise ValueError("The `nlp` object should have a pretrained `ner` component.")
+
+    logger.info("STEP 1b: Loading KB from {}".format(kb_path))
+    kb = read_kb(nlp, kb_path)
 
     # STEP 2: read the training dataset previously created from WP
     logger.info("STEP 2: Reading training & dev dataset from {}".format(training_path))
@@ -155,6 +157,7 @@ def main(
 
     if output_dir:
         # STEP 4: write the NLP pipeline (now including an EL model) to file
+        logger.info("Final NLP pipeline has following pipeline components: {}".format(nlp.pipe_names))
         logger.info("STEP 4: Writing trained NLP to {}".format(nlp_output_dir))
         nlp.to_disk(nlp_output_dir)
 

--- a/bin/wiki_entity_linking/wikipedia_processor.py
+++ b/bin/wiki_entity_linking/wikipedia_processor.py
@@ -453,28 +453,43 @@ def _write_training_entities(outputfile, article_id, clean_text, entities):
     outputfile.write(line)
 
 
-def read_training(nlp, entity_file_path, dev, limit, kb, labels_discard=None):
-    """ This method provides training examples that correspond to the entity annotations found by the nlp object.
+def read_training_ids(nlp, entity_file_path):
+    """ This method creates two lists of indices into the training file: one with indices for the
+     training examples, and one for the dev examples."""
+    train_indices = []
+    dev_indices = []
+
+    with entity_file_path.open("r", encoding="utf8") as file:
+        for i, line in enumerate(file):
+            example = json.loads(line)
+            article_id = example["article_id"]
+            clean_text = example["clean_text"]
+
+            if is_valid_article(clean_text):
+                if is_dev(article_id):
+                    dev_indices.append(i)
+                else:
+                    train_indices.append(i)
+
+    return train_indices, dev_indices
+
+
+def read_el_docs_golds(nlp, entity_file_path, dev, line_ids, kb, labels_discard=None):
+    """ This method provides training/dev examples that correspond to the entity annotations found by the nlp object.
      For training, it will include both positive and negative examples by using the candidate generator from the kb.
      For testing (kb=None), it will include all positive examples only."""
-
-    from tqdm import tqdm
-
     if not labels_discard:
         labels_discard = []
 
-    data = []
-    num_entities = 0
+    docs = []
+    golds = []
     get_gold_parse = partial(
         _get_gold_parse, dev=dev, kb=kb, labels_discard=labels_discard
     )
 
-    logger.info(
-        "Reading {} data with limit {}".format("dev" if dev else "train", limit)
-    )
     with entity_file_path.open("r", encoding="utf8") as file:
-        with tqdm(total=limit, leave=False) as pbar:
-            for i, line in enumerate(file):
+        for i, line in enumerate(file):
+            if i in line_ids:
                 example = json.loads(line)
                 article_id = example["article_id"]
                 clean_text = example["clean_text"]
@@ -486,13 +501,9 @@ def read_training(nlp, entity_file_path, dev, limit, kb, labels_discard=None):
                 doc = nlp(clean_text)
                 gold = get_gold_parse(doc, entities)
                 if gold and len(gold.links) > 0:
-                    data.append((doc, gold))
-                    num_entities += len(gold.links)
-                    pbar.update(len(gold.links))
-                if limit and num_entities >= limit:
-                    break
-    logger.info("Read {} entities in {} articles".format(num_entities, len(data)))
-    return data
+                    docs.append(doc)
+                    golds.append(gold)
+    return docs, golds
 
 
 def _get_gold_parse(doc, entities, dev, kb, labels_discard):

--- a/bin/wiki_entity_linking/wikipedia_processor.py
+++ b/bin/wiki_entity_linking/wikipedia_processor.py
@@ -498,18 +498,12 @@ def read_el_docs_golds(nlp, entity_file_path, dev, line_ids, kb, labels_discard=
                 texts.append(clean_text)
                 entities_list.append(entities)
 
-    docs = nlp.pipe(texts)
-
-    final_docs = []
-    golds = []
+    docs = nlp.pipe(texts, batch_size=50)
 
     for doc, entities in zip(docs, entities_list):
         gold = _get_gold_parse(doc, entities, dev=dev, kb=kb, labels_discard=labels_discard)
         if gold and len(gold.links) > 0:
-            final_docs.append(doc)
-            golds.append(gold)
-
-    return final_docs, golds
+            yield doc, gold
 
 
 def _get_gold_parse(doc, entities, dev, kb, labels_discard):

--- a/bin/wiki_entity_linking/wikipedia_processor.py
+++ b/bin/wiki_entity_linking/wikipedia_processor.py
@@ -453,7 +453,7 @@ def _write_training_entities(outputfile, article_id, clean_text, entities):
     outputfile.write(line)
 
 
-def read_training_ids(nlp, entity_file_path):
+def read_training_indices(entity_file_path):
     """ This method creates two lists of indices into the training file: one with indices for the
      training examples, and one for the dev examples."""
     train_indices = []

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -1308,7 +1308,7 @@ class EntityLinker(Pipe):
         for i, doc in enumerate(docs):
             if len(doc) > 0:
                 # Looping through each sentence and each entity
-                # This may go wrong if there are entities across sentences - because they might not get a KB ID
+                # This may go wrong if there are entities across sentences - which shouldn't happen normally.
                 for sent in doc.sents:
                     sent_doc = sent.as_doc()
                     # currently, the context is the same for each entity in a sentence (should be refined)


### PR DESCRIPTION
## Description
Optimizing the EL pipeline to be less memory-heavy. In practice this means that the same documents will have to be reprocessed with `nlp()` in each epoch, but storing in memory or on file seems worse. There's always a memory/cpu/disk trade-off but this change should hopefully make the pipeline runnable on most machines.

Additional minor edits:
- provide more informative progress bars
- warn up-front if output directory is not specified
- limit train/dev data in number of articles instead of number of entities (more intuitive)

### Types of change
enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
