### PR TITLE
Fix ent_ids and labels properties when id attribute used in patterns

### DIFF
--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -131,15 +131,15 @@ class EntityRuler(object):
         """
         keys = set(self.token_patterns.keys())
         keys.update(self.phrase_patterns.keys())
-        all_labels = []
+        all_labels = set()
 
         for l in keys:
             if self.ent_id_sep in l:
                 label, _ = self._split_label(l)
-                all_labels.append(label)
+                all_labels.add(label)
             else:
-                all_labels.append(l)
-        return tuple(set(all_labels))
+                all_labels.add(l)
+        return tuple(all_labels)
 
     @property
     def ent_ids(self):

--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -129,20 +129,31 @@ class EntityRuler(object):
 
         DOCS: https://spacy.io/api/entityruler#labels
         """
-        all_labels = set(self.token_patterns.keys())
-        all_labels.update(self.phrase_patterns.keys())
+        keys = set(self.token_patterns.keys())
+        keys.update(self.phrase_patterns.keys())
+        all_labels = []
+
+        for l in keys:
+            if self.ent_id_sep in l:
+                label, _ = self._split_label(l)
+                all_labels.append(label)
+            else:
+                all_labels.append(l)
         return tuple(all_labels)
 
     @property
     def ent_ids(self):
-        """All entity ids present in the match patterns `id` properties.
+        """All entity ids present in the match patterns `id` properties
 
         RETURNS (set): The string entity ids.
 
         DOCS: https://spacy.io/api/entityruler#ent_ids
         """
+        keys = set(self.token_patterns.keys())
+        keys.update(self.phrase_patterns.keys())
         all_ent_ids = set()
-        for l in self.labels:
+
+        for l in keys:
             if self.ent_id_sep in l:
                 _, ent_id = self._split_label(l)
                 all_ent_ids.add(ent_id)

--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -139,7 +139,7 @@ class EntityRuler(object):
                 all_labels.append(label)
             else:
                 all_labels.append(l)
-        return tuple(all_labels)
+        return tuple(set(all_labels))
 
     @property
     def ent_ids(self):

--- a/spacy/tests/pipeline/test_entity_ruler.py
+++ b/spacy/tests/pipeline/test_entity_ruler.py
@@ -158,4 +158,4 @@ def test_entity_ruler_properties(nlp, patterns):
         "COMPLEX",
         "TECH_ORG"
     ])
-    assert sorted(ruler.ent_ids) == ("a1", "a2")
+    assert sorted(ruler.ent_ids) == ["a1", "a2"]

--- a/spacy/tests/pipeline/test_entity_ruler.py
+++ b/spacy/tests/pipeline/test_entity_ruler.py
@@ -158,4 +158,4 @@ def test_entity_ruler_properties(nlp, patterns):
         "COMPLEX",
         "TECH_ORG"
     ])
-    assert ruler.ent_ids == ("a1", "a2")
+    assert sorted(ruler.ent_ids) == ("a1", "a2")

--- a/spacy/tests/pipeline/test_entity_ruler.py
+++ b/spacy/tests/pipeline/test_entity_ruler.py
@@ -21,6 +21,7 @@ def patterns():
         {"label": "HELLO", "pattern": [{"ORTH": "HELLO"}]},
         {"label": "COMPLEX", "pattern": [{"ORTH": "foo", "OP": "*"}]},
         {"label": "TECH_ORG", "pattern": "Apple", "id": "a1"},
+        {"label": "TECH_ORG", "pattern": "Microsoft", "id": "a2"},
     ]
 
 
@@ -151,10 +152,10 @@ def test_entity_ruler_validate(nlp):
 
 def test_entity_ruler_properties(nlp, patterns):
     ruler = EntityRuler(nlp, patterns=patterns, overwrite_ents=True)
-    assert set(ruler.labels) == set([
+    assert sorted(ruler.labels) == sorted([
         "HELLO",
         "BYE",
         "COMPLEX",
         "TECH_ORG"
     ])
-    assert ruler.ent_ids == ("a1",)
+    assert ruler.ent_ids == ("a1", "a2")

--- a/spacy/tests/pipeline/test_entity_ruler.py
+++ b/spacy/tests/pipeline/test_entity_ruler.py
@@ -147,3 +147,14 @@ def test_entity_ruler_validate(nlp):
     # invalid pattern raises error with validate
     with pytest.raises(MatchPatternError):
         validated_ruler.add_patterns([invalid_pattern])
+
+
+def test_entity_ruler_properties(nlp, patterns):
+    ruler = EntityRuler(nlp, patterns=patterns, overwrite_ents=True)
+    assert set(ruler.labels) == set([
+        "HELLO",
+        "BYE",
+        "COMPLEX",
+        "TECH_ORG"
+    ])
+    assert ruler.ent_ids == ("a1",)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

When using the "id" attribute in EntityRuler patterns right now, the labels property gives different strings for the same label because of the way patterns are stored.


## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Currently labels returns something like:
e.g. 

```python
[
    ...
    "TECH_ORG||apple",
    "TECH_ORG||microsoft",
    "TECH_ORG||google",
    ...
]
```

This PR fixes this so that the labels property only includes

```python
[
    ...
    "TECH_ORG",
    ...
]
```

and the ent_ids property has

```python
[
    ...
    "apple",
    "microsoft",
    "google",
    ...
]
```

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x ] I have submitted the spaCy Contributor Agreement.
- [ x] I ran the tests, and all new and existing tests passed.
- [ x] My changes don't require a change to the documentation, or if they do, I've added all required information.
