### PR TITLE
Add blank:{lang} shortcut support to util.load_model

### DIFF
--- a/spacy/tests/test_misc.py
+++ b/spacy/tests/test_misc.py
@@ -135,3 +135,14 @@ def test_ascii_filenames():
     root = Path(__file__).parent.parent
     for path in root.glob("**/*"):
         assert all(ord(c) < 128 for c in path.name), path.name
+
+
+def test_load_model_blank_shortcut():
+    """Test that using a model name like "blank:en" works as a shortcut for
+    spacy.blank("en").
+    """
+    nlp = util.load_model("blank:en")
+    assert nlp.lang == "en"
+    assert nlp.pipeline == []
+    with pytest.raises(ImportError):
+        util.load_model("blank:fjsfijsdof")

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -161,6 +161,8 @@ def load_model(name, **overrides):
     if not data_path or not data_path.exists():
         raise IOError(Errors.E049.format(path=path2str(data_path)))
     if isinstance(name, basestring_):  # in data dir / shortcut
+        if name.startswith("blank:"):  # shortcut for blank model
+            return get_lang_class(name.replace("blank:", ""))()
         if name in set([d.name for d in data_path.iterdir()]):
             return load_model_from_link(name, **overrides)
         if is_package(name):  # installed as package


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Using `"blank:en"` as a shortcut for a blank model is a convention we've been using in Prodigy for a while and it's also come up in our examples in this repo. I keep writing conditionals to resolve this to `spacy.load` vs. `spacy.blank`, so I'm proposing making this part of the official API for `util.load_model` and `spacy.load`.

```python
# The following are equivalent
nlp = spacy.util.load_model("blank:en")
nlp = spacy.load("blank:en")
nlp = spacy.blank("en")
```

⚠️ This is mostly intended to allow creating blank models and loading model packages programmatically based on string input, e.g. a command-line argument. The main recommended user-facing API is still `spacy.load` with a model path/package name and `spacy.blank` with a language code.

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
