### PR TITLE
fix minibatch_by_words  with int

### DIFF
--- a/spacy/util.py
+++ b/spacy/util.py
@@ -562,7 +562,7 @@ def minibatch_by_words(examples, size, tuples=True, count_words=len):
     """Create minibatches of a given number of words."""
     if isinstance(size, int):
         size_ = itertools.repeat(size)
-    if isinstance(size, List):
+    elif isinstance(size, List):
         size_ = iter(size)
     else:
         size_ = size


### PR DESCRIPTION
## Description
Bug crept in - `minibatch_by_words` with `size` an `int` did not work on `develop` anymore, because the `else` statement would overwrite the first `if`.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
