### PR TITLE
Use backwards-compatible super() for v2.x branch

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -7,7 +7,7 @@ def add_codes(err_cls):
 
     class ErrorsWithCodes(err_cls):
         def __getattribute__(self, code):
-            msg = super().__getattribute__(code)
+            msg = super(ErrorsWithCodes, self).__getattribute__(code)
             if code.startswith("__"):  # python system attributes like __class__
                 return msg
             else:

--- a/spacy/lang/pl/lemmatizer.py
+++ b/spacy/lang/pl/lemmatizer.py
@@ -13,7 +13,7 @@ class PolishLemmatizer(Lemmatizer):
     # lemmatization for nouns
     def __init__(self, lookups, *args, **kwargs):
         # this lemmatizer is lookup based, so it does not require an index, exceptionlist, or rules
-        super().__init__(lookups)
+        super(PolishLemmatizer, self).__init__(lookups)
         self.lemma_lookups = {}
         for tag in [
             "ADJ",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Tests currently fail on Python 2.7, which we still officially support on the spaCy v2.x line.

### Types of change
fix, compat

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
