### PR TITLE
Warn for punctuation in entities when training with noise

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -172,7 +172,8 @@ class Errors(object):
             "and satisfies the correct annotations specified in the GoldParse. "
             "For example, are all labels added to the model? If you're "
             "training a named entity recognizer, also make sure that none of "
-            "your annotated entity spans have leading or trailing whitespace. "
+            "your annotated entity spans have leading or trailing whitespace "
+            "or punctuation. "
             "You can also use the experimental `debug-data` command to "
             "validate your JSON-formatted training data. For details, run:\n"
             "python -m spacy debug-data --help")


### PR DESCRIPTION
## Description
When training with noise, punctuation may be [converted](https://github.com/explosion/spaCy/blob/master/spacy/gold.pyx#L480) into whitespace which can then crash the training process as this may result in invalid entities. 

This is a quick fix in the `debug_data` script that alerts the user to this potential issue.

Fixes #4830 

### Types of change
enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
