### PR TITLE
load Underscore state when multiprocessing

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -15,6 +15,7 @@ import multiprocessing as mp
 from itertools import chain, cycle
 
 from .tokenizer import Tokenizer
+from .tokens.underscore import Underscore
 from .vocab import Vocab
 from .lemmatizer import Lemmatizer
 from .lookups import Lookups
@@ -852,7 +853,10 @@ class Language(object):
         sender.send()
 
         procs = [
-            mp.Process(target=_apply_pipes, args=(self.make_doc, pipes, rch, sch))
+            mp.Process(
+                target=_apply_pipes,
+                args=(self.make_doc, pipes, rch, sch, Underscore.get_state()),
+            )
             for rch, sch in zip(texts_q, bytedocs_send_ch)
         ]
         for proc in procs:
@@ -1107,7 +1111,7 @@ def _pipe(docs, proc, kwargs):
         yield doc
 
 
-def _apply_pipes(make_doc, pipes, reciever, sender):
+def _apply_pipes(make_doc, pipes, receiver, sender, underscore_state):
     """Worker for Language.pipe
 
     receiver (multiprocessing.Connection): Pipe to receive text. Usually
@@ -1115,8 +1119,9 @@ def _apply_pipes(make_doc, pipes, reciever, sender):
     sender (multiprocessing.Connection): Pipe to send doc. Usually created by
         `multiprocessing.Pipe()`
     """
+    Underscore.load_state(underscore_state)
     while True:
-        texts = reciever.get()
+        texts = receiver.get()
         docs = (make_doc(text) for text in texts)
         for pipe in pipes:
             docs = pipe(docs)

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1118,6 +1118,7 @@ def _apply_pipes(make_doc, pipes, receiver, sender, underscore_state):
         created by `multiprocessing.Pipe()`
     sender (multiprocessing.Connection): Pipe to send doc. Usually created by
         `multiprocessing.Pipe()`
+    underscore_state (tuple): The data in the Underscore class of the parent
     """
     Underscore.load_state(underscore_state)
     while True:

--- a/spacy/tests/doc/test_underscore.py
+++ b/spacy/tests/doc/test_underscore.py
@@ -7,6 +7,15 @@ from spacy.tokens import Doc, Span, Token
 from spacy.tokens.underscore import Underscore
 
 
+@pytest.fixture(scope="function", autouse=True)
+def clean_underscore():
+    # reset the Underscore object after the test, to avoid having state copied across tests
+    yield
+    Underscore.doc_extensions = {}
+    Underscore.span_extensions = {}
+    Underscore.token_extensions = {}
+
+
 def test_create_doc_underscore():
     doc = Mock()
     doc.doc = doc

--- a/spacy/tests/matcher/test_matcher_api.py
+++ b/spacy/tests/matcher/test_matcher_api.py
@@ -6,6 +6,7 @@ import re
 from mock import Mock
 from spacy.matcher import Matcher, DependencyMatcher
 from spacy.tokens import Doc, Token
+from ..doc.test_underscore import clean_underscore
 
 
 @pytest.fixture
@@ -200,6 +201,7 @@ def test_matcher_any_token_operator(en_vocab):
     assert matches[2] == "test hello world"
 
 
+@pytest.mark.usefixtures("clean_underscore")
 def test_matcher_extension_attribute(en_vocab):
     matcher = Matcher(en_vocab)
     get_is_fruit = lambda token: token.text in ("apple", "banana")

--- a/spacy/tests/regression/test_issue4849.py
+++ b/spacy/tests/regression/test_issue4849.py
@@ -9,11 +9,6 @@ from spacy.tokens.underscore import Underscore
 def test_issue4849():
     nlp = English()
 
-    # reset the Underscore object because test_underscore has a lambda function that can't be pickled
-    Underscore.doc_extensions = {}
-    Underscore.span_extensions = {}
-    Underscore.token_extensions = {}
-
     ruler = EntityRuler(
         nlp, patterns=[
             {"label": "PERSON", "pattern": 'joe biden', "id": 'joe-biden'},

--- a/spacy/tests/regression/test_issue4849.py
+++ b/spacy/tests/regression/test_issue4849.py
@@ -3,10 +3,16 @@ from __future__ import unicode_literals
 
 from spacy.lang.en import English
 from spacy.pipeline import EntityRuler
+from spacy.tokens.underscore import Underscore
 
 
 def test_issue4849():
     nlp = English()
+
+    # reset the Underscore object because test_underscore has a lambda function that can't be pickled
+    Underscore.doc_extensions = {}
+    Underscore.span_extensions = {}
+    Underscore.token_extensions = {}
 
     ruler = EntityRuler(
         nlp, patterns=[

--- a/spacy/tests/regression/test_issue4903.py
+++ b/spacy/tests/regression/test_issue4903.py
@@ -35,6 +35,5 @@ def test_issue4903():
     nlp.add_pipe(custom_component, after="parser")
 
     text = ["I like bananas.", "Do you like them?", "No, I prefer wasabi."]
-    # works without 'n_process'
     for doc in nlp.pipe(text, n_process=2):
         print(doc)

--- a/spacy/tests/regression/test_issue4903.py
+++ b/spacy/tests/regression/test_issue4903.py
@@ -1,0 +1,40 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+import spacy
+from spacy.tokens import Span, Doc
+
+
+class CustomPipe:
+    name = "my_pipe"
+
+    def __init__(self):
+        Span.set_extension("my_ext", getter=self._get_my_ext)
+        Doc.set_extension("my_ext", default=None)
+
+    def __call__(self, doc):
+        gathered_ext = []
+        for sent in doc.sents:
+            sent_ext = self._get_my_ext(sent)
+            sent._.set("my_ext", sent_ext)
+            gathered_ext.append(sent_ext)
+
+        doc._.set("my_ext", "\n".join(gathered_ext))
+
+        return doc
+
+    @staticmethod
+    def _get_my_ext(span):
+        return str(span.end)
+
+
+def test_issue4903():
+    # ensures that this runs correctly and doesn't hang or crash on Windows / macOS
+    nlp = spacy.load("en_core_web_sm")
+    custom_component = CustomPipe()
+    nlp.add_pipe(custom_component, after="parser")
+
+    text = ["I like bananas.", "Do you like them?", "No, I prefer wasabi."]
+    # works without 'n_process'
+    for doc in nlp.pipe(text, n_process=2):
+        print(doc)

--- a/spacy/tests/regression/test_issue4903.py
+++ b/spacy/tests/regression/test_issue4903.py
@@ -35,5 +35,7 @@ def test_issue4903():
     nlp.add_pipe(custom_component, after="parser")
 
     text = ["I like bananas.", "Do you like them?", "No, I prefer wasabi."]
-    for doc in nlp.pipe(text, n_process=2):
-        print(doc)
+    docs = list(nlp.pipe(text, n_process=2))
+    assert docs[0].text == "I like bananas."
+    assert docs[1].text == "Do you like them?"
+    assert docs[2].text == "No, I prefer wasabi."

--- a/spacy/tests/regression/test_issue4903.py
+++ b/spacy/tests/regression/test_issue4903.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import spacy
+from spacy.lang.en import English
 from spacy.tokens import Span, Doc
 
 
@@ -30,9 +31,10 @@ class CustomPipe:
 
 def test_issue4903():
     # ensures that this runs correctly and doesn't hang or crash on Windows / macOS
-    nlp = spacy.load("en_core_web_sm")
+    nlp = English()
     custom_component = CustomPipe()
-    nlp.add_pipe(custom_component, after="parser")
+    nlp.add_pipe(nlp.create_pipe("sentencizer"))
+    nlp.add_pipe(custom_component, after="sentencizer")
 
     text = ["I like bananas.", "Do you like them?", "No, I prefer wasabi."]
     docs = list(nlp.pipe(text, n_process=2))

--- a/spacy/tests/regression/test_issue4903.py
+++ b/spacy/tests/regression/test_issue4903.py
@@ -33,11 +33,6 @@ class CustomPipe:
 def test_issue4903():
     # ensures that this runs correctly and doesn't hang or crash on Windows / macOS
 
-    # reset the Underscore object because test_underscore has a lambda function that can't be pickled
-    Underscore.doc_extensions = {}
-    Underscore.span_extensions = {}
-    Underscore.token_extensions = {}
-
     nlp = English()
     custom_component = CustomPipe()
     nlp.add_pipe(nlp.create_pipe("sentencizer"))

--- a/spacy/tests/regression/test_issue4903.py
+++ b/spacy/tests/regression/test_issue4903.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import spacy
 from spacy.lang.en import English
 from spacy.tokens import Span, Doc
+from spacy.tokens.underscore import Underscore
 
 
 class CustomPipe:
@@ -31,6 +32,12 @@ class CustomPipe:
 
 def test_issue4903():
     # ensures that this runs correctly and doesn't hang or crash on Windows / macOS
+
+    # reset the Underscore object because test_underscore has a lambda function that can't be pickled
+    Underscore.doc_extensions = {}
+    Underscore.span_extensions = {}
+    Underscore.token_extensions = {}
+
     nlp = English()
     custom_component = CustomPipe()
     nlp.add_pipe(nlp.create_pipe("sentencizer"))

--- a/spacy/tests/regression/test_issue4924.py
+++ b/spacy/tests/regression/test_issue4924.py
@@ -11,6 +11,6 @@ def nlp():
     return spacy.blank("en")
 
 
-def test_evaluate(nlp):
+def test_issue4924(nlp):
     docs_golds = [("", {})]
     nlp.evaluate(docs_golds)

--- a/spacy/tokens/underscore.py
+++ b/spacy/tokens/underscore.py
@@ -79,6 +79,14 @@ class Underscore(object):
     def _get_key(self, name):
         return ("._.", name, self._start, self._end)
 
+    @classmethod
+    def get_state(cls):
+        return cls.token_extensions, cls.span_extensions, cls.doc_extensions
+
+    @classmethod
+    def load_state(cls, state):
+        cls.token_extensions, cls.span_extensions, cls.doc_extensions = state
+
 
 def get_ext_args(**kwargs):
     """Validate and convert arguments. Reused in Doc, Token and Span."""


### PR DESCRIPTION
Fixes https://github.com/explosion/spaCy/issues/4903

## Description
- Define a `state` for the `Underscore` class
- Load that state when creating multiple works with `n_process`>1.

On Linux the current state is transferred as `fork` is being called (by default, can be changed), but this is not the case on Windows or macOS, where `spawn` is called instead. So it's always safer to make sure the necessary state is defined explicitely. See also https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods

If we have other global variables/state that should be retained when multiprocessing, we should make a similar fix for them.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
