### PR TITLE
Fixing pickling of the parser

### DIFF
--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -1173,7 +1173,7 @@ cdef class DependencyParser(Parser):
                                     tok2vec=tok2vec, sgd=sgd)
 
     def __reduce__(self):
-        return (DependencyParser, (self.vocab, self.moves, self.model), None, None)
+        return (DependencyParser, (self.vocab, self.model), None, None)
 
     @property
     def labels(self):
@@ -1214,8 +1214,7 @@ cdef class EntityRecognizer(Parser):
                                     tok2vec=tok2vec)
 
     def __reduce__(self):
-        return (EntityRecognizer, (self.vocab, self.moves, self.model),
-                None, None)
+        return (EntityRecognizer, (self.vocab, self.model), None, None)
 
     @property
     def labels(self):

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -1173,7 +1173,13 @@ cdef class DependencyParser(Parser):
                                     tok2vec=tok2vec, sgd=sgd)
 
     def __reduce__(self):
-        return (DependencyParser, (self.vocab, self.model), None, None)
+        return (DependencyParser, (self.vocab, self.model), self.moves)
+
+    def __getstate__(self):
+        return self.moves
+
+    def __setstate__(self, moves):
+        self.moves = moves
 
     @property
     def labels(self):
@@ -1214,7 +1220,13 @@ cdef class EntityRecognizer(Parser):
                                     tok2vec=tok2vec)
 
     def __reduce__(self):
-        return (EntityRecognizer, (self.vocab, self.model), None, None)
+        return (EntityRecognizer, (self.vocab, self.model), self.moves)
+
+    def __getstate__(self):
+        return self.moves
+
+    def __setstate__(self, moves):
+        self.moves = moves
 
     @property
     def labels(self):

--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -79,7 +79,7 @@ cdef class Parser:
         return cls(nlp.vocab, model, **cfg)
 
     def __reduce__(self):
-        return (Parser, (self.vocab, self.moves, self.model), None, None)
+        return (Parser, (self.vocab, self.model), None, None)
 
     @property
     def move_names(self):

--- a/spacy/syntax/nn_parser.pyx
+++ b/spacy/syntax/nn_parser.pyx
@@ -79,7 +79,13 @@ cdef class Parser:
         return cls(nlp.vocab, model, **cfg)
 
     def __reduce__(self):
-        return (Parser, (self.vocab, self.model), None, None)
+        return (Parser, (self.vocab, self.model), self.moves)
+
+    def __getstate__(self):
+        return self.moves
+
+    def __setstate__(self, moves):
+        self.moves = moves
 
     @property
     def move_names(self):

--- a/spacy/tests/regression/test_issue4725.py
+++ b/spacy/tests/regression/test_issue4725.py
@@ -5,7 +5,6 @@ from spacy.lang.en import English
 from spacy.vocab import Vocab
 
 
-@pytest.mark.skip(reason="currently hangs")
 def test_issue4725():
     # ensures that this runs correctly and doesn't hang or crash because of the global vectors
     vocab = Vocab(vectors_name="test_vocab_add_vector")

--- a/website/docs/usage/saving-loading.md
+++ b/website/docs/usage/saving-loading.md
@@ -131,7 +131,7 @@ shared vocab it depends on.
 If you need to pickle multiple objects, try to pickle them **together** instead
 of separately. For instance, instead of pickling all pipeline components, pickle
 the entire pipeline once. And instead of pickling several `Doc` objects
-separately, pickle a list of `Doc` objects. Since the all share a reference to
+separately, pickle a list of `Doc` objects. Since they all share a reference to
 the _same_ `Vocab` object, it will only be included once.
 
 ```python


### PR DESCRIPTION
## Description
Pickling of the parser got broken by changing the arguments of `__init__`. Fixed now by adjusting the `__reduce__` arguments and setting the `moves` object through `__get_state__`.

Fixes #4725 which got broken in the v3.0 refactor, see also PR #5213 (where we first noticed the hanging test).

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
