### PR TITLE
fix NEL overfitting test for GPU

### DIFF
--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -1443,7 +1443,7 @@ class EntityLinker(Pipe):
                                     scores = prior_probs + sims - (prior_probs*sims)
 
                                 # TODO: thresholding
-                                best_index = scores.argmax()
+                                best_index = scores.argmax().item()
                                 best_candidate = candidates[best_index]
                                 final_kb_ids.append(best_candidate.entity_)
                                 final_tensors.append(sentence_encoding)


### PR DESCRIPTION
## Description
Ran [`test_overfitting_IO`](https://github.com/explosion/spaCy/blob/develop/spacy/tests/pipeline/test_entity_linker.py#L264) in `test_entity_linker.py` with `require_gpu`.
It looks like only this one little change is needed to make it run properly?

@honnibal : I'm a little surprised by this. Considering [your original comment](https://github.com/explosion/spaCy/pull/3864#issuecomment-504370194) I was assuming I'd need to do more work. But perhaps I still should, to make it more efficient on GPU? Or do you think it's fine if it runs (which it does) ?

### Types of change
enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
