### PR TITLE
Add n_process to Language.pipe documentation (#4842) [ci skip]

### DIFF
--- a/.github/contributors/iechevarria.md
+++ b/.github/contributors/iechevarria.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI GmbH](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                 |
+|------------------------------- | --------------------- |
+| Name                           | Ivan Echevarria       |
+| Company name (if applicable)   |                       |
+| Title or role (if applicable)  |                       |
+| Date                           | 2019-12-24            |
+| GitHub username                | iechevarria           |
+| Website (optional)             | https://echevarria.io |

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -78,10 +78,9 @@ class Warnings(object):
     W015 = ("As of v2.1.0, the use of keyword arguments to exclude fields from "
             "being serialized or deserialized is deprecated. Please use the "
             "`exclude` argument instead. For example: exclude=['{arg}'].")
-    W016 = ("The keyword argument `n_threads` on the is now deprecated, as "
-            "the v2.x models cannot release the global interpreter lock. "
-            "Future versions may introduce a `n_process` argument for "
-            "parallel inference via multiprocessing.")
+    W016 = ("The keyword argument `n_threads` is now deprecated. As of v2.2.2, "
+            "the argument `n_process` controls parallel inference via "
+            "multiprocessing.")
     W017 = ("Alias '{alias}' already exists in the Knowledge Base.")
     W018 = ("Entity '{entity}' already exists in the Knowledge Base - "
             "ignoring the duplicate entry.")

--- a/website/docs/api/language.md
+++ b/website/docs/api/language.md
@@ -77,9 +77,9 @@ more efficient than processing texts one-by-one.
 Early versions of spaCy used simple statistical models that could be efficiently
 multi-threaded, as we were able to entirely release Python's global interpreter
 lock. The multi-threading was controlled using the `n_threads` keyword argument
-to the `.pipe` method. This keyword argument is now deprecated as of v2.1.0.
-A new keyword argument, `n_process`, was introduced to control parallel
-inference via multiprocessing in v2.2.2.
+to the `.pipe` method. This keyword argument is now deprecated as of v2.1.0. A
+new keyword argument, `n_process`, was introduced to control parallel inference
+via multiprocessing in v2.2.2.
 
 </Infobox>
 
@@ -98,7 +98,7 @@ inference via multiprocessing in v2.2.2.
 | `batch_size`                                 | int   | The number of texts to buffer.                                                                                                                             |
 | `disable`                                    | list  | Names of pipeline components to [disable](/usage/processing-pipelines#disabling).                                                                          |
 | `component_cfg` <Tag variant="new">2.1</Tag> | dict  | Config parameters for specific pipeline components, keyed by component name.                                                                               |
-| `n_process` <Tag variant="new">2.2.2</Tag>   | int   | Number of processors to use, only supported in Python 3.                                                                                                   |
+| `n_process` <Tag variant="new">2.2.2</Tag>   | int   | Number of processors to use, only supported in Python 3. Defaults to `1`.                                                                                  |
 | **YIELDS**                                   | `Doc` | Documents in the order of the original text.                                                                                                               |
 
 ## Language.update {#update tag="method"}

--- a/website/docs/api/language.md
+++ b/website/docs/api/language.md
@@ -78,8 +78,8 @@ Early versions of spaCy used simple statistical models that could be efficiently
 multi-threaded, as we were able to entirely release Python's global interpreter
 lock. The multi-threading was controlled using the `n_threads` keyword argument
 to the `.pipe` method. This keyword argument is now deprecated as of v2.1.0.
-Future versions may introduce a `n_process` argument for parallel inference via
-multiprocessing.
+A new keyword argument, `n_process`, was introduced to control parallel
+inference via multiprocessing in v2.2.2.
 
 </Infobox>
 
@@ -98,6 +98,7 @@ multiprocessing.
 | `batch_size`                                 | int   | The number of texts to buffer.                                                                                                                             |
 | `disable`                                    | list  | Names of pipeline components to [disable](/usage/processing-pipelines#disabling).                                                                          |
 | `component_cfg` <Tag variant="new">2.1</Tag> | dict  | Config parameters for specific pipeline components, keyed by component name.                                                                               |
+| `n_process` <Tag variant="new">2.2.2</Tag>   | int   | Number of processors to use, only supported in Python 3.                                                                                                   |
 | **YIELDS**                                   | `Doc` | Documents in the order of the original text.                                                                                                               |
 
 ## Language.update {#update tag="method"}


### PR DESCRIPTION
## Description
The tabluar documentation for Language.pipe leaves out the argument `n_process` which was introduced in v2.2.2. In addition, warning W016 says that a "future version" will introduce `n_process` while it was introduced in v2.2.2.

### Types of change
Change to the documentation

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
