### PR TITLE
Remove `pala` tokenizer exception

### DIFF
--- a/spacy/lang/es/tokenizer_exceptions.py
+++ b/spacy/lang/es/tokenizer_exceptions.py
@@ -3,7 +3,6 @@ from ...symbols import ORTH, LEMMA, NORM, PRON_LEMMA
 
 _exc = {
     "pal": [{ORTH: "pa", LEMMA: "para"}, {ORTH: "l", LEMMA: "el", NORM: "el"}],
-    "pala": [{ORTH: "pa", LEMMA: "para"}, {ORTH: "la", LEMMA: "la", NORM: "la"}],
 }
 
 


### PR DESCRIPTION

## Description
As I understand it, `pala` is a proper noun in Spanish and `para la` or `pa la` should be written with a space. So removing this tokenizer exception that would always split up the token `pala` into two.

Fixes #5255

### Types of change
fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
