### PR TITLE
Fix/website documentation spacy lookup

### DIFF
--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -334,15 +334,16 @@
                 "from spacy_lookup import Entity",
                 "",
                 "nlp = spacy.load('en')",
-                "entity = Entity(keywords_list=['python', 'java platform'])",
+                "entity = Entity(keywords_list=['python', 'product manager', 'java platform'])",
                 "nlp.add_pipe(entity, last=True)",
                 "",
                 "doc = nlp(u\"I am a product manager for a java and python.\")",
                 "assert doc._.has_entities == True",
-                "assert doc[2:5]._.has_entities == True",
                 "assert doc[0]._.is_entity == False",
+                "assert doc[3]._.entity_desc == 'product manager'",
                 "assert doc[3]._.is_entity == True",
-                "print(doc._.entities)"
+                "",
+                "print([(token.text, token._.canonical) for token in doc if token._.is_entity])"
             ],
             "author": "Marc Puig",
             "author_links": {


### PR DESCRIPTION
Spacy lookup example fix.

## Description
I was trying the [example](https://spacy.io/universe/project/spacy-lookup) of [spacy-lookup](https://github.com/mpuig/spacy-lookup). I was not able to run the example because of an assertion error. It seems to me that this example is not correct. I found this one on the [README.rst](https://github.com/mpuig/spacy-lookup/blob/master/README.rst) of spacy-lookup project and I propose this example in the website too.

### Types of change
It is only a documentation change.

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.

