### PR TITLE
Bugfix linking vectors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     "cymem>=2.0.2,<2.1.0",
     "preshed>=3.0.2,<3.1.0",
     "murmurhash>=0.28.0,<1.1.0",
-    "thinc==8.0.0a1",
+    "thinc==8.0.0a3",
     "blis>=0.4.0,<0.5.0"
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Our libraries
 cymem>=2.0.2,<2.1.0
 preshed>=3.0.2,<3.1.0
-thinc==8.0.0a1
+thinc==8.0.0a3
 blis>=0.4.0,<0.5.0
 ml_datasets>=0.1.1
 murmurhash>=0.28.0,<1.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,13 +36,13 @@ setup_requires =
     cymem>=2.0.2,<2.1.0
     preshed>=3.0.2,<3.1.0
     murmurhash>=0.28.0,<1.1.0
-    thinc==8.0.0a1
+    thinc==8.0.0a3
 install_requires =
     # Our libraries
     murmurhash>=0.28.0,<1.1.0
     cymem>=2.0.2,<2.1.0
     preshed>=3.0.2,<3.1.0
-    thinc==8.0.0a1
+    thinc==8.0.0a3
     blis>=0.4.0,<0.5.0
     wasabi>=0.4.0,<1.1.0
     srsly>=2.0.0,<3.0.0

--- a/spacy/about.py
+++ b/spacy/about.py
@@ -1,6 +1,6 @@
 # fmt: off
 __title__ = "spacy"
-__version__ = "3.0.0.dev3"
+__version__ = "3.0.0.dev4"
 __release__ = True
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -143,6 +143,7 @@ def train(
             )
         if vectors:
             msg.text(f"Loading vectors from model '{vectors}'")
+            _load_vectors(nlp, vectors)
 
         nlp.disable_pipes([p for p in nlp.pipe_names if p not in pipeline])
         for pipe in pipeline:
@@ -210,6 +211,7 @@ def train(
 
         if vectors:
             msg.text(f"Loading vectors from model '{vectors}'")
+            _load_vectors(nlp, vectors)
 
         for pipe in pipeline:
             # first, create the model.

--- a/spacy/syntax/_parser_model.pyx
+++ b/spacy/syntax/_parser_model.pyx
@@ -250,7 +250,7 @@ class ParserModel(Model):
             nI = smaller.get_dim("nI")
         with use_ops('numpy'):
             larger = Linear(nO=new_nO, nI=nI)
-            larger._init = smaller._init
+            larger.init = smaller.init
         # it could be that the model is not initialized yet, then skip this bit
         if nI:
             larger_W = larger.ops.alloc2f(new_nO, nI)


### PR DESCRIPTION
`_load_vectors` accidentally got removed in the refactor... 

+ bump thinc to 8.0.0a3 (which includes the rename of `_init` to `init`, and a fix for static vectors)

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
