### PR TITLE
Docs: tag-map-path since 2.2.4 instead of 2.2.3

### DIFF
--- a/website/docs/api/cli.md
+++ b/website/docs/api/cli.md
@@ -189,7 +189,7 @@ $ python -m spacy debug-data [lang] [train_path] [dev_path] [--base-model] [--pi
 | `lang`                                                 | positional | Model language.                                                                                    |
 | `train_path`                                           | positional | Location of JSON-formatted training data. Can be a file or a directory of files.                   |
 | `dev_path`                                             | positional | Location of JSON-formatted development data for evaluation. Can be a file or a directory of files. |
-| `--tag-map-path`, `-tm` <Tag variant="new">2.2.3</Tag> | option     | Location of JSON-formatted tag map.                                                                |
+| `--tag-map-path`, `-tm` <Tag variant="new">2.2.4</Tag> | option     | Location of JSON-formatted tag map.                                                                |
 | `--base-model`, `-b`                                   | option     | Optional name of base model to update. Can be any loadable spaCy model.                            |
 | `--pipeline`, `-p`                                     | option     | Comma-separated names of pipeline components to train. Defaults to `'tagger,parser,ner'`.          |
 | `--ignore-warnings`, `-IW`                             | flag       | Ignore warnings, only show stats and errors.                                                       |


### PR DESCRIPTION
Fixes #5285

## Description
The documentation contained the wrong version number for a new feature.

### Types of change
doc fix

## Checklist
- [x] have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
