### PR TITLE
Fix parser @ GPU

### DIFF
--- a/spacy/ml/_layers.py
+++ b/spacy/ml/_layers.py
@@ -79,7 +79,7 @@ def _backprop_precomputable_affine_padding(model, dY, ids):
     # for b in range(nB):
     #     for f in range(nF):
     #         if ids[b, f] < 0:
-    #             d_padding[0, f] += dY[b]
+    #             d_pad[0, f] += dY[b]
     #
     # Which can be rewritten as:
     #
@@ -88,9 +88,13 @@ def _backprop_precomputable_affine_padding(model, dY, ids):
     #
     # I don't know how to avoid the loop without building a whole array :(.
     # Cursed numpy.
+    #
+    # Note by Sofie: rewritten to longer loop because "CuPy only supports slices that consist of one boolean array."
     d_pad = model.ops.alloc((1, nF, nO, nP))
     for b in range(nB):
-        d_pad[0, ids[b] < 0] += dY[b]
+        for f in range(nF):
+            if ids[b, f] < 0:
+                d_pad[0, f] += dY[b]
     return d_pad
 
 

--- a/spacy/syntax/_parser_model.pyx
+++ b/spacy/syntax/_parser_model.pyx
@@ -445,8 +445,7 @@ cdef class precompute_hiddens:
         else:
             cached = gpu_cached
         if not isinstance(lower_model.get_param("b"), numpy.ndarray):
-            # self.bias = lower_model.get_param("b").get(stream=cuda_stream) ???
-            self.bias = lower_model.get_param("b")
+            self.bias = lower_model.get_param("b").get(stream=cuda_stream)
         else:
             self.bias = lower_model.get_param("b")
         self.nF = cached.shape[1]

--- a/spacy/syntax/_parser_model.pyx
+++ b/spacy/syntax/_parser_model.pyx
@@ -371,8 +371,6 @@ class ParserStepModel(Model):
             self.ops.scatter_add(d_tokvecs, ids,
                 d_state_features)
         # Padded -- see update()
-        #if isinstance(self.ops, CupyOps):
-           #d_tokvecs = self.ops.to_numpy(d_tokvecs)
         self.bp_tokvecs(d_tokvecs[:-1])
         return d_tokvecs
 

--- a/spacy/syntax/_parser_model.pyx
+++ b/spacy/syntax/_parser_model.pyx
@@ -250,7 +250,7 @@ class ParserModel(Model):
             nI = smaller.get_dim("nI")
         with use_ops('numpy'):
             larger = Linear(nO=new_nO, nI=nI)
-            larger._init = smaller._init
+            larger.init = smaller.init
         # it could be that the model is not initialized yet, then skip this bit
         if nI:
             larger_W = larger.ops.alloc2f(new_nO, nI)
@@ -371,8 +371,8 @@ class ParserStepModel(Model):
             self.ops.scatter_add(d_tokvecs, ids,
                 d_state_features)
         # Padded -- see update()
-        if isinstance(self.ops, CupyOps):
-           d_tokvecs = self.ops.to_numpy(d_tokvecs)
+        #if isinstance(self.ops, CupyOps):
+           #d_tokvecs = self.ops.to_numpy(d_tokvecs)
         self.bp_tokvecs(d_tokvecs[:-1])
         return d_tokvecs
 

--- a/spacy/tests/parser/test_ner.py
+++ b/spacy/tests/parser/test_ner.py
@@ -278,6 +278,8 @@ def test_block_ner():
 
 
 def test_overfitting_IO():
+    from thinc.api import require_gpu
+    require_gpu()
     # Simple test to try and quickly overfit the NER component - ensuring the ML models work correctly
     nlp = English()
     ner = nlp.create_pipe("ner")

--- a/spacy/tests/parser/test_ner.py
+++ b/spacy/tests/parser/test_ner.py
@@ -278,8 +278,6 @@ def test_block_ner():
 
 
 def test_overfitting_IO():
-    from thinc.api import require_gpu
-    require_gpu()
     # Simple test to try and quickly overfit the NER component - ensuring the ML models work correctly
     nlp = English()
     ner = nlp.create_pipe("ner")


### PR DESCRIPTION
## Description
The parser/ner was broken on GPU. This could be tested by adding `require_gpu` to the `overfitting_IO` test in `test_ner`.

This PR includes several fixes to make sure the parser again runs correctly on GPU. To ensure also IO works, it needs the additional fix from https://github.com/explosion/thinc/pull/332.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
