### PR TITLE
Better model compatibility and validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ numpy>=1.15.0
 requests>=2.13.0,<3.0.0
 plac>=0.9.6,<1.2.0
 tqdm>=4.38.0,<5.0.0
+importlib_metadata>=0.20; python_version < "3.8"
 # Optional dependencies
 jsonschema>=2.6.0,<3.1.0
 pydantic>=1.3.0,<2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ install_requires =
     requests>=2.13.0,<3.0.0
     pydantic>=1.3.0,<2.0.0
     tqdm>=4.38.0,<5.0.0
+    importlib_metadata>=0.20; python_version < "3.8"
 
 [options.extras_require]
 lookups =

--- a/spacy/cli/info.py
+++ b/spacy/cli/info.py
@@ -48,7 +48,9 @@ def info(
         "Location": str(Path(__file__).parent.parent),
         "Platform": platform.platform(),
         "Python version": platform.python_version(),
-        "Models": ", ".join(model["name"] for model in all_models.values()),
+        "Models": ", ".join(
+            f"{m['name']} ({m['version']})" for m in all_models.values()
+        ),
     }
     if not silent:
         title = "Info about spaCy"

--- a/spacy/cli/package.py
+++ b/spacy/cli/package.py
@@ -83,14 +83,14 @@ def generate_meta(model_path, existing_meta, msg):
         ("lang", "Model language", meta.get("lang", "en")),
         ("name", "Model name", meta.get("name", "model")),
         ("version", "Model version", meta.get("version", "0.0.0")),
-        ("spacy_version", "Required spaCy version", f">={about.__version__},<3.0.0"),
         ("description", "Model description", meta.get("description", False)),
         ("author", "Author", meta.get("author", False)),
         ("email", "Author email", meta.get("email", False)),
         ("url", "Author website", meta.get("url", False)),
-        ("license", "License", meta.get("license", "CC BY-SA 3.0")),
+        ("license", "License", meta.get("license", "MIT")),
     ]
     nlp = util.load_model_from_path(Path(model_path))
+    meta["spacy_version"] = about.__version__
     meta["pipeline"] = nlp.pipe_names
     meta["vectors"] = {
         "width": nlp.vocab.vectors_length,
@@ -168,6 +168,7 @@ def setup_package():
         package_data={model_name: list_files(model_dir)},
         install_requires=list_requirements(meta),
         zip_safe=False,
+        entry_points={'spacy_models': ['{m} = {m}'.format(m=model_name)]}
     )
 
 

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -467,7 +467,7 @@ def train(
                     # Update model meta.json
                     meta["lang"] = nlp.lang
                     meta["pipeline"] = nlp.pipe_names
-                    meta["spacy_version"] = f">={about.__version__}"
+                    meta["spacy_version"] = about.__version__
                     if beam_width == 1:
                         meta["speed"] = {
                             "nwords": nwords,

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -196,7 +196,7 @@ class Language(object):
             self._meta.setdefault("lang", self.lang)
         self._meta.setdefault("name", "model")
         self._meta.setdefault("version", "0.0.0")
-        self._meta.setdefault("spacy_version", f">={about.__version__}")
+        self._meta.setdefault("spacy_version", about.__version__)
         self._meta.setdefault("description", "")
         self._meta.setdefault("author", "")
         self._meta.setdefault("email", "")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- [x] make all models packaged by `spacy package` advertise themselves via an entry point, so spaCy always knows which models are installed in the current environment
- [x] make the `spacy_version` in the model meta the exact version used to package the model with, instead of a version range (makes it much easier to determine compatibility)
- [x] update `spacy validate` to support both official models with compatibility listed in the compatibility table, as well as custom models
- [x] for custom models, determine compatibility by comparing the minor versions of the current spaCy version and the version the model was created with (models are only compatible across patch versions, incompatible if they have different minor/major versions)
- [x] update `spacy info` and include list of all spaCy models installed in the environment, plus their versions

### Types of change
enhancement, cli

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
