### PR TITLE
[minor doc change] embedding vis. link is broken in `website/docs/usage/examples.md` 

### DIFF
--- a/.github/contributors/Mlawrence95.md
+++ b/.github/contributors/Mlawrence95.md
@@ -98,9 +98,9 @@ mark both statements:
 
 | Field                          | Entry                |
 |------------------------------- | -------------------- |
-| Name                           |       Mike Lawrence               |
-| Company name (if applicable)   |        NA              |
-| Title or role (if applicable)  |        NA              |
-| Date                           |     April 17, 2020                 |
-| GitHub username                |              mlawrence95        |
+| Name                           |   Mike Lawrence      |
+| Company name (if applicable)   |        NA            |
+| Title or role (if applicable)  |        NA            |
+| Date                           |     April 17, 2020   |
+| GitHub username                |     Mlawrence95      |
 | Website (optional)             |                      |

--- a/.github/contributors/mlawrence95.md
+++ b/.github/contributors/mlawrence95.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI GmbH](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [ x ] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           |       Mike Lawrence               |
+| Company name (if applicable)   |        NA              |
+| Title or role (if applicable)  |        NA              |
+| Date                           |     April 17, 2020                 |
+| GitHub username                |              mlawrence95        |
+| Website (optional)             |                      |

--- a/website/docs/usage/examples.md
+++ b/website/docs/usage/examples.md
@@ -161,8 +161,7 @@ https://github.com/explosion/spaCy/tree/master/examples/training/train_textcat.p
 ### Visualizing spaCy vectors in TensorBoard {#tensorboard}
 
 This script lets you load any spaCy model containing word vectors into
-[TensorBoard](https://projector.tensorflow.org/) to create an
-[embedding visualization](https://www.tensorflow.org/versions/r1.1/get_started/embedding_viz).
+[TensorBoard](https://projector.tensorflow.org/) to create an embedding visualization.
 
 ```python
 https://github.com/explosion/spaCy/tree/master/examples/vectors_tensorboard.py

--- a/website/docs/usage/examples.md
+++ b/website/docs/usage/examples.md
@@ -161,7 +161,8 @@ https://github.com/explosion/spaCy/tree/master/examples/training/train_textcat.p
 ### Visualizing spaCy vectors in TensorBoard {#tensorboard}
 
 This script lets you load any spaCy model containing word vectors into
-[TensorBoard](https://projector.tensorflow.org/) to create an embedding visualization.
+[TensorBoard](https://projector.tensorflow.org/) to create an
+[embedding visualization](https://github.com/tensorflow/tensorboard/blob/master/docs/tensorboard_projector_plugin.ipynb).
 
 ```python
 https://github.com/explosion/spaCy/tree/master/examples/vectors_tensorboard.py


### PR DESCRIPTION
## Description
The first link in this sentence looks great, but the second link does not work due to a 404. I'm not sure what the original link contained, so I don't feel comfortable replacing it.


### Types of change
Minor documentation/website change. Replaces link with base text

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
