### PR TITLE
ensure doc.similarity returns a float

### DIFF
--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -399,7 +399,10 @@ cdef class Doc:
             return 0.0
         vector = self.vector
         xp = get_array_module(vector)
-        return xp.dot(vector, other.vector) / (self.vector_norm * other.vector_norm)
+
+        result = xp.dot(vector, other.vector) / (self.vector_norm * other.vector_norm)
+        # ensure we get a scalar back (numpy does this automatically but cupy doesn't)
+        return result.item()
 
     @property
     def has_vector(self):


### PR DESCRIPTION

## Description
Ensure we get a float when calling `doc1.similarity(doc2)`:

* Before this PR (printing value & type):
    * cupy: 0.9182048, <class 'cupy.core.core.ndarray'> 
    * numpy: 0.9182046417319748, <class 'numpy.float64'>
* After this PR:
    * cupy: 0.9182047843933105, <class 'float'>
    * numpy: 0.9182046417319748, <class 'float'>

### Types of change
Fixes #4896

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
