### PR TITLE
add lemma option to displacy 'dep' visualiser

### DIFF
--- a/spacy/displacy/__init__.py
+++ b/spacy/displacy/__init__.py
@@ -144,10 +144,12 @@ def parse_deps(orig_doc, options={}):
             for span, tag, lemma, ent_type in spans:
                 attrs = {"tag": tag, "lemma": lemma, "ent_type": ent_type}
                 retokenizer.merge(span, attrs=attrs)
-    if options.get("fine_grained"):
-        words = [{"text": w.text, "tag": w.tag_} for w in doc]
+    fine = options.get("fine_grained", False)
+    if options.get("add_lemma", False):
+        words = [{"text": w.text, "tag": w.tag_ if fine else w.pos_, "lemma": w.lemma_} for w in doc]
     else:
-        words = [{"text": w.text, "tag": w.pos_} for w in doc]
+        words = [{"text": w.text, "tag": w.tag_ if fine else w.pos_} for w in doc]
+
     arcs = []
     for word in doc:
         if word.i < word.head.i:

--- a/spacy/displacy/__init__.py
+++ b/spacy/displacy/__init__.py
@@ -144,11 +144,11 @@ def parse_deps(orig_doc, options={}):
             for span, tag, lemma, ent_type in spans:
                 attrs = {"tag": tag, "lemma": lemma, "ent_type": ent_type}
                 retokenizer.merge(span, attrs=attrs)
-    fine = options.get("fine_grained", False)
-    if options.get("add_lemma", False):
-        words = [{"text": w.text, "tag": w.tag_ if fine else w.pos_, "lemma": w.lemma_} for w in doc]
-    else:
-        words = [{"text": w.text, "tag": w.tag_ if fine else w.pos_} for w in doc]
+    fine_grained = options.get("fine_grained")
+    add_lemma = options.get("add_lemma")
+    words = [{"text": w.text,
+              "tag": w.tag_ if fine_grained else w.pos_,
+              "lemma": w.lemma_ if add_lemma else None} for w in doc]
 
     arcs = []
     for word in doc:

--- a/spacy/displacy/render.py
+++ b/spacy/displacy/render.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 import uuid
 
-from .templates import TPL_DEP_SVG, TPL_DEP_WORDS, TPL_DEP_ARCS, TPL_ENTS
+from .templates import TPL_DEP_SVG, TPL_DEP_WORDS, TPL_DEP_WORDS_LEMMA, TPL_DEP_ARCS, TPL_ENTS
 from .templates import TPL_ENT, TPL_ENT_RTL, TPL_FIGURE, TPL_TITLE, TPL_PAGE
 from ..util import minify_html, escape_html, registry
 from ..errors import Errors
@@ -83,7 +83,7 @@ class DependencyRenderer(object):
         self.width = self.offset_x + len(words) * self.distance
         self.height = self.offset_y + 3 * self.word_spacing
         self.id = render_id
-        words = [self.render_word(w["text"], w["tag"], i) for i, w in enumerate(words)]
+        words = [self.render_word(w["text"], w["tag"],  w.get("lemma", None), i) for i, w in enumerate(words)]
         arcs = [
             self.render_arrow(a["label"], a["start"], a["end"], a["dir"], i)
             for i, a in enumerate(arcs)
@@ -101,7 +101,7 @@ class DependencyRenderer(object):
             lang=self.lang,
         )
 
-    def render_word(self, text, tag, i):
+    def render_word(self, text, tag, lemma, i,):
         """Render individual word.
 
         text (unicode): Word text.
@@ -114,6 +114,8 @@ class DependencyRenderer(object):
         if self.direction == "rtl":
             x = self.width - x
         html_text = escape_html(text)
+        if lemma is not None:
+            return TPL_DEP_WORDS_LEMMA.format(text=html_text, tag=tag, lemma=lemma, x=x, y=y)
         return TPL_DEP_WORDS.format(text=html_text, tag=tag, x=x, y=y)
 
     def render_arrow(self, label, start, end, direction, i):

--- a/spacy/displacy/templates.py
+++ b/spacy/displacy/templates.py
@@ -18,6 +18,15 @@ TPL_DEP_WORDS = """
 """
 
 
+TPL_DEP_WORDS_LEMMA = """
+<text class="displacy-token" fill="currentColor" text-anchor="middle" y="{y}">
+    <tspan class="displacy-word" fill="currentColor" x="{x}">{text}</tspan>
+    <tspan class="displacy-lemma" dy="2em" fill="currentColor" x="{x}">{lemma}</tspan>
+    <tspan class="displacy-tag" dy="2em" fill="currentColor" x="{x}">{tag}</tspan>
+</text>
+"""
+
+
 TPL_DEP_ARCS = """
 <g class="displacy-arrow">
     <path class="displacy-arc" id="arrow-{id}-{i}" stroke-width="{stroke}px" d="{arc}" fill="none" stroke="currentColor"/>

--- a/spacy/tests/test_displacy.py
+++ b/spacy/tests/test_displacy.py
@@ -23,19 +23,18 @@ def test_displacy_parse_ents(en_vocab):
 def test_displacy_parse_deps(en_vocab):
     """Test that deps and tags on a Doc are converted into displaCy's format."""
     words = ["This", "is", "a", "sentence"]
-    lemmas = ["this", "be", "a", "sentence"]
     heads = [1, 0, 1, -2]
     pos = ["DET", "VERB", "DET", "NOUN"]
     tags = ["DT", "VBZ", "DT", "NN"]
     deps = ["nsubj", "ROOT", "det", "attr"]
-    doc = get_doc(en_vocab, words=words, heads=heads, pos=pos, tags=tags, deps=deps, lemmas=lemmas)
-    deps = displacy.parse_deps(doc, options={"add_lemma": True})
+    doc = get_doc(en_vocab, words=words, heads=heads, pos=pos, tags=tags, deps=deps)
+    deps = displacy.parse_deps(doc)
     assert isinstance(deps, dict)
     assert deps["words"] == [
-        {"lemma": "this", "text": "This", "tag": "DET"},
-        {"lemma": "be", "text": "is", "tag": "AUX"},
-        {"lemma": "a", "text": "a", "tag": "DET"},
-        {"lemma": "sentence", "text": "sentence", "tag": "NOUN"},
+        {"lemma": None, "text": "This", "tag": "DET"},
+        {"lemma": None, "text": "is", "tag": "AUX"},
+        {"lemma": None, "text": "a", "tag": "DET"},
+        {"lemma": None, "text": "sentence", "tag": "NOUN"},
     ]
     assert deps["arcs"] == [
         {"start": 0, "end": 1, "label": "nsubj", "dir": "left"},

--- a/spacy/tests/test_displacy.py
+++ b/spacy/tests/test_displacy.py
@@ -23,7 +23,7 @@ def test_displacy_parse_ents(en_vocab):
 def test_displacy_parse_deps(en_vocab):
     """Test that deps and tags on a Doc are converted into displaCy's format."""
     words = ["This", "is", "a", "sentence"]
-    lemmas = ["This", "be", "a", "sentence"]
+    lemmas = ["this", "be", "a", "sentence"]
     heads = [1, 0, 1, -2]
     pos = ["DET", "VERB", "DET", "NOUN"]
     tags = ["DT", "VBZ", "DT", "NN"]

--- a/spacy/tests/test_displacy.py
+++ b/spacy/tests/test_displacy.py
@@ -23,18 +23,19 @@ def test_displacy_parse_ents(en_vocab):
 def test_displacy_parse_deps(en_vocab):
     """Test that deps and tags on a Doc are converted into displaCy's format."""
     words = ["This", "is", "a", "sentence"]
+    lemmas = ["This", "be", "a", "sentence"]
     heads = [1, 0, 1, -2]
     pos = ["DET", "VERB", "DET", "NOUN"]
     tags = ["DT", "VBZ", "DT", "NN"]
     deps = ["nsubj", "ROOT", "det", "attr"]
-    doc = get_doc(en_vocab, words=words, heads=heads, pos=pos, tags=tags, deps=deps)
-    deps = displacy.parse_deps(doc)
+    doc = get_doc(en_vocab, words=words, heads=heads, pos=pos, tags=tags, deps=deps, lemmas=lemmas)
+    deps = displacy.parse_deps(doc, options={"add_lemma": True})
     assert isinstance(deps, dict)
     assert deps["words"] == [
-        {"text": "This", "tag": "DET"},
-        {"text": "is", "tag": "AUX"},
-        {"text": "a", "tag": "DET"},
-        {"text": "sentence", "tag": "NOUN"},
+        {"lemma": "this", "text": "This", "tag": "DET"},
+        {"lemma": "be", "text": "is", "tag": "AUX"},
+        {"lemma": "a", "text": "a", "tag": "DET"},
+        {"lemma": "sentence", "text": "sentence", "tag": "NOUN"},
     ]
     assert deps["arcs"] == [
         {"start": 0, "end": 1, "label": "nsubj", "dir": "left"},

--- a/spacy/tests/util.py
+++ b/spacy/tests/util.py
@@ -8,7 +8,7 @@ import contextlib
 import srsly
 from pathlib import Path
 from spacy.tokens import Doc, Span
-from spacy.attrs import POS, HEAD, DEP
+from spacy.attrs import POS, HEAD, DEP, LEMMA
 from spacy.compat import path2str
 
 
@@ -26,22 +26,24 @@ def make_tempdir():
     shutil.rmtree(path2str(d))
 
 
-def get_doc(vocab, words=[], pos=None, heads=None, deps=None, tags=None, ents=None):
+def get_doc(vocab, words=[], pos=None, heads=None, deps=None, tags=None, ents=None, lemmas=None):
     """Create Doc object from given vocab, words and annotations."""
     pos = pos or [""] * len(words)
     tags = tags or [""] * len(words)
     heads = heads or [0] * len(words)
     deps = deps or [""] * len(words)
-    for value in deps + tags + pos:
+    lemmas = lemmas or [""] * len(words)
+    for value in deps + tags + pos + lemmas:
         vocab.strings.add(value)
 
     doc = Doc(vocab, words=words)
-    attrs = doc.to_array([POS, HEAD, DEP])
-    for i, (p, head, dep) in enumerate(zip(pos, heads, deps)):
+    attrs = doc.to_array([POS, HEAD, DEP, LEMMA])
+    for i, (p, head, dep, lemma) in enumerate(zip(pos, heads, deps, lemmas)):
         attrs[i, 0] = doc.vocab.strings[p]
         attrs[i, 1] = head
         attrs[i, 2] = doc.vocab.strings[dep]
-    doc.from_array([POS, HEAD, DEP], attrs)
+        attrs[i, 3] = doc.vocab.strings[lemma]
+    doc.from_array([POS, HEAD, DEP, LEMMA], attrs)
     if ents:
         doc.ents = [
             Span(doc, start, end, label=doc.vocab.strings[label])

--- a/spacy/tests/util.py
+++ b/spacy/tests/util.py
@@ -8,7 +8,7 @@ import contextlib
 import srsly
 from pathlib import Path
 from spacy.tokens import Doc, Span
-from spacy.attrs import POS, HEAD, DEP, LEMMA
+from spacy.attrs import POS, HEAD, DEP
 from spacy.compat import path2str
 
 
@@ -36,7 +36,7 @@ def get_doc(vocab, words=[], pos=None, heads=None, deps=None, tags=None, ents=No
         vocab.strings.add(value)
 
     doc = Doc(vocab, words=words)
-    attrs = doc.to_array([POS, HEAD, DEP, LEMMA])
+    attrs = doc.to_array([POS, HEAD, DEP])
     for i, (p, head, dep) in enumerate(zip(pos, heads, deps)):
         attrs[i, 0] = doc.vocab.strings[p]
         attrs[i, 1] = head

--- a/spacy/tests/util.py
+++ b/spacy/tests/util.py
@@ -26,24 +26,22 @@ def make_tempdir():
     shutil.rmtree(path2str(d))
 
 
-def get_doc(vocab, words=[], pos=None, heads=None, deps=None, tags=None, ents=None, lemmas=None):
+def get_doc(vocab, words=[], pos=None, heads=None, deps=None, tags=None, ents=None):
     """Create Doc object from given vocab, words and annotations."""
     pos = pos or [""] * len(words)
     tags = tags or [""] * len(words)
     heads = heads or [0] * len(words)
     deps = deps or [""] * len(words)
-    lemmas = lemmas or [""] * len(words)
-    for value in deps + tags + pos + lemmas:
+    for value in deps + tags + pos:
         vocab.strings.add(value)
 
     doc = Doc(vocab, words=words)
     attrs = doc.to_array([POS, HEAD, DEP, LEMMA])
-    for i, (p, head, dep, lemma) in enumerate(zip(pos, heads, deps, lemmas)):
+    for i, (p, head, dep) in enumerate(zip(pos, heads, deps)):
         attrs[i, 0] = doc.vocab.strings[p]
         attrs[i, 1] = head
         attrs[i, 2] = doc.vocab.strings[dep]
-        attrs[i, 3] = doc.vocab.strings[lemma]
-    doc.from_array([POS, HEAD, DEP, LEMMA], attrs)
+    doc.from_array([POS, HEAD, DEP], attrs)
     if ents:
         doc.ents = [
             Span(doc, start, end, label=doc.vocab.strings[label])

--- a/website/docs/api/top-level.md
+++ b/website/docs/api/top-level.md
@@ -239,6 +239,7 @@ If a setting is not present in the options, the default value will be used.
 | Name               | Type    | Description                                                                                                     | Default                 |
 | ------------------ | ------- | --------------------------------------------------------------------------------------------------------------- | ----------------------- |
 | `fine_grained`     | bool    | Use fine-grained part-of-speech tags (`Token.tag_`) instead of coarse-grained tags (`Token.pos_`).              | `False`                 |
+| `add_lemma`        | bool    | Print the lemma's in a separate row below the token texts in the `dep` visualisation.                           | `False`                 |
 | `collapse_punct`   | bool    | Attach punctuation to tokens. Can make the parse more readable, as it prevents long arcs to attach punctuation. | `True`                  |
 | `collapse_phrases` | bool    | Merge noun phrases into one token.                                                                              | `False`                 |
 | `compact`          | bool    | "Compact mode" with square arrows that takes up less space.                                                     | `False`                 |


### PR DESCRIPTION
## Description
Support `add_lemma` (default `False`) option for `dep` visualisation with `displacy`. Just adds an additional row of lemma's below the `token.text`. Made sure all combinations with `fine_grained` (for POS) work well. 

![image](https://user-images.githubusercontent.com/8796347/74948545-2032ef00-5405-11ea-8355-479d8cc5c39c.png)

Also changed the documentation.

### Types of change
enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
