### PR TITLE
Improve GoldParse NER alignment

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -110,6 +110,8 @@ class Warnings(object):
     W028 = ("Doc.from_array was called with a vector of type '{type}', "
             "but is expecting one of type 'uint64' instead. This may result "
             "in problems with the vocab further on in the pipeline.")
+    W029 = ("Unable to align tokens with entities from character offsets. "
+            "Discarding entity annotation for the text: {text}.")
 
 
 @add_codes

--- a/spacy/tests/test_gold.py
+++ b/spacy/tests/test_gold.py
@@ -6,6 +6,7 @@ from spacy.gold import spans_from_biluo_tags, GoldParse, iob_to_biluo
 from spacy.gold import GoldCorpus, docs_to_json, align
 from spacy.lang.en import English
 from spacy.tokens import Doc
+from spacy.util import get_words_and_spaces
 from .util import make_tempdir
 import pytest
 import srsly
@@ -57,6 +58,75 @@ def test_gold_biluo_misalign(en_vocab):
     entities = [(len("I flew to "), len("I flew to San Francisco Valley"), "LOC")]
     tags = biluo_tags_from_offsets(doc, entities)
     assert tags == ["O", "O", "O", "-", "-", "-"]
+
+
+def test_gold_biluo_different_tokenization(en_vocab, en_tokenizer):
+    # one-to-many
+    words = ["I", "flew to", "San Francisco Valley", "."]
+    spaces = [True, True, False, False]
+    doc = Doc(en_vocab, words=words, spaces=spaces)
+    entities = [(len("I flew to "), len("I flew to San Francisco Valley"), "LOC")]
+    gp = GoldParse(
+        doc,
+        words=["I", "flew", "to", "San", "Francisco", "Valley", "."],
+        entities=entities,
+    )
+    assert gp.ner == ["O", "O", "U-LOC", "O"]
+
+    # many-to-one
+    words = ["I", "flew", "to", "San", "Francisco", "Valley", "."]
+    spaces = [True, True, True, True, True, False, False]
+    doc = Doc(en_vocab, words=words, spaces=spaces)
+    entities = [(len("I flew to "), len("I flew to San Francisco Valley"), "LOC")]
+    gp = GoldParse(
+        doc, words=["I", "flew to", "San Francisco Valley", "."], entities=entities
+    )
+    assert gp.ner == ["O", "O", "O", "B-LOC", "I-LOC", "L-LOC", "O"]
+
+    # misaligned
+    words = ["I flew", "to", "San Francisco", "Valley", "."]
+    spaces = [True, True, True, False, False]
+    doc = Doc(en_vocab, words=words, spaces=spaces)
+    entities = [(len("I flew to "), len("I flew to San Francisco Valley"), "LOC")]
+    gp = GoldParse(
+        doc, words=["I", "flew to", "San", "Francisco Valley", "."], entities=entities,
+    )
+    assert gp.ner == ["O", "O", "B-LOC", "L-LOC", "O"]
+
+    # additional whitespace tokens in GoldParse words
+    words, spaces = get_words_and_spaces(
+        ["I", "flew", "to", "San Francisco", "Valley", "."],
+        "I flew  to San Francisco Valley.",
+    )
+    doc = Doc(en_vocab, words=words, spaces=spaces)
+    entities = [(len("I flew  to "), len("I flew  to San Francisco Valley"), "LOC")]
+    gp = GoldParse(
+        doc,
+        words=["I", "flew", " ", "to", "San Francisco Valley", "."],
+        entities=entities,
+    )
+    assert gp.ner == ["O", "O", "O", "O", "B-LOC", "L-LOC", "O"]
+
+    # from issue #4791
+    data = (
+        "I'll return the ₹54 amount",
+        {
+            "words": ["I", "'ll", "return", "the", "₹", "54", "amount",],
+            "entities": [(16, 19, "MONEY")],
+        },
+    )
+    gp = GoldParse(en_tokenizer(data[0]), **data[1])
+    assert gp.ner == ["O", "O", "O", "O", "U-MONEY", "O"]
+
+    data = (
+        "I'll return the $54 amount",
+        {
+            "words": ["I", "'ll", "return", "the", "$", "54", "amount",],
+            "entities": [(16, 19, "MONEY")],
+        },
+    )
+    gp = GoldParse(en_tokenizer(data[0]), **data[1])
+    assert gp.ner == ["O", "O", "O", "O", "B-MONEY", "L-MONEY", "O"]
 
 
 def test_roundtrip_offsets_biluo_conversion(en_tokenizer):

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -758,7 +758,7 @@ def get_serialization_exclude(serializers, exclude, kwargs):
 
 
 def get_words_and_spaces(words, text):
-    if "".join("".join(words).split())!= "".join(text.split()):
+    if "".join("".join(words).split()) != "".join(text.split()):
         raise ValueError(Errors.E194.format(text=text, words=words))
     text_words = []
     text_spaces = []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Improve GoldParse NER alignment by including all cases where the start and end of the NER span can be aligned, regardless of internal tokenization differences.

To do this, convert BILUO tags to character offsets, check start/end alignment with `doc.char_span()`, and assign the BILUO tags for the aligned spans. Alignment for `O/-` tags is handled through the one-to-one and multi alignments.

Fixes #4791.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bug fix / enhancement.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
