### PR TITLE
fix nlp.evaluate (#4924)

### DIFF
--- a/spacy/gold.pyx
+++ b/spacy/gold.pyx
@@ -694,6 +694,11 @@ cdef class GoldParse:
         self.cats = {} if cats is None else dict(cats)
         self.links = links
 
+        # orig_annot is used as an iterator in `nlp.evalate` even if self.length == 0,
+        # so set a empty list to avoid error.
+        # if self.lenght > 0, this is modified latter.
+        self.orig_annot = []
+
         # avoid allocating memory if the doc does not contain any tokens
         if self.length > 0:
             if words is None:

--- a/spacy/tests/regression/test_issue4924.py
+++ b/spacy/tests/regression/test_issue4924.py
@@ -1,4 +1,8 @@
+# coding: utf8
+from __future__ import unicode_literals
+
 import pytest
+
 import spacy
 
 

--- a/spacy/tests/regression/test_issue4924.py
+++ b/spacy/tests/regression/test_issue4924.py
@@ -1,0 +1,12 @@
+import pytest
+import spacy
+
+
+@pytest.fixture
+def nlp():
+    return spacy.blank("en")
+
+
+def test_evaluate(nlp):
+    docs_golds = [("", {})]
+    nlp.evaluate(docs_golds)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

From #4924.

I found `nlp.evaluate` fails with empty `doc` and `gold`.
This seems to be unintended, because the error is somewhat confusing:

```
        gold_deps = set()
        gold_deps_per_dep = {}
        gold_tags = set()
>       gold_ents = set(tags_to_entities([annot[-1] for annot in gold.orig_annot]))
E       TypeError: 'NoneType' object is not iterable

spacy/scorer.py:239: TypeError
```

I thought the following three ways to correct this:

1. Informs the users that `nlp.evaluate` will not accept an empty `gold`, and fails.
2. Modify `GoldParse` to set `gold.orig_annot = []` instead of `None`, if `gold` is empty.
3. Modify `nlp.evaluate` to properly handles empty `gold`

I adopted the second way.
In the first way, users should write a boilerplate to check `gold` is empty.
In the third way, it is necessary to introduce multiple `if`s, which complicates the code.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
