### PR TITLE
Improve Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ __pycache__/
 .~env/
 .venv
 venv/
+env3.*/
 .dev
 .denv
 .pypyenv
@@ -56,6 +57,7 @@ lib64/
 parts/
 sdist/
 var/
+wheelhouse/
 *.egg-info/
 pip-wheel-metadata/
 Pipfile.lock


### PR DESCRIPTION
Various improvements to building the .pex standalone executable.

* Create versioned files, e.g. `dist/spacy-2.2.3.pex` instead of using the Git sha.
* Build wheels with `pip wheel` into a directory `wheelhouse/`, so that we can disable pex's cache.
* Add `make test` command that runs the tests using the built artefact.

It should also now be easier to change the Python version. In summary, writing something like:

```
make PYVER=3.7 test
```

Should build and test a file `dist/spacy-2.3.3.pex`, if 2.2.3 is the current library version (according to the `about.py`). The executable will be self-contained, except that it will require the Python3.7 interpreter to be installed.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
