### PR TITLE
Support training of connected components

### DIFF
--- a/spacy/analysis.py
+++ b/spacy/analysis.py
@@ -173,3 +173,24 @@ def print_summary(nlp, pretty=True, no_print=False):
         msg.good("No problems found.")
     if no_print:
         return {"overview": overview, "problems": problems}
+
+
+def count_pipeline_interdependencies(pipeline):
+    """Count how many subsequent components require an annotation set by each
+    component in the pipeline.
+    """
+    pipe_assigns = []
+    pipe_requires = []
+    for name, pipe in pipeline:
+        pipe_assigns.append(set(getattr(pipe, "assigns", [])))
+        pipe_requires.append(set(getattr(pipe, "requires", [])))
+    counts = []
+    for i, assigns in enumerate(pipe_assigns):
+        count = 0
+        for requires in pipe_requires[i+1:]:
+            if assigns.intersection(requires):
+                count += 1
+        counts.append(count)
+    return counts
+
+

--- a/spacy/tests/pipeline/test_analysis.py
+++ b/spacy/tests/pipeline/test_analysis.py
@@ -2,6 +2,7 @@ import spacy.language
 from spacy.language import Language, component
 from spacy.analysis import print_summary, validate_attrs
 from spacy.analysis import get_assigns_for_attr, get_requires_for_attr
+from spacy.analysis import count_pipeline_interdependencies
 from mock import Mock, ANY
 import pytest
 
@@ -161,3 +162,19 @@ def test_analysis_validate_attrs_remove_pipe():
     with pytest.warns(None) as record:
         nlp.remove_pipe("c2")
     assert not record.list
+
+
+def test_pipe_interdependencies():
+    class Fancifier:
+        name = "fancifier"
+        assigns = ("doc._.fancy",)
+        requires = tuple()
+    
+    class FancyNeeder:
+        name = "needer"
+        assigns = tuple()
+        requires = ("doc._.fancy",)
+
+    pipeline = [("fancifier", Fancifier()), ("needer", FancyNeeder())]
+    counts = count_pipeline_interdependencies(pipeline)
+    assert counts == [1, 0]

--- a/spacy/tests/pipeline/test_pipe_methods.py
+++ b/spacy/tests/pipeline/test_pipe_methods.py
@@ -1,5 +1,5 @@
 import pytest
-from spacy.language import Language
+from spacy.language import Language, _count_pipeline_inter_dependencies
 
 
 @pytest.fixture
@@ -198,3 +198,19 @@ def test_pipe_labels(nlp):
     assert len(nlp.pipe_labels) == len(input_labels)
     for name, labels in nlp.pipe_labels.items():
         assert sorted(input_labels[name]) == sorted(labels)
+
+
+def test_pipe_inter_dependencies():
+    class Fancifier:
+        name = "fancifier"
+        assigns = ("doc._.fancy",)
+        requires = tuple()
+    
+    class FancyNeeder:
+        name = "needer"
+        assigns = tuple()
+        requires = ("doc._.fancy",)
+
+    pipeline = [("fancifier", Fancifier()), ("needer", FancyNeeder())]
+    counts = _count_pipeline_inter_dependencies(pipeline)
+    assert counts == [1, 0]

--- a/spacy/tests/pipeline/test_pipe_methods.py
+++ b/spacy/tests/pipeline/test_pipe_methods.py
@@ -1,5 +1,5 @@
 import pytest
-from spacy.language import Language, _count_pipeline_inter_dependencies
+from spacy.language import Language
 
 
 @pytest.fixture
@@ -198,19 +198,3 @@ def test_pipe_labels(nlp):
     assert len(nlp.pipe_labels) == len(input_labels)
     for name, labels in nlp.pipe_labels.items():
         assert sorted(input_labels[name]) == sorted(labels)
-
-
-def test_pipe_inter_dependencies():
-    class Fancifier:
-        name = "fancifier"
-        assigns = ("doc._.fancy",)
-        requires = tuple()
-    
-    class FancyNeeder:
-        name = "needer"
-        assigns = tuple()
-        requires = ("doc._.fancy",)
-
-    pipeline = [("fancifier", Fancifier()), ("needer", FancyNeeder())]
-    counts = _count_pipeline_inter_dependencies(pipeline)
-    assert counts == [1, 0]


### PR DESCRIPTION
During `nlp.update`, components can be passed a boolean set_annotations
to indicate whether they should assign annotations to the `Doc`. This
needs to be called if downstream components expect to use the
annotations during training, e.g. if we wanted to use tagger features in
the parser.

Components can specify their assignments and requirements, so we can
figure out which components have these inter-dependencies. After
figuring this out, we can guess whether to pass set_annotations=True.

We could also call `set_annotations=True` always, or even just have this
as the only behaviour. The downside of this is that it would require the
`Doc` objects to be created afresh to avoid problematic modifications.
One approach would be to make a fresh copy of the `Doc` objects within
`nlp.update()`, so that we can write to the objects without any
problems. If we do that, we can drop this logic and also drop the
`set_annotations` mechanism. I would be fine with that approach,
although it runs the risk of introducing some performance overhead, and
we'll have to take care to copy all extension attributes etc.

The current PR should be fine for experimenting during `spacy-nightly`. We
can decide to opt for the always-set-annotations approach prior
to release if we want.

- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
