### PR TITLE
Fix passing of component configuration

### DIFF
--- a/spacy/tests/regression/test_issue5137.py
+++ b/spacy/tests/regression/test_issue5137.py
@@ -1,0 +1,33 @@
+import spacy
+from spacy.language import Language
+from spacy.lang.en import English
+from spacy.tests.util import make_tempdir
+
+
+def test_issue5137():
+    class MyComponent(object):
+        name = "my_component"
+
+        def __init__(self, nlp, **cfg):
+            self.nlp = nlp
+            self.categories = cfg.get("categories", "all_categories")
+
+        def __call__(self, doc):
+            pass
+
+        def to_disk(self, path, **kwargs):
+            pass
+
+        def from_disk(self, path, **cfg):
+            pass
+
+    Language.factories["my_component"] = lambda nlp, **cfg: MyComponent(nlp, **cfg)
+
+    nlp = English()
+    nlp.add_pipe(nlp.create_pipe("my_component"))
+    assert nlp.get_pipe("my_component").categories == "all_categories"
+
+    with make_tempdir() as tmpdir:
+        nlp.to_disk(tmpdir)
+        nlp2 = spacy.load(tmpdir, categories="my_categories")
+        assert nlp2.get_pipe("my_component").categories == "my_categories"

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -207,6 +207,7 @@ def load_model_from_path(model_path, meta=False, **overrides):
     for name in pipeline:
         if name not in disable:
             config = meta.get("pipeline_args", {}).get(name, {})
+            config.update(overrides)
             factory = factories.get(name, name)
             component = nlp.create_pipe(factory, config=config)
             nlp.add_pipe(component, name=name)

--- a/website/docs/usage/saving-loading.md
+++ b/website/docs/usage/saving-loading.md
@@ -216,7 +216,7 @@ class CustomComponent(object):
         # Add something to the component's data
         self.data.append(data)
 
-    def to_disk(self, path):
+    def to_disk(self, path, **kwargs):
         # This will receive the directory path + /my_component
         data_path = path / "data.json"
         with data_path.open("w", encoding="utf8") as f:
@@ -461,7 +461,7 @@ model. When you save out a model using `nlp.to_disk` and the component exposes a
 `to_disk` method, it will be called with the disk path.
 
 ```python
-def to_disk(self, path):
+def to_disk(self, path, **kwargs):
     snek_path = path / "snek.txt"
     with snek_path.open("w", encoding="utf8") as snek_file:
         snek_file.write(self.snek)


### PR DESCRIPTION
Fixes Issue #5137 + unit test

## Description
As described in the [documentation](https://spacy.io/usage/saving-loading#advanced-cfg), 
```
nlp = spacy.load("en_core_snek_sm", snek_style="cute")
```
should pass on the custom configuration (`snek_style`) all the way down to the `init` `**cfg` of a custom component.

This was not actually happening though. Added a quick fix by putting `config.update(overrides)` to pass that `config` on to `create_pipe`.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
