### PR TITLE
Add missing comma in a dependency specification

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ install_requires =
 
 [options.extras_require]
 lookups =
-    spacy_lookups_data>=0.0.5<0.2.0
+    spacy_lookups_data>=0.0.5,<0.2.0
 cuda =
     cupy>=5.0.0b4
 cuda80 =


### PR DESCRIPTION
Conda is complaining that it can't parse that line otherwise.

- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all the required information.
