### PR TITLE
add message when cli train script throws exception

### DIFF
--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -508,6 +508,8 @@ def train(
                             "score = {}".format(best_score, current_score)
                         )
                         break
+    except Exception as e:
+        msg.warn("Aborting and saving the final best model. Encountered exception:", str(e))
     finally:
         best_pipes = nlp.pipe_names
         if disabled_pipes:

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -509,7 +509,7 @@ def train(
                         )
                         break
     except Exception as e:
-        msg.warn("Aborting and saving the final best model. Encountered exception:", str(e))
+        msg.warn("Aborting and saving the final best model. Encountered exception: {}".format(e))
     finally:
         best_pipes = nlp.pipe_names
         if disabled_pipes:


### PR DESCRIPTION
## Description
The `train` CLI script had a `try`-`finally` block, not sure why the `except` was missing?
If there wasn't a particular reason, I just added a quick log message to avoid confusion as in Issue https://github.com/explosion/spaCy/issues/4719.

### Types of change
enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
