### PR TITLE
update is_new_osx function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import sys
+import platform
 from distutils.command.build_ext import build_ext
 from distutils.sysconfig import get_python_inc
 import distutils.util
@@ -73,18 +74,18 @@ COPY_FILES = {
 
 
 def is_new_osx():
-    """Check whether we're on OSX >= 10.10"""
+    """Check whether we're on OSX >= 10.7"""
     name = distutils.util.get_platform()
     if sys.platform != "darwin":
         return False
-    elif name.startswith("macosx-10"):
-        minor_version = int(name.split("-")[1].split(".")[1])
+    mac_ver = platform.mac_ver()[0]
+    if mac_ver.startswith("10"):
+        minor_version = int(mac_ver.split('.')[1])
         if minor_version >= 7:
             return True
         else:
             return False
-    else:
-        return False
+    return False
 
 
 if is_new_osx():


### PR DESCRIPTION
## Description

Update `is_new_osx` according to discussions [here](https://github.com/explosion/spaCy/issues/5310) and [here](https://github.com/hajimes/mmh3/pull/22). @honnibal : the assumption is that the comment incorrectly mentioned `OSX >= 10.10`, and it should have been `OSX >= 10.7` instead?

Putting this on the `develop` branch where support for Python 2 is dropped, as apparently some behaviour may be different across Python 2 and 3.

(Hopefully) fixes #5310

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
