### PR TITLE
shortcut functionality `enable_only_pipes`

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -453,6 +453,17 @@ class Language(object):
             names = names[0]  # support list of names instead of spread
         return DisabledPipes(self, *names)
 
+    def enable_only_pipes(self, names):
+        """Disable all pipeline components except the ones given as argument.
+        If used as a context manager, the pipeline will be restored to the initial
+        state at the end of the block. Otherwise, a DisabledPipes object is returned,
+        that has a `.restore()` method you can use to undo your changes.
+
+        DOCS: https://spacy.io/api/language#enable_only_pipes
+        """
+        other_pipes = [pipe for pipe in self.pipe_names if pipe not in names]
+        return self.disable_pipes(*other_pipes)
+
     def make_doc(self, text):
         return self.tokenizer(text)
 

--- a/spacy/tests/pipeline/test_pipe_methods.py
+++ b/spacy/tests/pipeline/test_pipe_methods.py
@@ -97,6 +97,15 @@ def test_disable_pipes_method(nlp, name):
 
 
 @pytest.mark.parametrize("name", ["my_component"])
+def test_enable_pipes_method(nlp, name):
+    nlp.add_pipe(new_pipe, name=name)
+    assert nlp.has_pipe(name)
+    disabled = nlp.enable_only_pipes([])
+    assert not nlp.has_pipe(name)
+    disabled.restore()
+
+
+@pytest.mark.parametrize("name", ["my_component"])
 def test_disable_pipes_context(nlp, name):
     nlp.add_pipe(new_pipe, name=name)
     assert nlp.has_pipe(name)
@@ -113,6 +122,20 @@ def test_disable_pipes_list_arg(nlp):
         assert not nlp.has_pipe("c1")
         assert not nlp.has_pipe("c2")
         assert nlp.has_pipe("c3")
+
+
+def test_enable_pipes_list_arg(nlp):
+    for name in ["c1", "c2", "c3"]:
+        nlp.add_pipe(new_pipe, name=name)
+        assert nlp.has_pipe(name)
+    with nlp.enable_only_pipes(["c3"]):
+        assert not nlp.has_pipe("c1")
+        assert not nlp.has_pipe("c2")
+        assert nlp.has_pipe("c3")
+    with nlp.enable_only_pipes(["c1", "c2"]):
+        assert nlp.has_pipe("c1")
+        assert nlp.has_pipe("c2")
+        assert not nlp.has_pipe("c3")
 
 
 @pytest.mark.parametrize("n_pipes", [100])


### PR DESCRIPTION
## Description
I propose to have a new "shorthand" function 
```
with nlp.enable_only_pipes(["ner"]):
    ...
```
Instead of the long way of having to do 
```
pipe_exceptions = ["ner"]
other_pipes = [pipe for pipe in nlp.pipe_names if pipe not in pipe_exceptions]
with nlp.disable_pipes(*other_pipes):  # only train NER
    ...
```
which I think is just kind of unnecessary verbose and potentially confusing. I think the shorthand will be more clear also for example code snippets on the website etc.

If OK (and we can discuss about the exact name), I'll extend this PR by updating the docs, too.

### Types of change
enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
