### PR TITLE
Customize entity color in displaCy

### DIFF
--- a/spacy/displacy/__init__.py
+++ b/spacy/displacy/__init__.py
@@ -173,7 +173,7 @@ def parse_ents(doc, options={}):
     RETURNS (dict): Generated entities keyed by text (original text) and ents.
     """
     ents = [
-        {"start": ent.start_char, "end": ent.end_char, "label": ent.label_}
+        {"start": ent.start_char, "end": ent.end_char, "label": ent.label_, "params": ent.has_extension('params') and ent._.params or {}}
         for ent in doc.ents
     ]
     if not ents:


### PR DESCRIPTION
## Description
Currently, the color of an entity in displaCy is determined by its `label`. These colors can be overridden (at the entity label level) by setting the `colors` key in the `options` parameter for `displacy.serve`.

I would like the color of an entity to be determined by an arbitrary attribute of the `entity`. Consider negation with [negspaCy](https://spacy.io/universe/project/negspacy) -- a term like "hypertension" could be red (indicating a negated entity) in the phrase "no history of hypertension" but green (no negation) in "patient does have hypertension". Another use case would be to return a different intensity of a color, based on a confidence score.

I made a one-line change to the `parse_ents` function in `displacy/__init__.py` to add a `params` key to each entity dictionary sent to the renderer. The renderer is already looking for a params key (although I was never able to determine where it is set).

This change allows me to write the following in my code to change the color based on an entity's span._.negex value:
`spacy.tokens.Span.set_extension("params", getter=lambda span: { "bg": span._.negex and "#ff8197" or "#bfeeb7" })`

I'm totally open to feedback. This may be the wrong approach, but I thought it was an interesting use case.

### Types of change
enhancement
