### PR TITLE
Documentation for PhraseMatcher constructor

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -53,7 +53,9 @@ class Warnings(object):
     W009 = ("Custom factory '{name}' provided by entry points of another "
             "package overwrites built-in factory.")
     W010 = ("As of v2.1.0, the PhraseMatcher doesn't have a phrase length "
-            "limit anymore, so the max_length argument is now deprecated.")
+            "limit anymore, so the max_length argument is now deprecated. "
+            "If you did not specify this parameter, make sure you call the "
+            "constructor with named arguments instead of positional ones.")
     W011 = ("It looks like you're calling displacy.serve from within a "
             "Jupyter notebook or a similar environment. This likely means "
             "you're already running a local web server, so there's no need to "

--- a/website/docs/api/phrasematcher.md
+++ b/website/docs/api/phrasematcher.md
@@ -38,6 +38,7 @@ be shown.
 | Name                                    | Type            | Description                                                                                 |
 | --------------------------------------- | --------------- | ------------------------------------------------------------------------------------------- |
 | `vocab`                                 | `Vocab`         | The vocabulary object, which must be shared with the documents the matcher will operate on. |
+| `max_length`                            | int             | Deprecated argument -  the `PhraseMatcher` does not have a phrase length limit anymore.     |
 | `attr` <Tag variant="new">2.1</Tag>     | int / unicode   | The token attribute to match on. Defaults to `ORTH`, i.e. the verbatim token text.          |
 | `validate` <Tag variant="new">2.1</Tag> | bool            | Validate patterns added to the matcher.                                                     |
 | **RETURNS**                             | `PhraseMatcher` | The newly constructed object.                                                               |


### PR DESCRIPTION
## Description
The tabular [documentation of the PhraseMatcher constructor](https://spacy.io/api/phrasematcher#init) left out the deprecated argument `max_length`, which can result in subtle bugs when calling this constructor with positional arguments. Even though a warning is thrown about the deprecated `max_length`, users may still not realise that `attrs` is not parsed correctly, as the pipeline still runs (with the default `attrs`=`ORTH`). This happened in Issue #4825.

### Types of change
Change to the documentation

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
