### PR TITLE
Disallow creation of 0-length spans

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -566,6 +566,7 @@ class Errors(object):
     E197 = ("Row out of bounds, unable to add row {row} for key {key}.")
     E198 = ("Unable to return {n} most similar vectors for the current vectors "
             "table, which contains {n_rows} vectors.")
+    E199 = ("Unable to create a Span of length 0.")
 
 
 @add_codes

--- a/spacy/tests/doc/test_doc_api.py
+++ b/spacy/tests/doc/test_doc_api.py
@@ -37,8 +37,8 @@ def test_doc_api_getitem(en_tokenizer):
     def to_str(span):
         return "/".join(token.text for token in span)
 
-    span = tokens[1:1]
-    assert not to_str(span)
+    with pytest.raises(ValueError):
+        span = tokens[1:1]
     span = tokens[1:4]
     assert to_str(span) == "it/back/!"
     span = tokens[1:4:1]
@@ -54,11 +54,10 @@ def test_doc_api_getitem(en_tokenizer):
     assert to_str(span) == "He/pleaded"
     span = tokens[-5:-3]
     assert to_str(span) == "back/!"
-    span = tokens[5:4]
-    assert span.start == span.end == 5 and not to_str(span)
-    span = tokens[4:-3]
-    assert span.start == span.end == 4 and not to_str(span)
-
+    with pytest.raises(ValueError):
+        span = tokens[5:4]
+    with pytest.raises(ValueError):
+        span = tokens[4:-3]
     span = tokens[:]
     assert to_str(span) == "Give/it/back/!/He/pleaded/."
     span = tokens[4:]
@@ -74,10 +73,10 @@ def test_doc_api_getitem(en_tokenizer):
     assert to_str(span) == "He/pleaded/."
     span = tokens[-50:4]
     assert to_str(span) == "Give/it/back/!"
-    span = tokens[-50:-40]
-    assert span.start == span.end == 0 and not to_str(span)
-    span = tokens[40:50]
-    assert span.start == span.end == 7 and not to_str(span)
+    with pytest.raises(ValueError):
+        span = tokens[-50:-40]
+    with pytest.raises(ValueError):
+        span = tokens[40:50]
 
     span = tokens[1:4]
     assert span[0].orth_ == "it"
@@ -97,8 +96,8 @@ def test_doc_api_getitem(en_tokenizer):
     assert to_str(subspan) == "back"
     subspan = span[-50:50]
     assert to_str(subspan) == "it/back/!"
-    subspan = span[50:-50]
-    assert subspan.start == subspan.end == 4 and not to_str(subspan)
+    with pytest.raises(ValueError):
+        subspan = span[50:-50]
 
 
 @pytest.mark.parametrize(

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -106,6 +106,8 @@ cdef class Span:
         self.start = start
         self.start_char = self.doc[start].idx if start < self.doc.length else 0
         self.end = end
+        if self.start == self.end:
+            raise ValueError(Errors.E199)
         if end >= 1:
             self.end_char = self.doc[end - 1].idx + len(self.doc[end - 1])
         else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Disallow creation of 0-length spans

0-length spans don't seem to make a lot of sense and accessing some of their attributes (like `vector` and `sentiment`) raises division by zero errors due to the length. In addition, retokenizing 0-length spans also leads to ill-formed docs.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bug fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
