### PR TITLE
Fix sync between master and develop

### DIFF
--- a/bin/wiki_entity_linking/wikidata_train_entity_linker.py
+++ b/bin/wiki_entity_linking/wikidata_train_entity_linker.py
@@ -175,12 +175,10 @@ def main(
                             kb=kb,
                             labels_discard=labels_discard,
                         )
-                        docs, golds = zip(*train_batch)
                     try:
                         with nlp.disable_pipes(*other_pipes):
                             nlp.update(
-                                docs=docs,
-                                golds=golds,
+                                examples=train_batch,
                                 sgd=optimizer,
                                 drop=dropout,
                                 losses=losses,


### PR DESCRIPTION
## Description
Found a few bugs introduced from porting bug fixes from `master` to `develop` (PR #5027), mostly related to the refactor of using a batch of training `examples` (on `develop`) versus the old `golds, docs` (on `master`) as argument for `nlp.update()`.

Also reverted the additional parameters in the `train` script from https://github.com/explosion/spaCy/pull/5021 as this fix was really intended for `master` only and should probably be done more properly with config files for v.3 onwards.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
