### PR TITLE
remove unnecessary itertools call

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -778,8 +778,6 @@ class Language(object):
 
         DOCS: https://spacy.io/api/language#pipe
         """
-        # raw_texts will be used later to stop iterator.
-        texts, raw_texts = itertools.tee(texts)
         if n_threads != -1:
             warnings.warn(Warnings.W016, DeprecationWarning)
         if n_process == -1:


### PR DESCRIPTION
I stumbled upon these unnecessary lines and found that this already got fixed in `master` (https://github.com/explosion/spaCy/pull/5101), but we need it on `develop` as well. And for some reason cherry-picking didn't work.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
