### PR TITLE
Fix ResourceWarnings during unittest

### DIFF
--- a/.github/contributors/lfiedler.md
+++ b/.github/contributors/lfiedler.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI GmbH](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           | Leander Fiedler      |
+| Company name (if applicable)   |                      |
+| Title or role (if applicable)  |                      |
+| Date                           | 06 April 2020        |
+| GitHub username                | lfiedler             |
+| Website (optional)             |                      |

--- a/spacy/kb.pyx
+++ b/spacy/kb.pyx
@@ -446,10 +446,10 @@ cdef class KnowledgeBase:
 
 cdef class Writer:
     def __init__(self, object loc):
-        if path.exists(loc):
-            assert not path.isdir(loc), "%s is directory." % loc
         if isinstance(loc, Path):
             loc = bytes(loc)
+        if path.exists(loc):
+            assert not path.isdir(loc), "%s is directory." % loc
         cdef bytes bytes_loc = loc.encode('utf8') if type(loc) == unicode else loc
         self._fp = fopen(<char*>bytes_loc, 'wb')
         if not self._fp:

--- a/spacy/kb.pyx
+++ b/spacy/kb.pyx
@@ -491,10 +491,10 @@ cdef class Writer:
 
 cdef class Reader:
     def __init__(self, object loc):
-        assert path.exists(loc)
-        assert not path.isdir(loc)
         if isinstance(loc, Path):
             loc = bytes(loc)
+        assert path.exists(loc)
+        assert not path.isdir(loc)
         cdef bytes bytes_loc = loc.encode('utf8') if type(loc) == unicode else loc
         self._fp = fopen(<char*>bytes_loc, 'rb')
         if not self._fp:

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -903,9 +903,8 @@ class Language(object):
         serializers["tokenizer"] = lambda p: self.tokenizer.to_disk(
             p, exclude=["vocab"]
         )
-        serializers["meta.json"] = lambda p: p.open("w").write(
-            srsly.json_dumps(self.meta)
-        )
+        serializers["meta.json"] = lambda p: srsly.write_json(p, self.meta)
+
         for name, proc in self.pipeline:
             if not hasattr(proc, "name"):
                 continue

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -625,7 +625,7 @@ class Tagger(Pipe):
         serialize = OrderedDict((
             ("vocab", lambda p: self.vocab.to_disk(p)),
             ("tag_map", lambda p: srsly.write_msgpack(p, tag_map)),
-            ("model", self.model.to_disk),
+            ("model", lambda p: self.model.to_disk(p)),
             ("cfg", lambda p: srsly.write_json(p, self.cfg))
         ))
         exclude = util.get_serialization_exclude(serialize, exclude, kwargs)
@@ -1394,7 +1394,7 @@ class EntityLinker(Pipe):
         serialize["vocab"] = lambda p: self.vocab.to_disk(p)
         serialize["kb"] = lambda p: self.kb.dump(p)
         if self.model not in (None, True, False):
-            serialize["model"] = self.model.to_disk
+            serialize["model"] = lambda p: self.model.to_disk(p)
         exclude = util.get_serialization_exclude(serialize, exclude, kwargs)
         util.to_disk(path, serialize, exclude)
 

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -202,7 +202,7 @@ class Pipe(object):
         serialize["cfg"] = lambda p: srsly.write_json(p, self.cfg)
         serialize["vocab"] = lambda p: self.vocab.to_disk(p)
         if self.model not in (None, True, False):
-            serialize["model"] = self.model.to_disk
+            serialize["model"] = lambda p: self.model.to_disk(p)
         exclude = util.get_serialization_exclude(serialize, exclude, kwargs)
         util.to_disk(path, serialize, exclude)
 

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -202,7 +202,7 @@ class Pipe(object):
         serialize["cfg"] = lambda p: srsly.write_json(p, self.cfg)
         serialize["vocab"] = lambda p: self.vocab.to_disk(p)
         if self.model not in (None, True, False):
-            serialize["model"] = lambda p: p.open("wb").write(self.model.to_bytes())
+            serialize["model"] = self.model.to_disk
         exclude = util.get_serialization_exclude(serialize, exclude, kwargs)
         util.to_disk(path, serialize, exclude)
 
@@ -625,7 +625,7 @@ class Tagger(Pipe):
         serialize = OrderedDict((
             ("vocab", lambda p: self.vocab.to_disk(p)),
             ("tag_map", lambda p: srsly.write_msgpack(p, tag_map)),
-            ("model", lambda p: p.open("wb").write(self.model.to_bytes())),
+            ("model", self.model.to_disk),
             ("cfg", lambda p: srsly.write_json(p, self.cfg))
         ))
         exclude = util.get_serialization_exclude(serialize, exclude, kwargs)
@@ -1394,7 +1394,7 @@ class EntityLinker(Pipe):
         serialize["vocab"] = lambda p: self.vocab.to_disk(p)
         serialize["kb"] = lambda p: self.kb.dump(p)
         if self.model not in (None, True, False):
-            serialize["model"] = lambda p: p.open("wb").write(self.model.to_bytes())
+            serialize["model"] = self.model.to_disk
         exclude = util.get_serialization_exclude(serialize, exclude, kwargs)
         util.to_disk(path, serialize, exclude)
 

--- a/spacy/tests/regression/test_issue5230.py
+++ b/spacy/tests/regression/test_issue5230.py
@@ -1,3 +1,4 @@
+# coding: utf8
 import warnings
 
 import numpy

--- a/spacy/tests/regression/test_issue5230.py
+++ b/spacy/tests/regression/test_issue5230.py
@@ -98,6 +98,8 @@ def write_obj_and_catch_warnings(obj):
 @pytest.mark.parametrize("obj", objects_to_test[0], ids=objects_to_test[1])
 def test_to_disk_resource_warning(obj):
     warnings_list = write_obj_and_catch_warnings(obj)
+    for warning in warnings_list:
+        print(warning.message)
     assert len(warnings_list) == 0
 
 

--- a/spacy/tests/regression/test_issue5230.py
+++ b/spacy/tests/regression/test_issue5230.py
@@ -1,0 +1,112 @@
+import warnings
+
+import numpy
+import pytest
+import srsly
+
+from spacy.kb import KnowledgeBase
+from spacy.vectors import Vectors
+from spacy.language import Language
+from spacy.pipeline import Pipe
+from spacy.tests.util import make_tempdir
+
+
+@pytest.mark.xfail
+def test_language_to_disk_resource_warning():
+    nlp = Language()
+    with make_tempdir() as d:
+        with warnings.catch_warnings(record=True) as w:
+            # catch only warnings raised in spacy.language since there may be others from other components or pipelines
+            warnings.filterwarnings(
+                "always", module="spacy.language", category=ResourceWarning
+            )
+            nlp.to_disk(d)
+            assert len(w) == 0
+
+
+@pytest.mark.xfail
+def test_vectors_to_disk_resource_warning():
+    data = numpy.zeros((3, 300), dtype="f")
+    keys = ["cat", "dog", "rat"]
+    vectors = Vectors(data=data, keys=keys)
+    with make_tempdir() as d:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings("always", category=ResourceWarning)
+            vectors.to_disk(d)
+            assert len(w) == 0
+
+
+@pytest.mark.xfail
+def test_custom_pipes_to_disk_resource_warning():
+    # create dummy pipe partially implementing interface -- only want to test to_disk
+    class SerializableDummy(object):
+        def __init__(self, **cfg):
+            if cfg:
+                self.cfg = cfg
+            else:
+                self.cfg = None
+            super(SerializableDummy, self).__init__()
+
+        def to_bytes(self, exclude=tuple(), disable=None, **kwargs):
+            return srsly.msgpack_dumps({"dummy": srsly.json_dumps(None)})
+
+        def from_bytes(self, bytes_data, exclude):
+            return self
+
+        def to_disk(self, path, exclude=tuple(), **kwargs):
+            pass
+
+        def from_disk(self, path, exclude=tuple(), **kwargs):
+            return self
+
+    class MyPipe(Pipe):
+        def __init__(self, vocab, model=True, **cfg):
+            if cfg:
+                self.cfg = cfg
+            else:
+                self.cfg = None
+            self.model = SerializableDummy()
+            self.vocab = SerializableDummy()
+
+    pipe = MyPipe(None)
+    with make_tempdir() as d:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings("always", category=ResourceWarning)
+            pipe.to_disk(d)
+            assert len(w) == 0
+
+
+@pytest.mark.xfail
+def test_tagger_to_disk_resource_warning():
+    nlp = Language()
+    nlp.add_pipe(nlp.create_pipe("tagger"))
+    tagger = nlp.get_pipe("tagger")
+    # need to add model for two reasons:
+    # 1. no model leads to error in serialization,
+    # 2. the affected line is the one for model serialization
+    tagger.begin_training(pipeline=nlp.pipeline)
+
+    with make_tempdir() as d:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings("always", category=ResourceWarning)
+            tagger.to_disk(d)
+            assert len(w) == 0
+
+
+@pytest.mark.xfail
+def test_entity_linker_to_disk_resource_warning():
+    nlp = Language()
+    nlp.add_pipe(nlp.create_pipe("entity_linker"))
+    entity_linker = nlp.get_pipe("entity_linker")
+    # need to add model for two reasons:
+    # 1. no model leads to error in serialization,
+    # 2. the affected line is the one for model serialization
+    kb = KnowledgeBase(nlp.vocab, entity_vector_length=1)
+    entity_linker.set_kb(kb)
+    entity_linker.begin_training(pipeline=nlp.pipeline)
+
+    with make_tempdir() as d:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings("always", category=ResourceWarning)
+            entity_linker.to_disk(d)
+            assert len(w) == 0

--- a/spacy/tests/regression/test_issue5230.py
+++ b/spacy/tests/regression/test_issue5230.py
@@ -11,7 +11,6 @@ from spacy.pipeline import Pipe
 from spacy.tests.util import make_tempdir
 
 
-@pytest.mark.xfail
 def test_language_to_disk_resource_warning():
     nlp = Language()
     with make_tempdir() as d:

--- a/spacy/tests/regression/test_issue5230.py
+++ b/spacy/tests/regression/test_issue5230.py
@@ -92,7 +92,8 @@ def write_obj_and_catch_warnings(obj):
         with warnings.catch_warnings(record=True) as warnings_list:
             warnings.filterwarnings("always", category=ResourceWarning)
             obj.to_disk(d)
-    return list(map(lambda w: w.message, warnings_list))
+            # in python3.5 it seems that deprecation warnings are not filtered by filterwarnings
+            return list(filter(lambda x: isinstance(x, ResourceWarning), warnings_list))
 
 
 @pytest.mark.parametrize("obj", objects_to_test[0], ids=objects_to_test[1])

--- a/spacy/tests/regression/test_issue5230.py
+++ b/spacy/tests/regression/test_issue5230.py
@@ -90,9 +90,9 @@ objects_to_test = (
 def write_obj_and_catch_warnings(obj):
     with make_tempdir() as d:
         with warnings.catch_warnings(record=True) as warnings_list:
-            warnings.filterwarnings("error", category=ResourceWarning)
+            warnings.filterwarnings("always", category=ResourceWarning)
             obj.to_disk(d)
-    return warnings_list
+    return list(map(lambda w: w.message, warnings_list))
 
 
 @pytest.mark.parametrize("obj", objects_to_test[0], ids=objects_to_test[1])

--- a/spacy/tests/regression/test_issue5230.py
+++ b/spacy/tests/regression/test_issue5230.py
@@ -90,7 +90,7 @@ objects_to_test = (
 def write_obj_and_catch_warnings(obj):
     with make_tempdir() as d:
         with warnings.catch_warnings(record=True) as warnings_list:
-            warnings.filterwarnings("always", category=ResourceWarning)
+            warnings.filterwarnings("error", category=ResourceWarning)
             obj.to_disk(d)
     return warnings_list
 
@@ -98,8 +98,6 @@ def write_obj_and_catch_warnings(obj):
 @pytest.mark.parametrize("obj", objects_to_test[0], ids=objects_to_test[1])
 def test_to_disk_resource_warning(obj):
     warnings_list = write_obj_and_catch_warnings(obj)
-    for warning in warnings_list:
-        print(warning.message)
     assert len(warnings_list) == 0
 
 

--- a/spacy/tests/regression/test_issue5230.py
+++ b/spacy/tests/regression/test_issue5230.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 import pytest
 import srsly
 from numpy import zeros
-from spacy.kb import KnowledgeBase
+from spacy.kb import KnowledgeBase, Writer
 from spacy.vectors import Vectors
 
 from spacy.language import Language
@@ -99,6 +99,19 @@ def write_obj_and_catch_warnings(obj):
 def test_to_disk_resource_warning(obj):
     warnings_list = write_obj_and_catch_warnings(obj)
     assert len(warnings_list) == 0
+
+
+def test_writer_with_path_py35():
+    writer = None
+    with make_tempdir() as d:
+        path = d / "test"
+        try:
+            writer = Writer(path)
+        except Exception as e:
+            pytest.fail(str(e))
+        finally:
+            if writer:
+                writer.close()
 
 
 class TestToDiskResourceWarningUnittest(TestCase):

--- a/spacy/tests/regression/test_issue5230.py
+++ b/spacy/tests/regression/test_issue5230.py
@@ -24,7 +24,6 @@ def test_language_to_disk_resource_warning():
             assert len(w) == 0
 
 
-@pytest.mark.xfail
 def test_vectors_to_disk_resource_warning():
     data = numpy.zeros((3, 300), dtype="f")
     keys = ["cat", "dog", "rat"]
@@ -36,7 +35,6 @@ def test_vectors_to_disk_resource_warning():
             assert len(w) == 0
 
 
-@pytest.mark.xfail
 def test_custom_pipes_to_disk_resource_warning():
     # create dummy pipe partially implementing interface -- only want to test to_disk
     class SerializableDummy(object):
@@ -76,7 +74,6 @@ def test_custom_pipes_to_disk_resource_warning():
             assert len(w) == 0
 
 
-@pytest.mark.xfail
 def test_tagger_to_disk_resource_warning():
     nlp = Language()
     nlp.add_pipe(nlp.create_pipe("tagger"))
@@ -93,7 +90,6 @@ def test_tagger_to_disk_resource_warning():
             assert len(w) == 0
 
 
-@pytest.mark.xfail
 def test_entity_linker_to_disk_resource_warning():
     nlp = Language()
     nlp.add_pipe(nlp.create_pipe("entity_linker"))

--- a/spacy/tests/regression/test_issue5230.py
+++ b/spacy/tests/regression/test_issue5230.py
@@ -115,6 +115,23 @@ def test_writer_with_path_py35():
                 writer.close()
 
 
+def test_save_and_load_knowledge_base():
+    nlp = Language()
+    kb = KnowledgeBase(nlp.vocab, entity_vector_length=1)
+    with make_tempdir() as d:
+        path = d / "kb"
+        try:
+            kb.dump(path)
+        except Exception as e:
+            pytest.fail(str(e))
+
+        try:
+            kb_loaded = KnowledgeBase(nlp.vocab, entity_vector_length=1)
+            kb_loaded.load_bulk(path)
+        except Exception as e:
+            pytest.fail(str(e))
+
+
 class TestToDiskResourceWarningUnittest(TestCase):
     def test_resource_warning(self):
         scenarios = zip(*objects_to_test)

--- a/spacy/vectors.pyx
+++ b/spacy/vectors.pyx
@@ -385,7 +385,7 @@ cdef class Vectors:
                 save_array(self.data, _file)
 
         serializers = OrderedDict((
-            ("vectors", save_vectors),
+            ("vectors", lambda p: save_vectors(p)),
             ("key2row", lambda p: srsly.write_msgpack(p, self.key2row))
         ))
         return util.to_disk(path, serializers, [])

--- a/spacy/vectors.pyx
+++ b/spacy/vectors.pyx
@@ -376,8 +376,16 @@ cdef class Vectors:
             save_array = lambda arr, file_: xp.save(file_, arr, allow_pickle=False)
         else:
             save_array = lambda arr, file_: xp.save(file_, arr)
+
+        def save_vectors(path):
+            # the source of numpy.save indicates that the file object is closed after use.
+            # but it seems that somehow this does not happen, as ResourceWarnings are raised here.
+            # in order to not rely on this, wrap in context manager.
+            with path.open("wb") as _file:
+                save_array(self.data, _file)
+
         serializers = OrderedDict((
-            ("vectors", lambda p: save_array(self.data, p.open("wb"))),
+            ("vectors", save_vectors),
             ("key2row", lambda p: srsly.write_msgpack(p, self.key2row))
         ))
         return util.to_disk(path, serializers, [])


### PR DESCRIPTION
This PR fixes the issue where files were not closed in a timely manner, after some objects were writing to them during tests using `unittest`  #5230 

## Description
I ran through possible sources for the `ResourceWarnings` being raised. Classes directly pointed out by the warnings were `Language`, `Tagger`, `Vectors`. There the methods `to_disk` used write functions that did not close properly after write when used within tests (`unittest` and `pytest` as it turned out). Tests were implemented by catching the warnings and checking whether they still occur.

Having had a closer look, the classes `Pipes` and `EntityLinker` seemed to have implemented similar versions of `to_disk`, so I took care of them as well.

For each case I wrote unit tests (`unittest`, `pytest`) and fixed the affected code in a minimal possible way, so that existing unit tests still run green.

Side notes:
- In `Vectors` the numpy method `save` is used to persist numpy arrays to disk. Reading the source code (numpy versions 1.18 and 1.15) this should close the file descriptor. However, after wrapping the affected line into a context manager, the `ResourceWarnings` vor `Vectors` disappeared. I left a comment about this at the corresponding line I changed.
- As mention in the discussion of #5230  `ResourceWarnings` are swallowed by `pytest`. They can be made visible in `pytest` as again simply by catching them using `warnings`. 

Tests were run using both, `pytest` and `unittest`.

Looking forward for your feedback. If there is anything that should be improved in this PR I'd be happy to do so.

Thanks for your great work!

### Types of change
Bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
