### PR TITLE
Adapt parser and NER for transformers

### DIFF
--- a/examples/experiments/tok2vec-ner/multihashembed_tok2vec.cfg
+++ b/examples/experiments/tok2vec-ner/multihashembed_tok2vec.cfg
@@ -4,12 +4,18 @@ limit = 0
 dropout = 0.2
 patience = 10000
 eval_frequency = 200
-scores = ["ents_f"]
+scores = ["ents_p", "ents_r", "ents_f"]
 score_weights = {"ents_f": 1}
 orth_variant_level = 0.0
 gold_preproc = true
 max_length = 0
-batch_size = 25
+
+[training.batch_size]
+@schedules = "compounding.v1"
+start = 3000
+stop = 3000
+compound = 1.001
+
 
 [optimizer]
 @optimizers = "Adam.v1"
@@ -21,45 +27,18 @@ beta2 = 0.999
 lang = "en"
 vectors = null
 
-[nlp.pipeline.tok2vec]
-factory = "tok2vec"
-
-[nlp.pipeline.tok2vec.model]
-@architectures = "spacy.Tok2Vec.v1"
-
-[nlp.pipeline.tok2vec.model.extract]
-@architectures = "spacy.Doc2Feats.v1"
-columns = ["ID", "NORM", "PREFIX", "SUFFIX", "SHAPE", "ORTH"]
-
-[nlp.pipeline.tok2vec.model.embed]
-@architectures = "spacy.MultiHashEmbed.v1"
-columns = ${nlp.pipeline.tok2vec.model.extract:columns}
-width = 96
-rows = 2000
-use_subwords = true
-pretrained_vectors = null
-
-[nlp.pipeline.tok2vec.model.embed.mix]
-@architectures = "spacy.LayerNormalizedMaxout.v1"
-width = ${nlp.pipeline.tok2vec.model.embed:width}
-maxout_pieces = 3
-
-[nlp.pipeline.tok2vec.model.encode]
-@architectures = "spacy.MaxoutWindowEncoder.v1"
-width = ${nlp.pipeline.tok2vec.model.embed:width}
-window_size = 1
-maxout_pieces = 3
-depth = 2
-
 [nlp.pipeline.ner]
-factory = "ner"
+factory = "simple_ner"
 
 [nlp.pipeline.ner.model]
-@architectures = "spacy.TransitionBasedParser.v1"
-nr_feature_tokens = 6
-hidden_width = 64
-maxout_pieces = 2
+@architectures = "spacy.BiluoTagger.v1"
 
 [nlp.pipeline.ner.model.tok2vec]
-@architectures = "spacy.Tok2VecTensors.v1"
-width = ${nlp.pipeline.tok2vec.model.embed:width}
+@architectures = "spacy.HashEmbedCNN.v1"
+width = 128
+depth = 4
+embed_size = 7000
+maxout_pieces = 3
+window_size = 1
+subword_features = true
+pretrained_vectors = null

--- a/examples/training/train_ner.py
+++ b/examples/training/train_ner.py
@@ -42,26 +42,28 @@ def main(model=None, output_dir=None, n_iter=100):
 
     # create the built-in pipeline components and add them to the pipeline
     # nlp.create_pipe works for built-ins that are registered with spaCy
-    if "ner" not in nlp.pipe_names:
-        ner = nlp.create_pipe("ner")
+    if "simple_ner" not in nlp.pipe_names:
+        ner = nlp.create_pipe("simple_ner")
         nlp.add_pipe(ner, last=True)
     # otherwise, get it so we can add labels
     else:
-        ner = nlp.get_pipe("ner")
+        ner = nlp.get_pipe("simple_ner")
 
     # add labels
     for _, annotations in TRAIN_DATA:
         for ent in annotations.get("entities"):
+            print("Add label", ent[2])
             ner.add_label(ent[2])
 
     # get names of other pipes to disable them during training
-    pipe_exceptions = ["ner", "trf_wordpiecer", "trf_tok2vec"]
+    pipe_exceptions = ["simple_ner"]
     other_pipes = [pipe for pipe in nlp.pipe_names if pipe not in pipe_exceptions]
     with nlp.disable_pipes(*other_pipes):  # only train NER
         # reset and initialize the weights randomly – but only if we're
         # training a new model
         if model is None:
             nlp.begin_training()
+        print("Transitions", list(enumerate(nlp.get_pipe("simple_ner").get_tag_names())))
         for itn in range(n_iter):
             random.shuffle(TRAIN_DATA)
             losses = {}
@@ -70,7 +72,7 @@ def main(model=None, output_dir=None, n_iter=100):
             for batch in batches:
                 nlp.update(
                     batch,
-                    drop=0.5,  # dropout - make it harder to memorise data
+                    drop=0.0,  # dropout - make it harder to memorise data
                     losses=losses,
                 )
             print("Losses", losses)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     "cymem>=2.0.2,<2.1.0",
     "preshed>=3.0.2,<3.1.0",
     "murmurhash>=0.28.0,<1.1.0",
-    "thinc==8.0.0a3",
+    "thinc==8.0.0a8",
     "blis>=0.4.0,<0.5.0"
 ]
 build-backend = "setuptools.build_meta"

--- a/spacy/cli/train_from_config.py
+++ b/spacy/cli/train_from_config.py
@@ -170,6 +170,7 @@ def train_from_config(
 ):
     msg.info(f"Loading config from: {config_path}")
     config = util.load_config(config_path, create_objects=False)
+    util.fix_random_seed(config["training"]["seed"])
     nlp_config = config["nlp"]
     config = util.load_config(config_path, create_objects=True)
     msg.info("Creating nlp from config")

--- a/spacy/cli/train_from_config.py
+++ b/spacy/cli/train_from_config.py
@@ -8,6 +8,7 @@ from wasabi import msg
 import thinc
 import thinc.schedules
 from thinc.api import Model
+import random
 
 from ..gold import GoldCorpus
 from .. import util
@@ -119,6 +120,7 @@ class ConfigSchema(BaseModel):
     output_path=("Output directory to store model in", "option", "o", Path),
     meta_path=("Optional path to meta.json to use as base.", "option", "m", Path),
     raw_text=("Path to jsonl file with unlabelled text documents.", "option", "rt", Path),
+    use_gpu=("Use GPU", "option", "g", int),
     # fmt: on
 )
 def train_from_config_cli(
@@ -130,6 +132,7 @@ def train_from_config_cli(
     raw_text=None,
     debug=False,
     verbose=False,
+    use_gpu=-1
 ):
     """
     Train or update a spaCy model. Requires data to be formatted in spaCy's
@@ -147,6 +150,12 @@ def train_from_config_cli(
     if output_path is not None and not output_path.exists():
         output_path.mkdir()
 
+    if use_gpu >= 0:
+        msg.info("Using GPU")
+        util.use_gpu(use_gpu)
+    else:
+        msg.info("Using CPU")
+
     train_from_config(
         config_path,
         {"train": train_path, "dev": dev_path},
@@ -162,12 +171,6 @@ def train_from_config(
     msg.info(f"Loading config from: {config_path}")
     config = util.load_config(config_path, create_objects=False)
     nlp_config = config["nlp"]
-    use_gpu = config["training"]["use_gpu"]
-    if use_gpu >= 0:
-        msg.info("Using GPU")
-        util.use_gpu(use_gpu)
-    else:
-        msg.info("Using CPU")
     config = util.load_config(config_path, create_objects=True)
     msg.info("Creating nlp from config")
     nlp = util.load_model_from_config(nlp_config)
@@ -177,7 +180,7 @@ def train_from_config(
     msg.info("Loading training corpus")
     corpus = GoldCorpus(data_paths["train"], data_paths["dev"], limit=limit)
     msg.info("Initializing the nlp pipeline")
-    nlp.begin_training(lambda: corpus.train_examples, device=use_gpu)
+    nlp.begin_training(lambda: corpus.train_examples)
 
     train_batches = create_train_batches(nlp, corpus, training)
     evaluate = create_evaluation_callback(nlp, optimizer, corpus, training)
@@ -192,6 +195,7 @@ def train_from_config(
         training["dropout"],
         training["patience"],
         training["eval_frequency"],
+        training["accumulate_gradient"]
     )
 
     msg.info(f"Training. Initial learn rate: {optimizer.learn_rate}")
@@ -220,43 +224,50 @@ def train_from_config(
 
 def create_train_batches(nlp, corpus, cfg):
     while True:
-        train_examples = corpus.train_dataset(
+        train_examples = list(corpus.train_dataset(
             nlp,
             noise_level=0.0,
             orth_variant_level=cfg["orth_variant_level"],
             gold_preproc=cfg["gold_preproc"],
             max_length=cfg["max_length"],
             ignore_misaligned=True,
-        )
-        for batch in util.minibatch_by_words(train_examples, size=cfg["batch_size"]):
+        ))
+        random.shuffle(train_examples)
+        batches = util.minibatch(train_examples, size=cfg["batch_size"])
+        for batch in batches:
             yield batch
 
 
 def create_evaluation_callback(nlp, optimizer, corpus, cfg):
     def evaluate():
-        with nlp.use_params(optimizer.averages):
-            dev_examples = list(
-                corpus.dev_dataset(
-                    nlp, gold_preproc=cfg["gold_preproc"], ignore_misaligned=True
-                )
+        dev_examples = list(
+            corpus.dev_dataset(
+                nlp, gold_preproc=cfg["gold_preproc"], ignore_misaligned=True
             )
-            n_words = sum(len(ex.doc) for ex in dev_examples)
-            start_time = timer()
+        )
+        n_words = sum(len(ex.doc) for ex in dev_examples)
+        start_time = timer()
+            
+        if optimizer.averages:
+            with nlp.use_params(optimizer.averages):
+                scorer = nlp.evaluate(dev_examples)
+        else:
             scorer = nlp.evaluate(dev_examples)
-            end_time = timer()
-            wps = n_words / (end_time - start_time)
-            scores = scorer.scores
-            # Calculate a weighted sum based on score_weights for the main score
-            weights = cfg["score_weights"]
-            weighted_score = sum(scores[s] * weights.get(s, 0.0) for s in weights)
-            scores["speed"] = wps
+        end_time = timer()
+        wps = n_words / (end_time - start_time)
+        scores = scorer.scores
+        # Calculate a weighted sum based on score_weights for the main score
+        weights = cfg["score_weights"]
+        weighted_score = sum(scores[s] * weights.get(s, 0.0) for s in weights)
+        scores["speed"] = wps
         return weighted_score, scores
 
     return evaluate
 
 
 def train_while_improving(
-    nlp, optimizer, train_data, evaluate, dropout, patience, eval_frequency
+    nlp, optimizer, train_data, evaluate, dropout, patience, eval_frequency,
+    accumulate_gradient
 ):
     """Train until an evaluation stops improving. Works as a generator,
     with each iteration yielding a tuple `(batch, info, is_best_checkpoint)`,
@@ -303,7 +314,7 @@ def train_while_improving(
     losses = {}
     for step, batch in enumerate(train_data):
         dropout = next(dropouts)
-        for subbatch in subdivide_batch(batch):
+        for subbatch in subdivide_batch(batch, accumulate_gradient):
             nlp.update(subbatch, drop=dropout, losses=losses, sgd=False)
         for name, proc in nlp.pipeline:
             if hasattr(proc, "model"):
@@ -332,8 +343,17 @@ def train_while_improving(
             break
 
 
-def subdivide_batch(batch):
-    return [batch]
+def subdivide_batch(batch, accumulate_gradient):
+    sub_len = len(batch) // accumulate_gradient
+    start = 0
+    for i in range(accumulate_gradient):
+        subbatch = batch[start : start + sub_len]
+        if subbatch:
+            yield subbatch
+        start += len(subbatch)
+    subbatch = batch[start : ]
+    if subbatch:
+        yield subbatch
 
 
 def setup_printer(training, nlp):

--- a/spacy/gold.pyx
+++ b/spacy/gold.pyx
@@ -608,6 +608,14 @@ def iob_to_biluo(tags):
     return out
 
 
+def biluo_to_iob(tags):
+    out = []
+    for tag in tags:
+        tag = tag.replace("U-", "B-", 1).replace("L-", "I-", 1)
+        out.append(tag)
+    return out
+
+
 def _consume_os(tags):
     while tags and tags[0] == "O":
         yield tags.pop(0)

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -194,6 +194,7 @@ class Language(object):
             default_senter_config,
             default_tensorizer_config,
             default_tok2vec_config,
+            default_simple_ner_config
         )
 
         self.defaults = {
@@ -204,6 +205,7 @@ class Language(object):
             "entity_linker": default_nel_config(),
             "morphologizer": default_morphologizer_config(),
             "senter": default_senter_config(),
+            "simple_ner": default_simple_ner_config(),
             "tensorizer": default_tensorizer_config(),
             "tok2vec": default_tok2vec_config(),
         }
@@ -336,6 +338,7 @@ class Language(object):
                 raise KeyError(Errors.E002.format(name=name))
         factory = self.factories[name]
         default_config = self.defaults.get(name, None)
+        print("default config", name, default_config)
 
         # transform the model's config to an actual Model
         factory_cfg = dict(config)

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -338,7 +338,6 @@ class Language(object):
                 raise KeyError(Errors.E002.format(name=name))
         factory = self.factories[name]
         default_config = self.defaults.get(name, None)
-        print("default config", name, default_config)
 
         # transform the model's config to an actual Model
         factory_cfg = dict(config)

--- a/spacy/ml/_biluo.py
+++ b/spacy/ml/_biluo.py
@@ -74,7 +74,7 @@ def get_num_actions(n_labels: int) -> int:
 
 
 def _get_transition_table(
-    n_labels: int, _cache: Dict[int, Floats3d] = {}
+    n_labels: int, *, _cache: Dict[int, Floats3d] = {}
 ) -> Floats3d:
     n_actions = get_num_actions(n_labels)
     if n_actions in _cache:

--- a/spacy/ml/_biluo.py
+++ b/spacy/ml/_biluo.py
@@ -1,6 +1,7 @@
 """Thinc layer to do simpler transition-based parsing, NER, etc."""
 from typing import List, Tuple, Dict, Optional
 from thinc.api import Ops, Model, with_array, softmax_activation, padded2list
+from thinc.api import to_numpy
 from thinc.types import Padded, Ints1d, Ints3d, Floats2d, Floats3d
 
 from ..tokens import Doc
@@ -55,8 +56,7 @@ def forward(model: Model[Padded, Padded], Xp: Padded, is_train: bool):
         prev_actions = Y[t].argmax(axis=-1)
 
     def backprop_biluo(dY: Padded) -> Padded:
-        # Masking the gradient seems to do poorly here. But why?
-        #dY.data *= masks
+        dY.data *= masks
         return dY
 
     return Padded(Y, Xp.size_at_t, Xp.lengths, Xp.indices), backprop_biluo

--- a/spacy/ml/_biluo.py
+++ b/spacy/ml/_biluo.py
@@ -1,0 +1,89 @@
+"""Thinc layer to do simpler transition-based parsing, NER, etc."""
+from typing import List, Tuple
+from thinc.api import Ops, Model
+from thinc.types import Padded, Ints1d, Ints3d
+
+
+def BILUO(labels: List[str]) -> Model[Padded, Padded]:
+    return Model(
+        "biluo",
+        forward,
+        init=init,
+        dims={"nO": None},
+        attrs={"labels": labels}
+    )
+
+
+def init(model, X=None, Y=None):
+    n_labels = len(model.attrs["labels"])
+    if n_labels == 0:
+        raise ValueError("Error initializing BILUO layer: No labels")
+    nO = _get_n_actions(n_labels)
+    model.set_dim("nO", nO)
+
+
+def forward(model: Model[Padded, Padded], Xp: Padded, is_train: bool):
+    n_labels = len(model.attrs["labels"])
+    n_tokens, n_docs, n_actions = Xp.data.shape[1]
+    # At each timestep, we make a validity mask of shape (n_docs, n_actions)
+    # to indicate which actions are valid next for each sequence. To construct
+    # the mask, we have a state of shape (2, n_actions) and a validity table of
+    # shape (2, n_actions+1, n_actions). The first dimension of the state indicates
+    # whether it's the last token, the second dimension indicates the previous
+    # action, plus a special 'null action' for the first entry.
+    valid_transitions = _get_transition_table(model.ops, n_labels)
+    state = model.ops.alloc2i(2, n_docs)
+    actions = model.ops.alloc2i(Xp.data.shape[0], Xp.data.shape[1])
+    Y = model.ops.alloc3f(*Xp.data.shape)
+    for t in range(Xp.data.shape[0]):
+        mask = valid_transitions[state[0], state[1]]
+        Y.data[t] = Xp.data[t] * mask
+        actions[t] = Y[t].argmax(axis=-1)
+        state[0, Xp.size_at_t[t]:] = 1
+        state[1] = actions[t]
+
+    def backprop(dY: Padded) -> Padded:
+        dX = Padded(model.ops.alloc3f(*dY.shape, dY.size_at_t, dY.lengths, dY.indices))
+        dX.data[actions] = dY.data
+        return dX
+
+    return Padded(Y, Xp.size_at_t, Xp.lengths, Xp.indices)
+
+def _get_n_actions(n_labels: int) -> int:
+    # One BEGIN action per label
+    # One IN action per label
+    # One LAST action per label
+    # One UNIT action per label
+    # One OUT action
+    return n_labels + n_labels + n_labels + n_labels + 1
+
+
+def _get_transition_table(ops: Ops, n_labels: int) -> Tuple[Ints1d, Ints3d]:
+    n_actions = _get_n_actions(n_labels)
+    table = ops.alloc3i(2, n_actions+1, n_actions)
+    B_start, B_end = (n_labels, n_labels+n_labels)
+    I_start, I_end = (B_end, B_end + n_labels)
+    L_start, L_end = (I_end, I_end + n_labels)
+    U_start, U_end = (I_end, I_end + n_labels)
+    # Using ranges allows us to set specific cells, which is necessary to express
+    # that only actions of the same label are valid continuations.
+    B_range = ops.xp.arange(B_start, B_end)
+    I_range = ops.xp.arange(I_start, I_end)
+    L_range = ops.xp.arange(L_start, L_end)
+    O_action = U_end + 1
+    first_action = O_action + 1
+    assert first_action == n_actions
+    # If this is the last token and the previous action was B or I, only L
+    # of that label is valid
+    table[1, B_range, L_range] = 1
+    table[1, I_range, L_range] = 1
+    # If this isn't the last token and the previous action was B or I, only I or
+    # L of that label are valid.
+    table[0, B_range, I_range] = 1
+    table[0, B_range, L_range] = 1
+    table[0, I_range, I_range] = 1
+    table[0, I_range, L_range] = 1
+    # Regardless of whether this is the last token, if the previous action was
+    # U or O or none, U and O are valid.
+    table[:, U_start:, U_start:] = 1
+    return table

--- a/spacy/ml/_iob.py
+++ b/spacy/ml/_iob.py
@@ -1,0 +1,92 @@
+"""Thinc layer to do simpler transition-based parsing, NER, etc."""
+from typing import List, Tuple, Dict, Optional
+from thinc.api import Ops, Model, with_array, softmax_activation, padded2list
+from thinc.types import Padded, Ints1d, Ints3d, Floats2d, Floats3d
+
+from ..tokens import Doc
+
+
+def IOB() -> Model[Padded, Padded]:
+    return Model(
+        "biluo",
+        forward,
+        init=init,
+        dims={"nO": None},
+        attrs={"get_num_actions": get_num_actions}
+    )
+
+
+def init(model, X: Optional[Padded]=None, Y: Optional[Padded]=None):
+    if X is not None and Y is not None:
+        if X.data.shape != Y.data.shape:
+            # TODO: Fix error
+            raise ValueError("Mismatched shapes (TODO: Fix message)")
+        model.set_dim("nO", X.data.shape[2])
+    elif X is not None:
+        model.set_dim("nO", X.data.shape[2])
+    elif Y is not None:
+        model.set_dim("nO", Y.data.shape[2])
+    elif model.get_dim("nO") is None:
+        raise ValueError("Dimension unset for BILUO: nO")
+
+
+def forward(model: Model[Padded, Padded], Xp: Padded, is_train: bool):
+    n_labels = (model.get_dim("nO") - 1) // 2
+    n_tokens, n_docs, n_actions = Xp.data.shape
+    # At each timestep, we make a validity mask of shape (n_docs, n_actions)
+    # to indicate which actions are valid next for each sequence. To construct
+    # the mask, we have a state of shape (2, n_actions) and a validity table of
+    # shape (2, n_actions+1, n_actions). The first dimension of the state indicates
+    # whether it's the last token, the second dimension indicates the previous
+    # action, plus a special 'null action' for the first entry.
+    valid_transitions = _get_transition_table(model.ops, n_labels)
+    prev_actions = model.ops.alloc1i(n_docs)
+    # Initialize as though prev action was O
+    prev_actions.fill(n_actions - 1)
+    Y = model.ops.alloc3f(*Xp.data.shape)
+    masks = model.ops.alloc3f(*Y.shape)
+    for t in range(Xp.data.shape[0]):
+        masks[t] = valid_transitions[prev_actions]
+        # Don't train the out-of-bounds sequences.
+        masks[t, Xp.size_at_t[t]:] = 0
+        # Valid actions get 0*10e8, invalid get -1*10e8
+        Y[t] = Xp.data[t] + ((masks[t]-1) * 10e8)
+        prev_actions = Y[t].argmax(axis=-1)
+
+    def backprop_biluo(dY: Padded) -> Padded:
+        # Masking the gradient seems to do poorly here. But why?
+        #dY.data *= masks
+        return dY
+
+    return Padded(Y, Xp.size_at_t, Xp.lengths, Xp.indices), backprop_biluo
+
+
+def get_num_actions(n_labels: int) -> int:
+    # One BEGIN action per label
+    # One IN action per label
+    # One LAST action per label
+    # One UNIT action per label
+    # One OUT action
+    return n_labels * 2 + 1
+
+
+def _get_transition_table(
+    ops: Ops, n_labels: int, _cache: Dict[int, Floats3d] = {}
+) -> Floats3d:
+    n_actions = get_num_actions(n_labels)
+    if n_actions in _cache:
+        return ops.asarray(_cache[n_actions])
+    table = ops.alloc2f(n_actions, n_actions)
+    B_start, B_end = (0, n_labels)
+    I_start, I_end = (B_end, B_end + n_labels)
+    O_action = I_end
+    B_range = ops.xp.arange(B_start, B_end)
+    I_range = ops.xp.arange(I_start, I_end)
+    # B and O are always valid
+    table[:, B_start : B_end] = 1
+    table[:, O_action] = 1
+    # I can only follow a matching B
+    table[B_range, I_range] = 1
+ 
+    _cache[n_actions] = table
+    return table

--- a/spacy/ml/_precomputable_affine.py
+++ b/spacy/ml/_precomputable_affine.py
@@ -9,7 +9,6 @@ def PrecomputableAffine(nO, nI, nF, nP):
         dims={"nO": nO, "nI": nI, "nF": nF, "nP": nP},
         params={"W": None, "b": None, "pad": None},
     )
-    model.initialize()
     return model
 
 

--- a/spacy/ml/_precomputable_affine.py
+++ b/spacy/ml/_precomputable_affine.py
@@ -110,7 +110,7 @@ def init(model, X=None, Y=None):
     pad = model.ops.alloc4f(1, nF, nO, nP)
 
     ops = model.ops
-    W = normal_init(ops, W.shape, fan_in=nF * nI)
+    W = normal_init(ops, W.shape, mean=float(ops.xp.sqrt(1.0 / nF * nI)))
     model.set_param("W", W)
     model.set_param("b", b)
     model.set_param("pad", pad)

--- a/spacy/ml/models/__init__.py
+++ b/spacy/ml/models/__init__.py
@@ -1,5 +1,6 @@
 from .entity_linker import *  # noqa
 from .parser import *  # noqa
+from .simple_ner import *
 from .tagger import *  # noqa
 from .tensorizer import *  # noqa
 from .textcat import *  # noqa

--- a/spacy/ml/models/defaults/__init__.py
+++ b/spacy/ml/models/defaults/__init__.py
@@ -91,3 +91,13 @@ def default_tok2vec_config():
 def default_tok2vec():
     loc = Path(__file__).parent / "tok2vec_defaults.cfg"
     return util.load_config(loc, create_objects=True)["model"]
+
+
+def default_simple_ner_config():
+    loc = Path(__file__).parent / "simple_ner_defaults.cfg"
+    return util.load_config(loc, create_objects=False)
+
+
+def default_simple_ner():
+    loc = Path(__file__).parent / "simple_ner_defaults.cfg"
+    return util.load_config(loc, create_objects=True)["model"]

--- a/spacy/ml/models/defaults/simple_ner_defaults.cfg
+++ b/spacy/ml/models/defaults/simple_ner_defaults.cfg
@@ -1,0 +1,12 @@
+[model]
+@architectures = "spacy.BiluoTagger.v1"
+
+[model.tok2vec]
+@architectures = "spacy.HashEmbedCNN.v1"
+pretrained_vectors = null
+width = 128
+depth = 4
+embed_size = 7000
+window_size = 1
+maxout_pieces = 3
+subword_features = true

--- a/spacy/ml/models/parser.py
+++ b/spacy/ml/models/parser.py
@@ -35,5 +35,4 @@ def build_tb_parser_model(
             upper = Linear(nO=nO, init_W=zero_init)
     else:
         upper = None
-    model = ParserModel(tok2vec, lower, upper)
-    return model
+    return TransitionModel(tok2vec, lower, upper)

--- a/spacy/ml/models/parser.py
+++ b/spacy/ml/models/parser.py
@@ -1,9 +1,9 @@
 from pydantic import StrictInt
-from thinc.api import Model, chain, list2array, Linear, zero_init, use_ops
+from thinc.api import Model, chain, list2array, Linear, zero_init, use_ops, with_array
 
 from ...util import registry
 from .._precomputable_affine import PrecomputableAffine
-from ...syntax._parser_model import ParserModel
+from ..tb_framework import TransitionModel
 
 
 @registry.architectures.register("spacy.TransitionBasedParser.v1")
@@ -12,21 +12,28 @@ def build_tb_parser_model(
     nr_feature_tokens: StrictInt,
     hidden_width: StrictInt,
     maxout_pieces: StrictInt,
+    use_upper=True,
     nO=None,
 ):
     token_vector_width = tok2vec.get_dim("nO")
-    tok2vec = chain(tok2vec, list2array())
-    tok2vec.set_dim("nO", token_vector_width)
+    tok2vec = chain(
+        tok2vec,
+        with_array(Linear(hidden_width, token_vector_width)),
+        list2array(),
+    )
+    tok2vec.set_dim("nO", hidden_width)
 
     lower = PrecomputableAffine(
-        nO=hidden_width,
+        nO=hidden_width if use_upper else nO,
         nF=nr_feature_tokens,
         nI=tok2vec.get_dim("nO"),
-        nP=maxout_pieces,
+        nP=maxout_pieces
     )
-    lower.set_dim("nP", maxout_pieces)
-    with use_ops("numpy"):
-        # Initialize weights at zero, as it's a classification layer.
-        upper = Linear(nO=nO, init_W=zero_init)
+    if use_upper:
+        with use_ops("numpy"):
+            # Initialize weights at zero, as it's a classification layer.
+            upper = Linear(nO=nO, init_W=zero_init)
+    else:
+        upper = None
     model = ParserModel(tok2vec, lower, upper)
     return model

--- a/spacy/ml/models/simple_ner.py
+++ b/spacy/ml/models/simple_ner.py
@@ -32,7 +32,7 @@ def BiluoTagger(tok2vec: Model[List[Doc], List[Floats2d]]) -> Model[List[Doc], L
         "biluo-tagger",
         forward,
         init=init,
-        layers=[model],
+        layers=[model, linear],
         refs={"tok2vec": tok2vec, "linear": linear, "biluo": biluo},
         dims={"nO": None},
         attrs={"get_num_actions": biluo.attrs["get_num_actions"]}

--- a/spacy/ml/models/simple_ner.py
+++ b/spacy/ml/models/simple_ner.py
@@ -2,6 +2,7 @@ import functools
 from typing import List, Tuple, Dict, Optional
 from thinc.api import Ops, Model, Linear, Softmax, with_array, softmax_activation, padded2list
 from thinc.api import chain, list2padded, configure_normal_init
+from thinc.api import Dropout
 from thinc.types import Padded, Ints1d, Ints3d, Floats2d, Floats3d
 
 from ...tokens import Doc
@@ -21,7 +22,7 @@ def BiluoTagger(tok2vec: Model[List[Doc], List[Floats2d]]) -> Model[List[Doc], L
     model = chain(
         tok2vec,
         list2padded(),
-        with_array(linear),
+        with_array(chain(Dropout(0.1), linear)),
         biluo,
         with_array(softmax_activation()),
         padded2list()

--- a/spacy/ml/models/simple_ner.py
+++ b/spacy/ml/models/simple_ner.py
@@ -1,0 +1,29 @@
+from typing import List, Tuple, Dict, Optional
+from thinc.api import Ops, Model, Mish, with_array, softmax_activation, padded2list
+from thinc.api import chain, list2padded
+from thinc.types import Padded, Ints1d, Ints3d, Floats2d, Floats3d
+
+from ...tokens import Doc
+from .._biluo import BILUO
+from ...util import registry
+
+
+@registry.architectures.register("spacy.BiluoTagger.v1")
+def BiluoTagger(tok2vec: Model[List[Doc], List[Floats2d]], labels: Optional[List[str]]=None) -> Model[List[Doc], List[Floats2d]]:
+    labels = ["PERSON", "LOC"]
+    biluo = BILUO(labels=labels)
+    n_actions = biluo.get_dim("nO") if biluo.has_dim("nO") else None
+    model = chain(
+        tok2vec,
+        list2padded(),
+        with_array(Mish(nO=n_actions, nI=tok2vec.get_dim("nO"))),
+        biluo,
+        with_array(softmax_activation()),
+        padded2list()
+    )
+    model.set_ref("biluo", biluo)
+    assert model is not None
+    return model
+
+
+__all__ = ["BiluoTagger"]

--- a/spacy/ml/models/simple_ner.py
+++ b/spacy/ml/models/simple_ner.py
@@ -1,5 +1,6 @@
+import functools
 from typing import List, Tuple, Dict, Optional
-from thinc.api import Ops, Model, Mish, with_array, softmax_activation, padded2list
+from thinc.api import Ops, Model, Linear, with_array, softmax_activation, padded2list
 from thinc.api import chain, list2padded
 from thinc.types import Padded, Ints1d, Ints3d, Floats2d, Floats3d
 
@@ -9,21 +10,42 @@ from ...util import registry
 
 
 @registry.architectures.register("spacy.BiluoTagger.v1")
-def BiluoTagger(tok2vec: Model[List[Doc], List[Floats2d]], labels: Optional[List[str]]=None) -> Model[List[Doc], List[Floats2d]]:
-    labels = ["PERSON", "LOC"]
-    biluo = BILUO(labels=labels)
-    n_actions = biluo.get_dim("nO") if biluo.has_dim("nO") else None
+def BiluoTagger(tok2vec: Model[List[Doc], List[Floats2d]]) -> Model[List[Doc], List[Floats2d]]:
+    biluo = BILUO()
+    linear = Linear(nO=None, nI=tok2vec.get_dim("nO"))
     model = chain(
         tok2vec,
         list2padded(),
-        with_array(Mish(nO=n_actions, nI=tok2vec.get_dim("nO"))),
+        with_array(linear),
         biluo,
         with_array(softmax_activation()),
         padded2list()
     )
-    model.set_ref("biluo", biluo)
-    assert model is not None
-    return model
+
+    return Model(
+        "biluo-tagger",
+        forward,
+        init=init,
+        layers=[model],
+        refs={"tok2vec": tok2vec, "linear": linear, "biluo": biluo},
+        dims={"nO": None},
+        attrs={"get_num_actions": biluo.attrs["get_num_actions"]}
+    )
+
+
+def init(model: Model[List[Doc], List[Floats2d]], X=None, Y=None) -> None:
+    if model.get_dim("nO") is None and Y:
+        model.set_dim("nO", Y[0].shape[1])
+    nO = model.get_dim("nO")
+    biluo = model.get_ref("biluo")
+    linear = model.get_ref("linear")
+    biluo.set_dim("nO", nO)
+    linear.set_dim("nO", nO)
+    model.layers[0].initialize(X=X, Y=Y)
+
+
+def forward(model: Model, X: List[Doc], is_train: bool):
+    return model.layers[0](X, is_train)
 
 
 __all__ = ["BiluoTagger"]

--- a/spacy/ml/models/tagger.py
+++ b/spacy/ml/models/tagger.py
@@ -1,4 +1,5 @@
-from thinc.api import zero_init, with_array, Softmax, chain, Model
+from thinc.api import zero_init, with_array, Softmax, chain, Model, Dropout
+from thinc.api import glorot_uniform_init
 
 from ...util import registry
 
@@ -7,9 +8,9 @@ from ...util import registry
 def build_tagger_model(tok2vec, nO=None) -> Model:
     token_vector_width = tok2vec.get_dim("nO")
     # TODO: glorot_uniform_init seems to work a bit better than zero_init here?!
-    output_layer = Softmax(nO, nI=token_vector_width, init_W=zero_init)
+    output_layer = Softmax(nO, nI=token_vector_width, init_W=glorot_uniform_init)
     softmax = with_array(output_layer)
-    model = chain(tok2vec, softmax)
+    model = chain(tok2vec, Dropout(0.1), softmax)
     model.set_ref("tok2vec", tok2vec)
     model.set_ref("softmax", softmax)
     model.set_ref("output_layer", output_layer)

--- a/spacy/ml/models/tagger.py
+++ b/spacy/ml/models/tagger.py
@@ -8,10 +8,10 @@ from ...util import registry
 def build_tagger_model(tok2vec, nO=None) -> Model:
     token_vector_width = tok2vec.get_dim("nO")
     # TODO: glorot_uniform_init seems to work a bit better than zero_init here?!
-    output_layer = Softmax(nO, nI=token_vector_width, init_W=glorot_uniform_init)
+    output_layer = Softmax(nO, nI=token_vector_width, init_W=zero_init)
     softmax = with_array(output_layer)
-    model = chain(tok2vec, Dropout(0.1), softmax)
+    model = chain(tok2vec, softmax)
     model.set_ref("tok2vec", tok2vec)
-    model.set_ref("softmax", softmax)
+    model.set_ref("softmax", output_layer)
     model.set_ref("output_layer", output_layer)
     return model

--- a/spacy/ml/tb_framework.py
+++ b/spacy/ml/tb_framework.py
@@ -1,0 +1,86 @@
+from thinc.api import Model, noop
+from ..syntax._parser_model import ParserStepModel
+
+
+def TransitionModel(tok2vec, lower, upper, unseen_classes=set()):
+    """Set up a stepwise transition-based model"""
+    if upper is None:
+        has_upper = False
+        upper = noop()
+    else:
+        has_upper = True
+    # don't define nO for this object, because we can't dynamically change it
+    return Model(
+        name="parser_model",
+        forward=forward,
+        dims={"nI": tok2vec.get_dim("nI") if tok2vec.has_dim("nI") else None},
+        layers=[tok2vec, lower, upper],
+        refs={"tok2vec": tok2vec, "lower": lower, "upper": upper},
+        init=init,
+        attrs={
+            "has_upper": has_upper,
+            "unseen_classes": set(unseen_classes),
+            "resize_output": resize_output
+        }
+    )
+
+
+def forward(model: ParserModel, X, is_train):
+    step_model = ParserStepModel(
+        X,
+        model.layers,
+        unseen_classes=model.attrs["unseen_classes"],
+        train=is_train,
+        has_upper=model.attrs["has_upper"]
+    )
+
+    return step_model, step_model.finish_steps
+
+
+def init(model, X=None, Y=None):
+    tok2vec = model.get_ref("tok2vec").initialize()
+    lower = model.get_ref("lower").initialize(X=X)
+    if model.attrs["has_upper"]:
+        statevecs = model.ops.alloc2f(2, lower.get_dim("nO"))
+        model.get_ref("upper").initialize(X=statevecs)
+
+
+def resize_output(model, new_nO):
+    tok2vec = model.get_ref("tok2vec")
+    lower = model.get_ref("lower")
+    upper = model.get_ref("upper")
+    if not model.attrs["has_upper"]:
+        if lower.has_dim("nO") is None:
+            lower.set_dim("nO", new_nO)
+        return
+    elif upper.has_dim("nO") is None:
+        upper.set_dim("nO", new_nO)
+        return
+    elif new_nO == upper.get_dim("nO"):
+        return
+    smaller = upper
+    nI = None
+    if smaller.has_dim("nI"):
+        nI = smaller.get_dim("nI")
+    with use_ops('numpy'):
+        larger = Linear(nO=new_nO, nI=nI)
+        larger.init = smaller.init
+    # it could be that the model is not initialized yet, then skip this bit
+    if nI:
+        larger_W = larger.ops.alloc2f(new_nO, nI)
+        larger_b = larger.ops.alloc1f(new_nO)
+        smaller_W = smaller.get_param("W")
+        smaller_b = smaller.get_param("b")
+        # Weights are stored in (nr_out, nr_in) format, so we're basically
+        # just adding rows here.
+        if smaller.has_dim("nO"):
+            larger_W[:smaller.get_dim("nO")] = smaller_W
+            larger_b[:smaller.get_dim("nO")] = smaller_b
+            for i in range(smaller.get_dim("nO"), new_nO):
+                model.attrs["unseen_classes"].add(i)
+
+        larger.set_param("W", larger_W)
+        larger.set_param("b", larger_b)
+    model._layers[-1] = larger
+    model.set_ref("upper", larger)
+    return model

--- a/spacy/ml/tb_framework.py
+++ b/spacy/ml/tb_framework.py
@@ -1,4 +1,4 @@
-from thinc.api import Model, noop
+from thinc.api import Model, noop, use_ops, Linear
 from ..syntax._parser_model import ParserStepModel
 
 

--- a/spacy/ml/tb_framework.py
+++ b/spacy/ml/tb_framework.py
@@ -25,7 +25,7 @@ def TransitionModel(tok2vec, lower, upper, unseen_classes=set()):
     )
 
 
-def forward(model: ParserModel, X, is_train):
+def forward(model, X, is_train):
     step_model = ParserStepModel(
         X,
         model.layers,

--- a/spacy/pipeline/__init__.py
+++ b/spacy/pipeline/__init__.py
@@ -1,6 +1,7 @@
 from .pipes import Tagger, DependencyParser, EntityRecognizer, EntityLinker
 from .pipes import TextCategorizer, Tensorizer, Pipe, Sentencizer
 from .pipes import SentenceRecognizer
+from .simple_ner import SimpleNER
 from .morphologizer import Morphologizer
 from .entityruler import EntityRuler
 from .tok2vec import Tok2Vec
@@ -22,6 +23,7 @@ __all__ = [
     "SentenceSegmenter",
     "SentenceRecognizer",
     "SimilarityHook",
+    "SimpleNER",
     "merge_entities",
     "merge_noun_chunks",
     "merge_subtokens",

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -517,6 +517,9 @@ class Tagger(Pipe):
         correct = self.model.ops.xp.array(correct, dtype="i")
         d_scores = scores - to_categorical(correct, n_classes=scores.shape[1])
         d_scores *= self.model.ops.asarray(known_labels)
+        n_known = known_labels.sum()
+        if n_known > 0:
+            d_scores /= known_labels.sum()
         loss = (d_scores**2).sum()
         docs = [ex.doc for ex in examples]
         d_scores = self.model.ops.unflatten(d_scores, [len(d) for d in docs])

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -464,6 +464,9 @@ class Tagger(Pipe):
             return
         set_dropout_rate(self.model, drop)
         tag_scores, bp_tag_scores = self.model.begin_update([ex.doc for ex in examples])
+        for sc in tag_scores:
+            if self.model.ops.xp.isnan(sc.sum()):
+                raise ValueError("nan value in scores")
         loss, d_tag_scores = self.get_loss(examples, tag_scores)
         bp_tag_scores(d_tag_scores)
         if sgd not in (None, False):

--- a/spacy/pipeline/simple_ner.py
+++ b/spacy/pipeline/simple_ner.py
@@ -82,19 +82,15 @@ class SimpleNER(Pipe):
         return loss
 
     def get_loss(self, examples, scores):
-        # We need to normalize by the number of words in the batch. If we
-        # set normalize=True here, longer sequences receive smaller gradients.
-        loss_func = CategoricalCrossentropy(
-            names=self.get_tag_names(),
-            normalize=False
-        )
+        loss_func = CategoricalCrossentropy(names=self.get_tag_names(), normalize=False)
         loss = 0
         d_scores = []
-        n_tokens = sum(s.shape[0] for s in scores)
+        n_words = sum(len(eg.doc) for eg in examples)
         for eg, doc_scores in zip(examples, scores):
             gold_tags = eg.gold.ner if self.is_biluo else biluo_to_iob(eg.gold.ner)
             d_doc_scores, doc_loss = loss_func(doc_scores, gold_tags)
-            d_scores.append(d_doc_scores / n_tokens)
+            d_doc_scores /= n_words
+            d_scores.append(d_doc_scores)
             loss += doc_loss
         return loss, d_scores
 

--- a/spacy/pipeline/simple_ner.py
+++ b/spacy/pipeline/simple_ner.py
@@ -1,0 +1,132 @@
+from typing import List
+from thinc.types import Floats2d
+from thinc.api import CategoricalCrossentropy, set_dropout_rate
+from ..gold import Example
+from ..tokens import Doc
+from ..language import component
+from ..util import link_vectors_to_models
+from .pipes import Pipe
+
+
+@component("simple_ner", assigns=["doc.ents"])
+class SimpleNER(Pipe):
+    """Named entity recognition with a tagging model. The model should include
+    validity constraints to ensure that only valid tag sequences are returned."""
+
+    def __init__(self, vocab, model):
+        self.vocab = vocab
+        self.model = model
+        self.cfg = {}
+        assert self.model is not None
+
+    @property
+    def labels(self):
+        return self.model.get_ref("biluo").attrs["labels"]
+
+    def add_label(self, label):
+        biluo = self.model.get_ref("biluo")
+        if biluo.attrs["labels"] is None:
+            biluo.attrs["labels"] = [label]
+        elif label not in biluo.attrs["labels"]:
+            biluo.attrs["labels"].append(label)
+ 
+    def get_tag_names(self):
+        return (
+            [f"B-{label}" for label in self.labels] +
+            [f"I-{label}" for label in self.labels] +
+            [f"L-{label}" for label in self.labels] +
+            [f"U-{label}" for label in self.labels] +
+            ["O"]
+        )
+
+    def predict(self, docs: List[Doc]) -> List[Floats2d]:
+        scores = self.model.predict(docs)
+        return scores
+
+    def set_annotations(self, docs: List[Doc], scores: List[Floats2d], tensors=None):
+        """Set entities on a batch of documents from a batch of scores."""
+        tag_names = self.get_tag_names()
+        for i, doc in enumerate(docs):
+            actions = scores[i].argmax(axis=1)
+            tags = [tag_names[actions[j, i]] for j in range(len(doc))]
+            doc.ents = spans_from_biluo_tags(doc, tags)
+
+    def update(self, examples, set_annotations=False, drop=0.0, sgd=None, losses=None):
+        examples = Example.to_example_objects(examples)
+        docs = [ex.doc for ex in examples]
+        set_dropout_rate(self.model, drop)
+        scores, bp_scores = self.model.begin_update(docs)
+        loss, d_scores = self.get_loss(examples, scores)
+        bp_scores(d_scores)
+        if set_annotations:
+            self.set_annotations(docs, scores)
+        if sgd is not None:
+            self.model.finish_update(sgd)
+        if losses is not None:
+            losses.setdefault(self.name, 0.0)
+            losses[self.name] += loss
+        return loss
+
+    def get_loss(self, examples, scores):
+        loss_func = CategoricalCrossentropy(names=self.get_tag_names())
+        loss = 0
+        d_scores = []
+        for eg, doc_scores in zip(examples, scores):
+            d_doc_scores, doc_loss = loss_func(doc_scores, eg.gold.ner)
+            d_scores.append(d_doc_scores)
+            loss += doc_loss
+        return loss, d_scores
+
+    def begin_training(self, get_examples, pipeline=None, sgd=None, **kwargs):
+        self.cfg.update(kwargs)
+        if not hasattr(get_examples, '__call__'):
+            gold_tuples = get_examples
+            get_examples = lambda: gold_tuples
+        labels = _get_labels(get_examples())
+        n_actions = _set_labels(self.model, _get_labels(get_examples()))
+        doc_sample, output_sample = _get_sample(self.model.ops, n_actions, get_examples())
+        if doc_sample:
+            self.model.initialize(X=doc_sample, Y=output_sample)
+        else:
+            for node in self.model.walk():
+                if node.has_dim("nO") is None and node.name == "mish":
+                    node.set_dim("nO", n_actions)
+            self.model.initialize()
+        if pipeline is not None:
+            self.init_multitask_objectives(get_examples, pipeline, sgd=sgd, **self.cfg)
+        link_vectors_to_models(self.vocab)
+        return sgd
+
+    def init_multitask_objectives(self, *args, **kwargs):
+        pass
+
+
+def _get_sample(ops, n_actions, examples, limit=10):
+    doc_sample = []
+    output_sample = [] 
+    for example in examples:
+        for doc, gold in parses:
+            doc_sample.append(doc)
+            output_sample.append(ops.alloc2f(len(doc), n_actions))
+            if limit >= 1 and len(doc_sample) >= limit:
+                break
+    return doc_sample, output_sample
+
+
+def _set_labels(model, labels):
+    for node in model.walk():
+        if node.name == "biluo" and node.attrs.get("labels") is None:
+            node.attrs["labels"] = list(sorted(labels))
+            break
+    n_actions = len(labels) * 4 + 1
+    return n_actions
+
+
+def _get_labels(examples):
+    labels = set()
+    for eg in examples:
+        for ner_tag in eg.token_annotation.entities:
+            if ner_tag != 'O' and ner_tag != '-':
+                _, label = ner_tag.split('-', 1)
+                labels.add(label)
+    return list(sorted(labels))

--- a/spacy/pipeline/simple_ner.py
+++ b/spacy/pipeline/simple_ner.py
@@ -68,10 +68,9 @@ class SimpleNER(Pipe):
             doc.ents = spans_from_biluo_tags(doc, tags)
 
     def update(self, examples, set_annotations=False, drop=0.0, sgd=None, losses=None):
-        examples = Example.to_example_objects(examples)
-        examples = [eg for eg in examples if _has_ner(eg)]
-        if not examples:
+        if not any(_has_ner(eg) for eg in examples):
             return 0
+        examples = Example.to_example_objects(examples)
         docs = [ex.doc for ex in examples]
         set_dropout_rate(self.model, drop)
         scores, bp_scores = self.model.begin_update(docs)
@@ -133,7 +132,7 @@ class SimpleNER(Pipe):
 
 
 def _has_ner(eg):
-    for ner_tag in eg.token_annotation.entities:
+    for ner_tag in eg.gold.ner:
         if ner_tag != "-" and ner_tag != None:
             return True
     else:
@@ -143,7 +142,7 @@ def _has_ner(eg):
 def _get_labels(examples):
     labels = set()
     for eg in examples:
-        for ner_tag in eg.gold.ner:
+        for ner_tag in eg.token_annotation.entities:
             if ner_tag != 'O' and ner_tag != '-':
                 _, label = ner_tag.split('-', 1)
                 labels.add(label)

--- a/spacy/syntax/_parser_model.pyx
+++ b/spacy/syntax/_parser_model.pyx
@@ -12,7 +12,7 @@ cimport blis.cy
 
 import numpy
 import numpy.random
-from thinc.api import Linear, Model, CupyOps, NumpyOps, use_ops
+from thinc.api import Linear, Model, CupyOps, NumpyOps, use_ops, noop
 
 from ..typedefs cimport weight_t, class_t, hash_t
 from ..tokens.doc cimport Doc
@@ -219,112 +219,27 @@ cdef int arg_max_if_valid(const weight_t* scores, const int* is_valid, int n) no
     return best
 
 
-class ParserModel(Model):
-    def __init__(self, tok2vec, lower_model, upper_model, unseen_classes=None):
-        # don't define nO for this object, because we can't dynamically change it
-        Model.__init__(self, name="parser_model", forward=forward, dims={"nI": None})
-        if tok2vec.has_dim("nI"):
-            self.set_dim("nI", tok2vec.get_dim("nI"))
-        self._layers = [tok2vec, lower_model]
-        if upper_model is not None:
-            self._layers.append(upper_model)
-        self.unseen_classes = set()
-        if unseen_classes:
-            for class_ in unseen_classes:
-                self.unseen_classes.add(class_)
-        self.set_ref("tok2vec", tok2vec)
-
-    def predict(self, docs):
-        step_model = ParserStepModel(docs, self._layers,
-                        unseen_classes=self.unseen_classes, train=False)
-        return step_model
-
-    def resize_output(self, new_nO):
-        if len(self._layers) == 2:
-            return
-        if self.upper.has_dim("nO") and (new_nO == self.upper.get_dim("nO")):
-            return
-        smaller = self.upper
-        nI = None
-        if smaller.has_dim("nI"):
-            nI = smaller.get_dim("nI")
-        with use_ops('numpy'):
-            larger = Linear(nO=new_nO, nI=nI)
-            larger.init = smaller.init
-        # it could be that the model is not initialized yet, then skip this bit
-        if nI:
-            larger_W = larger.ops.alloc2f(new_nO, nI)
-            larger_b = larger.ops.alloc1f(new_nO)
-            smaller_W = smaller.get_param("W")
-            smaller_b = smaller.get_param("b")
-            # Weights are stored in (nr_out, nr_in) format, so we're basically
-            # just adding rows here.
-            if smaller.has_dim("nO"):
-                larger_W[:smaller.get_dim("nO")] = smaller_W
-                larger_b[:smaller.get_dim("nO")] = smaller_b
-                for i in range(smaller.get_dim("nO"), new_nO):
-                    self.unseen_classes.add(i)
-
-            larger.set_param("W", larger_W)
-            larger.set_param("b", larger_b)
-        self._layers[-1] = larger
-
-    def initialize(self, X=None, Y=None):
-        self.tok2vec.initialize()
-        self.lower.initialize(X=X, Y=Y)
-        if self.upper is not None:
-            # In case we need to trigger the callbacks
-            statevecs = self.ops.alloc((2, self.lower.get_dim("nO")))
-            self.upper.initialize(X=statevecs)
-
-    def finish_update(self, optimizer):
-        self.tok2vec.finish_update(optimizer)
-        self.lower.finish_update(optimizer)
-        if self.upper is not None:
-            self.upper.finish_update(optimizer)
-
-    @property
-    def tok2vec(self):
-        return self._layers[0]
-
-    @property
-    def lower(self):
-        return self._layers[1]
-
-    @property
-    def upper(self):
-        return self._layers[2]
-
-
-def forward(model:ParserModel, X, is_train):
-    step_model = ParserStepModel(X, model._layers, unseen_classes=model.unseen_classes,
-        train=is_train)
-
-    return step_model, step_model.finish_steps
-
 
 class ParserStepModel(Model):
-    def __init__(self, docs, layers, unseen_classes=None, train=True):
+    def __init__(self, docs, layers, *, has_upper, unseen_classes=None, train=True):
         Model.__init__(self, name="parser_step_model", forward=step_forward)
+        self.attrs["has_upper"] = has_upper
         self.tokvecs, self.bp_tokvecs = layers[0](docs, is_train=train)
         if layers[1].get_dim("nP") >= 2:
             activation = "maxout"
-        elif len(layers) == 2:
+        elif has_upper:
             activation = None
         else:
             activation = "relu"
         self.state2vec = precompute_hiddens(len(docs), self.tokvecs, layers[1],
                                             activation=activation, train=train)
-        if len(layers) == 3:
+        if has_upper:
             self.vec2scores = layers[-1]
         else:
             self.vec2scores = None
         self.cuda_stream = util.get_cuda_stream(non_blocking=True)
         self.backprops = []
-        if self.vec2scores is None:
-            self._class_mask = numpy.zeros((self.state2vec.nO,), dtype='f')
-        else:
-            self._class_mask = numpy.zeros((self.vec2scores.get_dim("nO"),), dtype='f')
+        self._class_mask = numpy.zeros((self.nO,), dtype='f')
         self._class_mask.fill(1)
         if unseen_classes is not None:
             for class_ in unseen_classes:
@@ -332,7 +247,10 @@ class ParserStepModel(Model):
 
     @property
     def nO(self):
-        return self.state2vec.nO
+        if self.attrs["has_upper"]:
+            return self.vec2scores.nO
+        else:
+            return self.state2vec.nO
 
     def class_is_unseen(self, class_):
         return self._class_mask[class_]
@@ -378,7 +296,7 @@ class ParserStepModel(Model):
 def step_forward(model: ParserStepModel, states, is_train):
     token_ids = model.get_token_ids(states)
     vector, get_d_tokvecs = model.state2vec(token_ids, is_train)
-    if model.vec2scores is not None:
+    if model.attrs["has_upper"]:
         scores, get_d_vector = model.vec2scores(vector, is_train)
     else:
         scores = NumpyOps().asarray(vector)

--- a/spacy/syntax/_parser_model.pyx
+++ b/spacy/syntax/_parser_model.pyx
@@ -248,9 +248,9 @@ class ParserStepModel(Model):
     @property
     def nO(self):
         if self.attrs["has_upper"]:
-            return self.vec2scores.nO
+            return self.vec2scores.get_dim("nO")
         else:
-            return self.state2vec.nO
+            return self.state2vec.get_dim("nO")
 
     def class_is_unseen(self, class_):
         return self._class_mask[class_]

--- a/spacy/tests/parser/test_add_label.py
+++ b/spacy/tests/parser/test_add_label.py
@@ -65,7 +65,7 @@ def test_add_label_deserializes_correctly():
     ner2 = EntityRecognizer(Vocab(), default_ner())
 
     # the second model needs to be resized before we can call from_bytes
-    ner2.model.resize_output(ner1.moves.n_moves)
+    ner2.model.attrs["resize_output"](ner2.model, ner1.moves.n_moves)
     ner2.from_bytes(ner1.to_bytes())
     assert ner1.moves.n_moves == ner2.moves.n_moves
     for i in range(ner1.moves.n_moves):

--- a/spacy/tests/parser/test_neural_parser.py
+++ b/spacy/tests/parser/test_neural_parser.py
@@ -3,9 +3,9 @@ from spacy.ml.models.defaults import default_parser, default_tok2vec
 from spacy.vocab import Vocab
 from spacy.syntax.arc_eager import ArcEager
 from spacy.syntax.nn_parser import Parser
-from spacy.ml.tb_framework import TransitionModel
 from spacy.tokens.doc import Doc
 from spacy.gold import GoldParse
+from thinc.api import Model
 
 
 @pytest.fixture
@@ -34,7 +34,7 @@ def parser(vocab, arc_eager):
 @pytest.fixture
 def model(arc_eager, tok2vec, vocab):
     model = default_parser()
-    model.resize_output(arc_eager.n_moves)
+    model.attrs["resize_output"](model, arc_eager.n_moves)
     model.initialize()
     return model
 
@@ -50,7 +50,7 @@ def gold(doc):
 
 
 def test_can_init_nn_parser(parser):
-    assert isinstance(parser.model, TransitionModel)
+    assert isinstance(parser.model, Model)
 
 
 def test_build_model(parser, vocab):

--- a/spacy/tests/parser/test_neural_parser.py
+++ b/spacy/tests/parser/test_neural_parser.py
@@ -3,7 +3,7 @@ from spacy.ml.models.defaults import default_parser, default_tok2vec
 from spacy.vocab import Vocab
 from spacy.syntax.arc_eager import ArcEager
 from spacy.syntax.nn_parser import Parser
-from spacy.syntax._parser_model import ParserModel
+from spacy.ml.tb_framework import TransitionModel
 from spacy.tokens.doc import Doc
 from spacy.gold import GoldParse
 
@@ -50,7 +50,7 @@ def gold(doc):
 
 
 def test_can_init_nn_parser(parser):
-    assert isinstance(parser.model, ParserModel)
+    assert isinstance(parser.model, TransitionModel)
 
 
 def test_build_model(parser, vocab):

--- a/spacy/tests/pipeline/test_simple_ner.py
+++ b/spacy/tests/pipeline/test_simple_ner.py
@@ -3,6 +3,8 @@ from collections import namedtuple
 
 from thinc.api import NumpyOps
 from spacy.ml._biluo import BILUO, _get_transition_table
+from spacy.pipeline.simple_ner import SimpleNER
+import spacy
 
 
 @pytest.fixture(params=[

--- a/spacy/tests/pipeline/test_simple_ner.py
+++ b/spacy/tests/pipeline/test_simple_ner.py
@@ -39,7 +39,7 @@ def test_init_biluo_layer(labels):
 
 def test_transition_table(ops):
     labels = ["per", "loc", "org"]
-    table = _get_transition_table(ops, len(labels))
+    table = _get_transition_table(len(labels))
     a = _get_actions(labels)
     assert table.shape == (2, len(a), len(a))
     # Not last token, prev action was B

--- a/spacy/tests/pipeline/test_simple_ner.py
+++ b/spacy/tests/pipeline/test_simple_ner.py
@@ -46,7 +46,7 @@ def test_transition_table(ops):
     labels = ["per", "loc", "org"]
     table = _get_transition_table(ops, len(labels))
     a = _get_actions(labels)
-    assert table.shape == (2, len(a)+1, len(a))
+    assert table.shape == (2, len(a), len(a))
     # Not last token, prev action was B
     assert table[0, a.Bper, a.Bper] == 0
     assert table[0, a.Bper, a.Bloc] == 0

--- a/spacy/tests/pipeline/test_simple_ner.py
+++ b/spacy/tests/pipeline/test_simple_ner.py
@@ -1,0 +1,422 @@
+import pytest
+from collections import namedtuple
+
+from thinc.api import NumpyOps
+from spacy.ml._biluo import BILUO, _get_transition_table
+
+
+@pytest.fixture(params=[
+    ["PER", "ORG", "LOC", "MISC"],
+    ["GPE", "PERSON", "NUMBER", "CURRENCY", "EVENT"]
+])
+def labels(request):
+    return request.param
+
+@pytest.fixture
+def ops():
+    return NumpyOps()
+
+def _get_actions(labels):
+    action_names = (
+        [f"B{label}" for label in labels] + \
+        [f"I{label}" for label in labels] + \
+        [f"L{label}" for label in labels] + \
+        [f"U{label}" for label in labels] + \
+        ["O"]
+    )
+    A = namedtuple("actions", action_names)
+    return A(**{name: i for i, name in enumerate(action_names)})
+
+
+def test_init_biluo_layer(labels):
+    # Test passing in the labels first
+    model = BILUO(labels)
+    assert model.attrs["labels"] == labels
+    model.initialize()
+    assert model.get_dim("nO") == len(labels) * 4 + 1
+    # Test passing in the labels later
+    model = BILUO()
+    assert model.attrs["labels"] is None
+    model.attrs["labels"] = labels
+    model.initialize()
+    assert model.get_dim("nO") == len(labels) * 4 + 1
+
+
+def test_transition_table(ops):
+    labels = ["per", "loc", "org"]
+    table = _get_transition_table(ops, len(labels))
+    a = _get_actions(labels)
+    assert table.shape == (2, len(a)+1, len(a))
+    # Not last token, prev action was B
+    assert table[0, a.Bper, a.Bper] == 0
+    assert table[0, a.Bper, a.Bloc] == 0
+    assert table[0, a.Bper, a.Borg] == 0
+    assert table[0, a.Bper, a.Iper] == 1
+    assert table[0, a.Bper, a.Iloc] == 0
+    assert table[0, a.Bper, a.Iorg] == 0
+    assert table[0, a.Bper, a.Lper] == 1
+    assert table[0, a.Bper, a.Lloc] == 0
+    assert table[0, a.Bper, a.Lorg] == 0
+    assert table[0, a.Bper, a.Uper] == 0
+    assert table[0, a.Bper, a.Uloc] == 0
+    assert table[0, a.Bper, a.Uorg] == 0
+    assert table[0, a.Bper, a.O] == 0
+
+    assert table[0, a.Bloc, a.Bper] == 0
+    assert table[0, a.Bloc, a.Bloc] == 0
+    assert table[0, a.Bloc, a.Borg] == 0
+    assert table[0, a.Bloc, a.Iper] == 0
+    assert table[0, a.Bloc, a.Iloc] == 1
+    assert table[0, a.Bloc, a.Iorg] == 0
+    assert table[0, a.Bloc, a.Lper] == 0
+    assert table[0, a.Bloc, a.Lloc] == 1
+    assert table[0, a.Bloc, a.Lorg] == 0
+    assert table[0, a.Bloc, a.Uper] == 0
+    assert table[0, a.Bloc, a.Uloc] == 0
+    assert table[0, a.Bloc, a.Uorg] == 0
+    assert table[0, a.Bloc, a.O] == 0
+
+    assert table[0, a.Borg, a.Bper] == 0
+    assert table[0, a.Borg, a.Bloc] == 0
+    assert table[0, a.Borg, a.Borg] == 0
+    assert table[0, a.Borg, a.Iper] == 0
+    assert table[0, a.Borg, a.Iloc] == 0
+    assert table[0, a.Borg, a.Iorg] == 1
+    assert table[0, a.Borg, a.Lper] == 0
+    assert table[0, a.Borg, a.Lloc] == 0
+    assert table[0, a.Borg, a.Lorg] == 1
+    assert table[0, a.Borg, a.Uper] == 0
+    assert table[0, a.Borg, a.Uloc] == 0
+    assert table[0, a.Borg, a.Uorg] == 0
+    assert table[0, a.Borg, a.O] == 0
+
+    # Not last token, prev action was I
+    assert table[0, a.Iper, a.Bper] == 0
+    assert table[0, a.Iper, a.Bloc] == 0
+    assert table[0, a.Iper, a.Borg] == 0
+    assert table[0, a.Iper, a.Iper] == 1
+    assert table[0, a.Iper, a.Iloc] == 0
+    assert table[0, a.Iper, a.Iorg] == 0
+    assert table[0, a.Iper, a.Lper] == 1
+    assert table[0, a.Iper, a.Lloc] == 0
+    assert table[0, a.Iper, a.Lorg] == 0
+    assert table[0, a.Iper, a.Uper] == 0
+    assert table[0, a.Iper, a.Uloc] == 0
+    assert table[0, a.Iper, a.Uorg] == 0
+    assert table[0, a.Iper, a.O] == 0
+
+    assert table[0, a.Iloc, a.Bper] == 0
+    assert table[0, a.Iloc, a.Bloc] == 0
+    assert table[0, a.Iloc, a.Borg] == 0
+    assert table[0, a.Iloc, a.Iper] == 0
+    assert table[0, a.Iloc, a.Iloc] == 1
+    assert table[0, a.Iloc, a.Iorg] == 0
+    assert table[0, a.Iloc, a.Lper] == 0
+    assert table[0, a.Iloc, a.Lloc] == 1
+    assert table[0, a.Iloc, a.Lorg] == 0
+    assert table[0, a.Iloc, a.Uper] == 0
+    assert table[0, a.Iloc, a.Uloc] == 0
+    assert table[0, a.Iloc, a.Uorg] == 0
+    assert table[0, a.Iloc, a.O] == 0
+
+    assert table[0, a.Iorg, a.Bper] == 0
+    assert table[0, a.Iorg, a.Bloc] == 0
+    assert table[0, a.Iorg, a.Borg] == 0
+    assert table[0, a.Iorg, a.Iper] == 0
+    assert table[0, a.Iorg, a.Iloc] == 0
+    assert table[0, a.Iorg, a.Iorg] == 1
+    assert table[0, a.Iorg, a.Lper] == 0
+    assert table[0, a.Iorg, a.Lloc] == 0
+    assert table[0, a.Iorg, a.Lorg] == 1
+    assert table[0, a.Iorg, a.Uper] == 0
+    assert table[0, a.Iorg, a.Uloc] == 0
+    assert table[0, a.Iorg, a.Uorg] == 0
+    assert table[0, a.Iorg, a.O] == 0
+
+    # Not last token, prev action was L
+    assert table[0, a.Lper, a.Bper] == 1
+    assert table[0, a.Lper, a.Bloc] == 1
+    assert table[0, a.Lper, a.Borg] == 1
+    assert table[0, a.Lper, a.Iper] == 0
+    assert table[0, a.Lper, a.Iloc] == 0
+    assert table[0, a.Lper, a.Iorg] == 0
+    assert table[0, a.Lper, a.Lper] == 0
+    assert table[0, a.Lper, a.Lloc] == 0
+    assert table[0, a.Lper, a.Lorg] == 0
+    assert table[0, a.Lper, a.Uper] == 1
+    assert table[0, a.Lper, a.Uloc] == 1
+    assert table[0, a.Lper, a.Uorg] == 1
+    assert table[0, a.Lper, a.O] == 1
+
+    assert table[0, a.Lloc, a.Bper] == 1
+    assert table[0, a.Lloc, a.Bloc] == 1
+    assert table[0, a.Lloc, a.Borg] == 1
+    assert table[0, a.Lloc, a.Iper] == 0
+    assert table[0, a.Lloc, a.Iloc] == 0
+    assert table[0, a.Lloc, a.Iorg] == 0
+    assert table[0, a.Lloc, a.Lper] == 0
+    assert table[0, a.Lloc, a.Lloc] == 0
+    assert table[0, a.Lloc, a.Lorg] == 0
+    assert table[0, a.Lloc, a.Uper] == 1
+    assert table[0, a.Lloc, a.Uloc] == 1
+    assert table[0, a.Lloc, a.Uorg] == 1
+    assert table[0, a.Lloc, a.O] == 1
+
+    assert table[0, a.Lorg, a.Bper] == 1
+    assert table[0, a.Lorg, a.Bloc] == 1
+    assert table[0, a.Lorg, a.Borg] == 1
+    assert table[0, a.Lorg, a.Iper] == 0
+    assert table[0, a.Lorg, a.Iloc] == 0
+    assert table[0, a.Lorg, a.Iorg] == 0
+    assert table[0, a.Lorg, a.Lper] == 0
+    assert table[0, a.Lorg, a.Lloc] == 0
+    assert table[0, a.Lorg, a.Lorg] == 0
+    assert table[0, a.Lorg, a.Uper] == 1
+    assert table[0, a.Lorg, a.Uloc] == 1
+    assert table[0, a.Lorg, a.Uorg] == 1
+    assert table[0, a.Lorg, a.O] == 1
+
+    # Not last token, prev action was U
+    assert table[0, a.Uper, a.Bper] == 1
+    assert table[0, a.Uper, a.Bloc] == 1
+    assert table[0, a.Uper, a.Borg] == 1
+    assert table[0, a.Uper, a.Iper] == 0
+    assert table[0, a.Uper, a.Iloc] == 0
+    assert table[0, a.Uper, a.Iorg] == 0
+    assert table[0, a.Uper, a.Lper] == 0
+    assert table[0, a.Uper, a.Lloc] == 0
+    assert table[0, a.Uper, a.Lorg] == 0
+    assert table[0, a.Uper, a.Uper] == 1
+    assert table[0, a.Uper, a.Uloc] == 1
+    assert table[0, a.Uper, a.Uorg] == 1
+    assert table[0, a.Uper, a.O] == 1
+
+    assert table[0, a.Uloc, a.Bper] == 1
+    assert table[0, a.Uloc, a.Bloc] == 1
+    assert table[0, a.Uloc, a.Borg] == 1
+    assert table[0, a.Uloc, a.Iper] == 0
+    assert table[0, a.Uloc, a.Iloc] == 0
+    assert table[0, a.Uloc, a.Iorg] == 0
+    assert table[0, a.Uloc, a.Lper] == 0
+    assert table[0, a.Uloc, a.Lloc] == 0
+    assert table[0, a.Uloc, a.Lorg] == 0
+    assert table[0, a.Uloc, a.Uper] == 1
+    assert table[0, a.Uloc, a.Uloc] == 1
+    assert table[0, a.Uloc, a.Uorg] == 1
+    assert table[0, a.Uloc, a.O] == 1
+
+    assert table[0, a.Uorg, a.Bper] == 1
+    assert table[0, a.Uorg, a.Bloc] == 1
+    assert table[0, a.Uorg, a.Borg] == 1
+    assert table[0, a.Uorg, a.Iper] == 0
+    assert table[0, a.Uorg, a.Iloc] == 0
+    assert table[0, a.Uorg, a.Iorg] == 0
+    assert table[0, a.Uorg, a.Lper] == 0
+    assert table[0, a.Uorg, a.Lloc] == 0
+    assert table[0, a.Uorg, a.Lorg] == 0
+    assert table[0, a.Uorg, a.Uper] == 1
+    assert table[0, a.Uorg, a.Uloc] == 1
+    assert table[0, a.Uorg, a.Uorg] == 1
+    assert table[0, a.Uorg, a.O] == 1
+
+    # Not last token, prev action was O
+    assert table[0, a.O, a.Bper] == 1
+    assert table[0, a.O, a.Bloc] == 1
+    assert table[0, a.O, a.Borg] == 1
+    assert table[0, a.O, a.Iper] == 0
+    assert table[0, a.O, a.Iloc] == 0
+    assert table[0, a.O, a.Iorg] == 0
+    assert table[0, a.O, a.Lper] == 0
+    assert table[0, a.O, a.Lloc] == 0
+    assert table[0, a.O, a.Lorg] == 0
+    assert table[0, a.O, a.Uper] == 1
+    assert table[0, a.O, a.Uloc] == 1
+    assert table[0, a.O, a.Uorg] == 1
+    assert table[0, a.O, a.O] == 1
+    
+    # Last token, prev action was B
+    assert table[1, a.Bper, a.Bper] == 0
+    assert table[1, a.Bper, a.Bloc] == 0
+    assert table[1, a.Bper, a.Borg] == 0
+    assert table[1, a.Bper, a.Iper] == 0
+    assert table[1, a.Bper, a.Iloc] == 0
+    assert table[1, a.Bper, a.Iorg] == 0
+    assert table[1, a.Bper, a.Lper] == 1
+    assert table[1, a.Bper, a.Lloc] == 0
+    assert table[1, a.Bper, a.Lorg] == 0
+    assert table[1, a.Bper, a.Uper] == 0
+    assert table[1, a.Bper, a.Uloc] == 0
+    assert table[1, a.Bper, a.Uorg] == 0
+    assert table[1, a.Bper, a.O] == 0
+
+    assert table[1, a.Bloc, a.Bper] == 0
+    assert table[1, a.Bloc, a.Bloc] == 0
+    assert table[0, a.Bloc, a.Borg] == 0
+    assert table[1, a.Bloc, a.Iper] == 0
+    assert table[1, a.Bloc, a.Iloc] == 0
+    assert table[1, a.Bloc, a.Iorg] == 0
+    assert table[1, a.Bloc, a.Lper] == 0
+    assert table[1, a.Bloc, a.Lloc] == 1
+    assert table[1, a.Bloc, a.Lorg] == 0
+    assert table[1, a.Bloc, a.Uper] == 0
+    assert table[1, a.Bloc, a.Uloc] == 0
+    assert table[1, a.Bloc, a.Uorg] == 0
+    assert table[1, a.Bloc, a.O] == 0
+
+    assert table[1, a.Borg, a.Bper] == 0
+    assert table[1, a.Borg, a.Bloc] == 0
+    assert table[1, a.Borg, a.Borg] == 0
+    assert table[1, a.Borg, a.Iper] == 0
+    assert table[1, a.Borg, a.Iloc] == 0
+    assert table[1, a.Borg, a.Iorg] == 0
+    assert table[1, a.Borg, a.Lper] == 0
+    assert table[1, a.Borg, a.Lloc] == 0
+    assert table[1, a.Borg, a.Lorg] == 1
+    assert table[1, a.Borg, a.Uper] == 0
+    assert table[1, a.Borg, a.Uloc] == 0
+    assert table[1, a.Borg, a.Uorg] == 0
+    assert table[1, a.Borg, a.O] == 0
+
+    # Last token, prev action was I
+    assert table[1, a.Iper, a.Bper] == 0
+    assert table[1, a.Iper, a.Bloc] == 0
+    assert table[1, a.Iper, a.Borg] == 0
+    assert table[1, a.Iper, a.Iper] == 0
+    assert table[1, a.Iper, a.Iloc] == 0
+    assert table[1, a.Iper, a.Iorg] == 0
+    assert table[1, a.Iper, a.Lper] == 1
+    assert table[1, a.Iper, a.Lloc] == 0
+    assert table[1, a.Iper, a.Lorg] == 0
+    assert table[1, a.Iper, a.Uper] == 0
+    assert table[1, a.Iper, a.Uloc] == 0
+    assert table[1, a.Iper, a.Uorg] == 0
+    assert table[1, a.Iper, a.O] == 0
+
+    assert table[1, a.Iloc, a.Bper] == 0
+    assert table[1, a.Iloc, a.Bloc] == 0
+    assert table[1, a.Iloc, a.Borg] == 0
+    assert table[1, a.Iloc, a.Iper] == 0
+    assert table[1, a.Iloc, a.Iloc] == 0
+    assert table[1, a.Iloc, a.Iorg] == 0
+    assert table[1, a.Iloc, a.Lper] == 0
+    assert table[1, a.Iloc, a.Lloc] == 1
+    assert table[1, a.Iloc, a.Lorg] == 0
+    assert table[1, a.Iloc, a.Uper] == 0
+    assert table[1, a.Iloc, a.Uloc] == 0
+    assert table[1, a.Iloc, a.Uorg] == 0
+    assert table[1, a.Iloc, a.O] == 0
+
+    assert table[1, a.Iorg, a.Bper] == 0
+    assert table[1, a.Iorg, a.Bloc] == 0
+    assert table[1, a.Iorg, a.Borg] == 0
+    assert table[1, a.Iorg, a.Iper] == 0
+    assert table[1, a.Iorg, a.Iloc] == 0
+    assert table[1, a.Iorg, a.Iorg] == 0
+    assert table[1, a.Iorg, a.Lper] == 0
+    assert table[1, a.Iorg, a.Lloc] == 0
+    assert table[1, a.Iorg, a.Lorg] == 1
+    assert table[1, a.Iorg, a.Uper] == 0
+    assert table[1, a.Iorg, a.Uloc] == 0
+    assert table[1, a.Iorg, a.Uorg] == 0
+    assert table[1, a.Iorg, a.O] == 0
+
+    # Last token, prev action was L
+    assert table[1, a.Lper, a.Bper] == 0
+    assert table[1, a.Lper, a.Bloc] == 0
+    assert table[1, a.Lper, a.Borg] == 0
+    assert table[1, a.Lper, a.Iper] == 0
+    assert table[1, a.Lper, a.Iloc] == 0
+    assert table[1, a.Lper, a.Iorg] == 0
+    assert table[1, a.Lper, a.Lper] == 0
+    assert table[1, a.Lper, a.Lloc] == 0
+    assert table[1, a.Lper, a.Lorg] == 0
+    assert table[1, a.Lper, a.Uper] == 1
+    assert table[1, a.Lper, a.Uloc] == 1
+    assert table[1, a.Lper, a.Uorg] == 1
+    assert table[1, a.Lper, a.O] == 1
+
+    assert table[1, a.Lloc, a.Bper] == 0
+    assert table[1, a.Lloc, a.Bloc] == 0
+    assert table[1, a.Lloc, a.Borg] == 0
+    assert table[1, a.Lloc, a.Iper] == 0
+    assert table[1, a.Lloc, a.Iloc] == 0
+    assert table[1, a.Lloc, a.Iorg] == 0
+    assert table[1, a.Lloc, a.Lper] == 0
+    assert table[1, a.Lloc, a.Lloc] == 0
+    assert table[1, a.Lloc, a.Lorg] == 0
+    assert table[1, a.Lloc, a.Uper] == 1
+    assert table[1, a.Lloc, a.Uloc] == 1
+    assert table[1, a.Lloc, a.Uorg] == 1
+    assert table[1, a.Lloc, a.O] == 1
+
+    assert table[1, a.Lorg, a.Bper] == 0
+    assert table[1, a.Lorg, a.Bloc] == 0
+    assert table[1, a.Lorg, a.Borg] == 0
+    assert table[1, a.Lorg, a.Iper] == 0
+    assert table[1, a.Lorg, a.Iloc] == 0
+    assert table[1, a.Lorg, a.Iorg] == 0
+    assert table[1, a.Lorg, a.Lper] == 0
+    assert table[1, a.Lorg, a.Lloc] == 0
+    assert table[1, a.Lorg, a.Lorg] == 0
+    assert table[1, a.Lorg, a.Uper] == 1
+    assert table[1, a.Lorg, a.Uloc] == 1
+    assert table[1, a.Lorg, a.Uorg] == 1
+    assert table[1, a.Lorg, a.O] == 1
+
+    # Last token, prev action was U
+    assert table[1, a.Uper, a.Bper] == 0
+    assert table[1, a.Uper, a.Bloc] == 0
+    assert table[1, a.Uper, a.Borg] == 0
+    assert table[1, a.Uper, a.Iper] == 0
+    assert table[1, a.Uper, a.Iloc] == 0
+    assert table[1, a.Uper, a.Iorg] == 0
+    assert table[1, a.Uper, a.Lper] == 0
+    assert table[1, a.Uper, a.Lloc] == 0
+    assert table[1, a.Uper, a.Lorg] == 0
+    assert table[1, a.Uper, a.Uper] == 1
+    assert table[1, a.Uper, a.Uloc] == 1
+    assert table[1, a.Uper, a.Uorg] == 1
+    assert table[1, a.Uper, a.O] == 1
+
+    assert table[1, a.Uloc, a.Bper] == 0
+    assert table[1, a.Uloc, a.Bloc] == 0
+    assert table[1, a.Uloc, a.Borg] == 0
+    assert table[1, a.Uloc, a.Iper] == 0
+    assert table[1, a.Uloc, a.Iloc] == 0
+    assert table[1, a.Uloc, a.Iorg] == 0
+    assert table[1, a.Uloc, a.Lper] == 0
+    assert table[1, a.Uloc, a.Lloc] == 0
+    assert table[1, a.Uloc, a.Lorg] == 0
+    assert table[1, a.Uloc, a.Uper] == 1
+    assert table[1, a.Uloc, a.Uloc] == 1
+    assert table[1, a.Uloc, a.Uorg] == 1
+    assert table[1, a.Uloc, a.O] == 1
+
+    assert table[1, a.Uorg, a.Bper] == 0
+    assert table[1, a.Uorg, a.Bloc] == 0
+    assert table[1, a.Uorg, a.Borg] == 0
+    assert table[1, a.Uorg, a.Iper] == 0
+    assert table[1, a.Uorg, a.Iloc] == 0
+    assert table[1, a.Uorg, a.Iorg] == 0
+    assert table[1, a.Uorg, a.Lper] == 0
+    assert table[1, a.Uorg, a.Lloc] == 0
+    assert table[1, a.Uorg, a.Lorg] == 0
+    assert table[1, a.Uorg, a.Uper] == 1
+    assert table[1, a.Uorg, a.Uloc] == 1
+    assert table[1, a.Uorg, a.Uorg] == 1
+    assert table[1, a.Uorg, a.O] == 1
+
+    # Last token, prev action was O
+    assert table[1, a.O, a.Bper] == 0
+    assert table[1, a.O, a.Bloc] == 0
+    assert table[1, a.O, a.Borg] == 0
+    assert table[1, a.O, a.Iper] == 0
+    assert table[1, a.O, a.Iloc] == 0
+    assert table[1, a.O, a.Iorg] == 0
+    assert table[1, a.O, a.Lper] == 0
+    assert table[1, a.O, a.Lloc] == 0
+    assert table[1, a.O, a.Lorg] == 0
+    assert table[1, a.O, a.Uper] == 1
+    assert table[1, a.O, a.Uloc] == 1
+    assert table[1, a.O, a.Uorg] == 1
+    assert table[1, a.O, a.O] == 1

--- a/spacy/tests/pipeline/test_simple_ner.py
+++ b/spacy/tests/pipeline/test_simple_ner.py
@@ -31,15 +31,8 @@ def _get_actions(labels):
 
 
 def test_init_biluo_layer(labels):
-    # Test passing in the labels first
-    model = BILUO(labels)
-    assert model.attrs["labels"] == labels
-    model.initialize()
-    assert model.get_dim("nO") == len(labels) * 4 + 1
-    # Test passing in the labels later
     model = BILUO()
-    assert model.attrs["labels"] is None
-    model.attrs["labels"] = labels
+    model.set_dim("nO", model.attrs["get_num_actions"](len(labels)))
     model.initialize()
     assert model.get_dim("nO") == len(labels) * 4 + 1
 

--- a/spacy/tests/regression/test_issue2001-2500.py
+++ b/spacy/tests/regression/test_issue2001-2500.py
@@ -34,7 +34,8 @@ def test_issue2179():
     nlp2.add_pipe(nlp2.create_pipe("ner"))
 
     assert len(nlp2.get_pipe("ner").labels) == 0
-    nlp2.get_pipe("ner").model.attrs["resize_output"](nlp.get_pipe("ner").moves.n_moves)
+    model = nlp2.get_pipe("ner").model
+    model.attrs["resize_output"](model, nlp.get_pipe("ner").moves.n_moves)
     nlp2.from_bytes(nlp.to_bytes())
     assert "extra_labels" not in nlp2.get_pipe("ner").cfg
     assert nlp2.get_pipe("ner").labels == ("CITIZENSHIP",)

--- a/spacy/tests/regression/test_issue2001-2500.py
+++ b/spacy/tests/regression/test_issue2001-2500.py
@@ -34,7 +34,7 @@ def test_issue2179():
     nlp2.add_pipe(nlp2.create_pipe("ner"))
 
     assert len(nlp2.get_pipe("ner").labels) == 0
-    nlp2.get_pipe("ner").model.resize_output(nlp.get_pipe("ner").moves.n_moves)
+    nlp2.get_pipe("ner").model.attrs["resize_output"](nlp.get_pipe("ner").moves.n_moves)
     nlp2.from_bytes(nlp.to_bytes())
     assert "extra_labels" not in nlp2.get_pipe("ner").cfg
     assert nlp2.get_pipe("ner").labels == ("CITIZENSHIP",)

--- a/spacy/tests/regression/test_issue3001-3500.py
+++ b/spacy/tests/regression/test_issue3001-3500.py
@@ -104,7 +104,7 @@ def test_issue3209():
     assert ner.move_names == move_names
     nlp2 = English()
     nlp2.add_pipe(nlp2.create_pipe("ner"))
-    nlp2.get_pipe("ner").model.resize_output(ner.moves.n_moves)
+    nlp2.get_pipe("ner").model.attrs["resize_output"](ner.moves.n_moves)
     nlp2.from_bytes(nlp.to_bytes())
     assert nlp2.get_pipe("ner").move_names == move_names
 

--- a/spacy/tests/regression/test_issue3001-3500.py
+++ b/spacy/tests/regression/test_issue3001-3500.py
@@ -104,7 +104,8 @@ def test_issue3209():
     assert ner.move_names == move_names
     nlp2 = English()
     nlp2.add_pipe(nlp2.create_pipe("ner"))
-    nlp2.get_pipe("ner").model.attrs["resize_output"](ner.moves.n_moves)
+    model = nlp2.get_pipe("ner").model
+    model.attrs["resize_output"](model, ner.moves.n_moves)
     nlp2.from_bytes(nlp.to_bytes())
     assert nlp2.get_pipe("ner").move_names == move_names
 

--- a/spacy/tests/serialize/test_serialize_config.py
+++ b/spacy/tests/serialize/test_serialize_config.py
@@ -110,10 +110,9 @@ def test_serialize_custom_nlp():
         nlp2 = spacy.load(d)
         model = nlp2.get_pipe("parser").model
         tok2vec = model.get_ref("tok2vec")
-        upper = model.upper
+        upper = model.get_ref("upper")
 
         # check that we have the correct settings, not the default ones
-        assert tok2vec.get_dim("nO") == 321
         assert upper.get_dim("nI") == 65
 
 
@@ -131,8 +130,7 @@ def test_serialize_parser():
         nlp2 = spacy.load(d)
         model = nlp2.get_pipe("parser").model
         tok2vec = model.get_ref("tok2vec")
-        upper = model.upper
+        upper = model.get_ref("upper")
 
         # check that we have the correct settings, not the default ones
         assert upper.get_dim("nI") == 66
-        assert tok2vec.get_dim("nO") == 333

--- a/spacy/tests/serialize/test_serialize_pipeline.py
+++ b/spacy/tests/serialize/test_serialize_pipeline.py
@@ -63,7 +63,7 @@ def test_to_from_bytes(parser, blank_parser):
     bytes_data = parser.to_bytes(exclude=["vocab"])
 
     # the blank parser needs to be resized before we can call from_bytes
-    blank_parser.model.attrs["resize_output"](parser.moves.n_moves)
+    blank_parser.model.attrs["resize_output"](blank_parser.model, parser.moves.n_moves)
     blank_parser.from_bytes(bytes_data)
     assert blank_parser.model is not True
     assert blank_parser.moves.n_moves == parser.moves.n_moves

--- a/spacy/tests/serialize/test_serialize_pipeline.py
+++ b/spacy/tests/serialize/test_serialize_pipeline.py
@@ -63,7 +63,7 @@ def test_to_from_bytes(parser, blank_parser):
     bytes_data = parser.to_bytes(exclude=["vocab"])
 
     # the blank parser needs to be resized before we can call from_bytes
-    blank_parser.model.resize_output(parser.moves.n_moves)
+    blank_parser.model.attrs["resize_output"](parser.moves.n_moves)
     blank_parser.from_bytes(bytes_data)
     assert blank_parser.model is not True
     assert blank_parser.moves.n_moves == parser.moves.n_moves

--- a/spacy/tests/test_misc.py
+++ b/spacy/tests/test_misc.py
@@ -38,7 +38,7 @@ def test_util_get_package_path(package):
 
 
 def test_PrecomputableAffine(nO=4, nI=5, nF=3, nP=2):
-    model = PrecomputableAffine(nO=nO, nI=nI, nF=nF, nP=nP)
+    model = PrecomputableAffine(nO=nO, nI=nI, nF=nF, nP=nP).initialize()
     assert model.get_param("W").shape == (nF, nO, nP, nI)
     tensor = model.ops.alloc((10, nI))
     Y, get_dX = model.begin_update(tensor)

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -571,8 +571,10 @@ def decaying(start, stop, decay):
         curr -= decay
 
 
-def minibatch_by_words(examples, size, tuples=True, count_words=len):
-    """Create minibatches of a given number of words."""
+def minibatch_by_words(examples, size, tuples=True, count_words=len, tolerance=0.2):
+    """Create minibatches of roughly a given number of words. If any examples
+    are longer than the specified batch length, they will appear in a batch by
+    themselves."""
     if isinstance(size, int):
         size_ = itertools.repeat(size)
     elif isinstance(size, List):
@@ -580,18 +582,34 @@ def minibatch_by_words(examples, size, tuples=True, count_words=len):
     else:
         size_ = size
     examples = iter(examples)
+    oversize = []
     while True:
         batch_size = next(size_)
+        tol_size = batch_size * 0.2
         batch = []
+        if oversize:
+            example = oversize.pop(0)
+            n_words = count_words(example.doc)
+            batch.append(example)
+            batch_size -= n_words
         while batch_size >= 0:
             try:
                 example = next(examples)
             except StopIteration:
-                if batch:
-                    yield batch
-                return
-            batch_size -= count_words(example.doc)
-            batch.append(example)
+                if oversize:
+                    examples = iter(oversize)
+                    oversize = []
+                    continue
+                else:
+                    if batch:
+                        yield batch
+                    return
+            n_words = count_words(example.doc)
+            if n_words < (batch_size + tol_size):
+                batch_size -= n_words
+                batch.append(example)
+            else:
+                oversize.append(example)
         if batch:
             yield batch
 

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -592,14 +592,16 @@ def minibatch_by_words(examples, size, tuples=True, count_words=len, tolerance=0
             n_words = count_words(example.doc)
             batch.append(example)
             batch_size -= n_words
-        while batch_size >= 0:
+        while batch_size >= 1:
             try:
                 example = next(examples)
             except StopIteration:
                 if oversize:
                     examples = iter(oversize)
                     oversize = []
-                    continue
+                    if batch:
+                        yield batch
+                    break
                 else:
                     if batch:
                         yield batch


### PR DESCRIPTION
The parser and NER models use a transition-based approach that's rather more intricate and indirect than the most obvious way people implement something like an NER model on top of a transformer. The most obvious way is more analogous to a tagger, with either a minimal modification to ensure valid sequences are produced, or perhaps a more involved CRF layer doing viterbi decoding with previous-tag features.

This PR adds a new component, provisionally titled `SimpleNER`, that uses this more baseline-ish strategy. The logic of applying the validity constraints is performed in a Thinc layer named `BILUO`.

Bug-fixes and some tweaks are also made to the existing parser model to make it more suitable for usage with transformers. In particular, the option to not use an output hidden layer receives bugfixes (it had been broken on develop), and instead a dimensionality reducing linear layer is added to the `tok2vec` component prior to the feature-extraction for the state.

These changes make the parser and NER faster and better for transformer models, which naturally use a wide tok2vec layer, e.g. 768 dimensions instead of the 96 or 128 dimensions we typically use in the CNN. The parser and NER use 8 and 3 features respectively, which would produce state vectors of 6144 and 2304 dimensions. These vectors are too wide, we want fewer parameters in the non-pretrained components. To address this, we simply downcast the token vectors to e.g. 128 prior to feature extraction. Now the state vectors are the same size we were using in the CNN models (1024 and 384). Dropping the last hidden layer further reduces the parameters and increases speed. I haven't tested whether this helps or hurts the model properly yet.

I haven't tested extensively, but so far the existing NER model does beat the `SimpleNER` baseline, in both speed and accuracy. I do think it makes sense: the NER model has an imitation-learning objective that's really a better way to decode than the dumb approach in the `SimpleNER` tagger.

With this approach we're now getting really good results on a multi-task transformer pipeline. With the `feature/spacy-v3` branch of the new `spacy-transformers` and the latest Thinc alpha, we get the following dev accuracies on OntoNotes 5:

| Speed (wps GPU) | TAGS | UAS | LAS | ENTS F |
| ------------------- | ------ | ---- | ---- | -------- |
| 2900                     | 97.9   | 95.9 | 94.5 | 89.6    |

These development accuracies are getting close to the highest published test accuracies on the data, e.g. Flair's OntoNotes 5 test accuracy is 89.7. The hyper-parameters aren't especially well-tuned, and the model uses `bert-base-cased`, which is definitely not the hottest transformer these days. Training was on a single GTX 2080 for about 7 hours. Full settings can be found here: https://github.com/explosion/spacy-transformers/blob/feature/spacy-v3/examples/listen/joint-core-bert.cfg

The nice thing here is that the parser, NER and tagger are all reading from and writing to a single copy of the transformer. No special tricks were required to make the multi-task learning work well.

The one thing I haven't gotten to work is the training from raw documents, which is the setting we use to produce the current core models. Nobody else trains from long documents, but I do think it ought to work. I suspect I have a bug in the alignment code or something. Anyway, if we can't get that setting to work, we'll just have to train on the gold preprocessing and use a sentence boundary detection model as a preprocess at runtime.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
