### PR TITLE
Use int only in key2row for better performance

### DIFF
--- a/spacy/vectors.pyx
+++ b/spacy/vectors.pyx
@@ -283,7 +283,11 @@ cdef class Vectors:
 
         DOCS: https://spacy.io/api/vectors#add
         """
-        key = get_string_id(key)
+        # use int for all keys and rows in key2row for more efficient access
+        # and serialization
+        key = int(get_string_id(key))
+        if row is not None:
+            row = int(row)
         if row is None and key in self.key2row:
             row = self.key2row[key]
         elif row is None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Cast all keys and rows to `int` in `vectors.key2row` for more efficient access and serialization.

After pruning vectors, `key2row` ended up as `Dict[numpy.uint64, Union[int, numpy.int32]]` instead of `Dict[int, int]`, which is much larger when serialized with msgpack for (4x larger for English `md` vs. `lg`) and much slower to load and access.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
