### PR TITLE
stop rendering mathjax by default in displacy

### DIFF
--- a/spacy/displacy/__init__.py
+++ b/spacy/displacy/__init__.py
@@ -55,9 +55,10 @@ def render(
         html = RENDER_WRAPPER(html)
     if jupyter or (jupyter is None and is_in_jupyter()):
         # return HTML rendered by IPython display()
+        # See #4840 for details on span wrapper to disable mathjax
         from IPython.core.display import display, HTML
 
-        return display(HTML(f'<span class="tex2jax_ignore">{html}</span>'))
+        return display(HTML('<span class="tex2jax_ignore">{}</span>'.format(html)))
     return html
 
 

--- a/spacy/displacy/__init__.py
+++ b/spacy/displacy/__init__.py
@@ -57,7 +57,7 @@ def render(
         # return HTML rendered by IPython display()
         from IPython.core.display import display, HTML
 
-        return display(HTML(html))
+        return display(HTML(f'<span class="tex2jax_ignore">{html}</span>'))
     return html
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

By default, Jupyter renders MathJax between any two dollar signs. When running displacy through some news documents I was seeing very odd rendering due to this behavior. Using this [SO answer](https://stackoverflow.com/questions/16089089/escaping-dollar-sign-in-ipython-notebook), I added a span tag to stop rendering mathjax when `jupyter=True`.

signed contributor agreement: https://github.com/explosion/spaCy/pull/4839

### Types of change

bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
