### PR TITLE
Fix using pre-trained vectors in textcat

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -608,6 +608,7 @@ class Language(object):
         link_vectors_to_models(self.vocab)
         if self.vocab.vectors.data.shape[1]:
             cfg["pretrained_vectors"] = self.vocab.vectors.name
+            cfg['pretrained_dims'] = self.vocab.vectors.data.shape[1]
         if sgd is None:
             sgd = create_default_optimizer(Model.ops)
         self._optimizer = sgd

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -1044,6 +1044,7 @@ class TextCategorizer(Pipe):
                     self.add_label(cat)
         if self.model is True:
             self.cfg["pretrained_vectors"] = kwargs.get("pretrained_vectors")
+            self.cfg["pretrained_dims"] = kwargs.get("pretrained_dims")
             self.require_labels()
             self.model = self.Model(len(self.labels), **self.cfg)
             link_vectors_to_models(self.vocab)


### PR DESCRIPTION
Fixes #4009

## Description
Refactor https://github.com/explosion/spaCy/commit/95a96152213a0c3e4827c00ab396357d3abf02d2 started using `pretrained_vectors` instead of `pretrained_dims` in the `cfg`, but [`build_text_classifier`](https://github.com/explosion/spaCy/blob/2c107f02a4d60bda2440db0aad1a88cbbf4fb52d/spacy/_ml.py#L638) still needs that `pretrained_dims` parameter. This is a quick hack to make sure that setting is there, so that the TextCategorizer actually does use the pretrained vectors when available. This will be much more cleanly fixed in spaCy 3.

To use pre-trained vectors in the `textcat` component, either call 
```
nlp.begin_training()
```
or  
```
textcat.begin_training(pretrained_vectors=nlp.vocab.vectors.name, pretrained_dims=nlp.vocab.vectors.data.shape[1])
```

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
