### PR TITLE
take care of global vectors in multiprocessing

### DIFF
--- a/spacy/_ml.py
+++ b/spacy/_ml.py
@@ -296,8 +296,7 @@ def link_vectors_to_models(vocab):
     key = (ops.device, vectors.name)
     if key in thinc.extra.load_nlp.VECTORS:
         if thinc.extra.load_nlp.VECTORS[key].shape != data.shape:
-            # This is a hack to avoid the problem in #3853. Maybe we should
-            # print a warning as well?
+            # This is a hack to avoid the problem in #3853.
             old_name = vectors.name
             new_name = vectors.name + "_%d" % data.shape[0]
             user_warning(Warnings.W019.format(old=old_name, new=new_name))

--- a/spacy/tests/regression/test_issue4725.py
+++ b/spacy/tests/regression/test_issue4725.py
@@ -1,0 +1,26 @@
+import numpy
+
+import multiprocessing
+
+from spacy.lang.en import English
+from spacy.vocab import Vocab
+
+
+def test_issue4725():
+    # ensures that this runs correctly and doesn't hang or crash because of the global vectors
+    vocab = Vocab(vectors_name="test_vocab_add_vector")
+    data = numpy.ndarray((5, 3), dtype="f")
+    data[0] = 1.0
+    data[1] = 2.0
+    vocab.set_vector("cat", data[0])
+    vocab.set_vector("dog", data[1])
+
+    nlp = English(vocab=vocab)
+    ner = nlp.create_pipe("ner")
+    nlp.add_pipe(ner)
+    nlp.begin_training()
+    multiprocessing.set_start_method('spawn')
+    docs = ["Kurt is in London."] * 10
+    for _ in nlp.pipe(docs, batch_size=2, n_process=2):
+        pass
+

--- a/spacy/tests/regression/test_issue4725.py
+++ b/spacy/tests/regression/test_issue4725.py
@@ -1,7 +1,5 @@
 import numpy
 
-import multiprocessing
-
 from spacy.lang.en import English
 from spacy.vocab import Vocab
 

--- a/spacy/tests/regression/test_issue4725.py
+++ b/spacy/tests/regression/test_issue4725.py
@@ -1,4 +1,6 @@
 # coding: utf8
+from __future__ import unicode_literals
+
 import numpy
 
 from spacy.lang.en import English

--- a/spacy/tests/regression/test_issue4725.py
+++ b/spacy/tests/regression/test_issue4725.py
@@ -19,7 +19,6 @@ def test_issue4725():
     ner = nlp.create_pipe("ner")
     nlp.add_pipe(ner)
     nlp.begin_training()
-    multiprocessing.set_start_method('spawn')
     docs = ["Kurt is in London."] * 10
     for _ in nlp.pipe(docs, batch_size=2, n_process=2):
         pass

--- a/spacy/tests/regression/test_issue4725.py
+++ b/spacy/tests/regression/test_issue4725.py
@@ -1,3 +1,4 @@
+# coding: utf8
 import numpy
 
 from spacy.lang.en import English

--- a/spacy/tests/regression/test_issue4849.py
+++ b/spacy/tests/regression/test_issue4849.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 from spacy.lang.en import English
 from spacy.pipeline import EntityRuler
-from spacy.tokens.underscore import Underscore
 
 
 def test_issue4849():

--- a/spacy/tests/regression/test_issue4903.py
+++ b/spacy/tests/regression/test_issue4903.py
@@ -1,10 +1,8 @@
 # coding: utf8
 from __future__ import unicode_literals
 
-import spacy
 from spacy.lang.en import English
 from spacy.tokens import Span, Doc
-from spacy.tokens.underscore import Underscore
 
 
 class CustomPipe:


### PR DESCRIPTION
Fixes #4725
Should not be ported to `develop` - is a quick fix for 2.x.

## Description
Similar to https://github.com/explosion/spaCy/pull/5006 where the global data for `Underscore` needed to be passed on to the child processes, here we pass on the global vectors data.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
