### PR TITLE
bugfix in span similarity

### DIFF
--- a/spacy/tests/regression/test_issue5152.py
+++ b/spacy/tests/regression/test_issue5152.py
@@ -1,0 +1,18 @@
+from spacy.lang.en import English
+
+
+def test_issue5152():
+    # Test that the comparison between a Span and a Token, goes well
+    # There was a bug when the number of tokens in the span equaled the number of characters in the token (!)
+    nlp = English()
+    text = nlp("Talk about being boring!")
+    text_var = nlp("Talk of being boring!")
+    y = nlp("Let")
+
+    span = text[0:3]         # Talk about being
+    span_2 = text[0:3]       # Talk about being
+    span_3 = text_var[0:3]   # Talk of being
+    token = y[0]             # Let
+    assert span.similarity(token) == 0.0
+    assert span.similarity(span_2) == 1.0
+    assert span_2.similarity(span_3) < 1.0

--- a/spacy/tests/regression/test_issue5152.py
+++ b/spacy/tests/regression/test_issue5152.py
@@ -9,10 +9,10 @@ def test_issue5152():
     text_var = nlp("Talk of being boring!")
     y = nlp("Let")
 
-    span = text[0:3]         # Talk about being
-    span_2 = text[0:3]       # Talk about being
-    span_3 = text_var[0:3]   # Talk of being
-    token = y[0]             # Let
+    span = text[0:3]  # Talk about being
+    span_2 = text[0:3]  # Talk about being
+    span_3 = text_var[0:3]  # Talk of being
+    token = y[0]  # Let
     assert span.similarity(token) == 0.0
     assert span.similarity(span_2) == 1.0
     assert span_2.similarity(span_3) < 1.0

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -378,13 +378,14 @@ cdef class Doc:
         if isinstance(other, (Lexeme, Token)) and self.length == 1:
             if self.c[0].lex.orth == other.orth:
                 return 1.0
-        elif isinstance(other, (Span, Doc)):
-            if len(self) == len(other):
-                for i in range(self.length):
-                    if self[i].orth != other[i].orth:
-                        break
-                else:
-                    return 1.0
+        elif isinstance(other, (Span, Doc)) and len(self) == len(other):
+            similar = True
+            for i in range(self.length):
+                if self[i].orth != other[i].orth:
+                    similar = False
+                    break
+            if similar:
+                return 1.0
         if self.vocab.vectors.n_keys == 0:
             warnings.warn(Warnings.W007.format(obj="Doc"))
         if self.vector_norm == 0 or other.vector_norm == 0:

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -320,11 +320,13 @@ cdef class Span:
         if len(self) == 1 and hasattr(other, "orth"):
             if self[0].orth == other.orth:
                 return 1.0
-        elif hasattr(other, "__len__") and len(self) == len(other):
+        elif isinstance(other, (Doc, Span)) and len(self) == len(other):
+            similar = True
             for i in range(len(self)):
                 if self[i].orth != getattr(other[i], "orth", None):
+                    similar = False
                     break
-            else:
+            if similar:
                 return 1.0
         if self.vocab.vectors.n_keys == 0:
             warnings.warn(Warnings.W007.format(obj="Span"))


### PR DESCRIPTION
## Description
There was a bug when calculating the similarity of a `Span` of X tokens ("`self`"), to a `Token` with X characters ("`other`"), because of this line:
``` elif hasattr(other, "__len__") and len(self) == len(other)```
which would be `True` in that case, and then `other[i]` would crash because a `Token` can't be indexed.

I rewrote the check to actually look at the class of the instance instead (like it is in the implementation in `doc.pyx`, I found out afterwards).

Also, I thought there was a bit of a weird construct with an `else` statement with an unmatched `if`. I rewrote it for clarity.

Fixes #5152

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information. 
