### PR TITLE
[WIP] KB Registry for customized `get_candidates` function

### DIFF
--- a/spacy/kb.pyx
+++ b/spacy/kb.pyx
@@ -2,7 +2,7 @@
 # cython: profile=True
 # coding: utf8
 from spacy.errors import Errors, Warnings, user_warning
-from spacy.tokens import Span
+from spacy.tokens.span import Span
 from spacy.util import registry
 
 from pathlib import Path
@@ -21,7 +21,7 @@ from libcpp.vector cimport vector
 
 
 @registry.kb.register("get_candidates")
-def get_candidates(KnowledgeBase kb, Span ent):
+def get_candidates(kb: KnowledgeBase, ent: Span):
     """Registered function to get_candidates from a `KnowledgeBase`
     given an ent from doc.ents
     """

--- a/spacy/kb.pyx
+++ b/spacy/kb.pyx
@@ -277,7 +277,6 @@ cdef class KnowledgeBase:
         and the prior probability of that alias resolving to that entity.
         If the alias is not known in the KB, and empty list is returned.
         """
-
         cdef hash_t alias_hash = self.vocab.strings[alias]
         if not alias_hash in self._alias_index:
             return []
@@ -285,11 +284,11 @@ cdef class KnowledgeBase:
         alias_entry = self._aliases_table[alias_index]
 
         return [Candidate(kb=self,
-                        entity_hash=self._entries[entry_index].entity_hash,
-                        entity_freq=self._entries[entry_index].freq,
-                        entity_vector=self._vectors_table[self._entries[entry_index].vector_index],
-                        alias_hash=alias_hash,
-                        prior_prob=prior_prob)
+                          entity_hash=self._entries[entry_index].entity_hash,
+                          entity_freq=self._entries[entry_index].freq,
+                          entity_vector=self._vectors_table[self._entries[entry_index].vector_index],
+                          alias_hash=alias_hash,
+                          prior_prob=prior_prob)
                 for (entry_index, prior_prob) in zip(alias_entry.entry_indices, alias_entry.probs)
                 if entry_index != 0]
 

--- a/spacy/kb.pyx
+++ b/spacy/kb.pyx
@@ -2,6 +2,7 @@
 # cython: profile=True
 # coding: utf8
 from spacy.errors import Errors, Warnings, user_warning
+from spacy.tokens import Span
 from spacy.util import registry
 
 from pathlib import Path
@@ -20,11 +21,11 @@ from libcpp.vector cimport vector
 
 
 @registry.kb.register("get_candidates")
-def get_candidates(KnowledgeBase kb, unicode alias):
+def get_candidates(KnowledgeBase kb, Span ent):
     """Registered function to get_candidates from a `KnowledgeBase`
-    given a unicode alias
+    given an ent from doc.ents
     """
-    return kb.get_candidates(alias)
+    return kb.get_candidates(ent.text)
 
 
 cdef class Candidate:

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -1327,7 +1327,7 @@ class EntityLinker(Pipe):
                             final_tensors.append(sentence_encoding)
 
                         else:
-                            candidates = util.registry.kb.get('get_candidates')(self.kb, ent.text)
+                            candidates = util.registry.kb.get('get_candidates')(self.kb, ent)
                             if not candidates:
                                 # no prediction possible for this entity - setting to NIL
                                 final_kb_ids.append(self.NIL)

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -1327,7 +1327,7 @@ class EntityLinker(Pipe):
                             final_tensors.append(sentence_encoding)
 
                         else:
-                            candidates = self.kb.get_candidates(ent.text)
+                            candidates = util.registry.kb.get('get_candidates')(self.kb, ent.text)
                             if not candidates:
                                 # no prediction possible for this entity - setting to NIL
                                 final_kb_ids.append(self.NIL)

--- a/spacy/tests/pipeline/test_entity_linker.py
+++ b/spacy/tests/pipeline/test_entity_linker.py
@@ -7,6 +7,7 @@ from spacy.kb import KnowledgeBase
 from spacy.lang.en import English
 from spacy.pipeline import EntityRuler
 from spacy.tokens import Span
+from spacy.util import registry
 
 
 @pytest.fixture

--- a/spacy/tests/pipeline/test_entity_linker.py
+++ b/spacy/tests/pipeline/test_entity_linker.py
@@ -172,7 +172,7 @@ def test_custom_candidate_generation_kb_registry_1(nlp):
     assert list(doc.ents)[0].kb_id_ == "NIL"
 
     @registry.kb.register('get_candidates')
-    def lower_get_candidates(kb: KnowledgeBase, ent: Span):
+    def lower_get_candidates(kb, ent):
         return kb.get_candidates(ent.text.lower())
     
     doc = nlp("Douglas is a person.")
@@ -219,7 +219,7 @@ def test_custom_candidate_generation_kb_registry_2(nlp):
     assert list(doc.ents)[0].kb_id_ == "NIL"
 
     @registry.kb.register('get_candidates')
-    def get_candidates_ent_id_attribute(kb: KnowledgeBase, ent: Span):
+    def get_candidates_ent_id_attribute(kb, ent):
         return kb.get_candidates(ent.ent_id_)
     
     doc = nlp("Doug is a person.")

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -42,6 +42,7 @@ class registry(object):
     lookups = catalogue.create("spacy", "lookups", entry_points=True)
     factories = catalogue.create("spacy", "factories", entry_points=True)
     displacy_colors = catalogue.create("spacy", "displacy_colors", entry_points=True)
+    kb = catalogue.create("spacy", "kb", entry_points=True)
 
 
 def set_env_log(value):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

WIP idea of allowing custom `get_candidates` function for KnowledgeBase based on this issue https://github.com/explosion/spaCy/issues/4981

@svlandeg I don't really like the idea of adding a full new registry for the kb itself.
And I'm not sold on the implementation here but this is just an idea of how to provide the custom functionality for methods of arbitrary spaCy objects. 

It would be interesting to expand the idea to a more generic solution but I assume that's a lot of what you're thinking about for spaCy v3.

Would love to discuss further

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
