### PR TITLE
Simplify is_package check for installed model packages

### DIFF
--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -5,6 +5,7 @@ import sys
 from wasabi import msg
 
 from .. import about
+from ..util import is_package
 
 
 def download(
@@ -17,7 +18,7 @@ def download(
     flag is set, the command expects the full model name with version.
     For direct downloads, the compatibility check will be skipped.
     """
-    if not require_package("spacy") and "--no-deps" not in pip_args:
+    if not is_package("spacy") and "--no-deps" not in pip_args:
         msg.warn(
             "Skipping model package dependencies and setting `--no-deps`. "
             "You don't seem to have the spaCy package itself installed "
@@ -45,21 +46,6 @@ def download(
             "Download and installation successful",
             f"You can now load the model via spacy.load('{model_name}')",
         )
-        # If a model is downloaded and then loaded within the same process, our
-        # is_package check currently fails, because pkg_resources.working_set
-        # is not refreshed automatically (see #3923). We're trying to work
-        # around this here be requiring the package explicitly.
-        require_package(model_name)
-
-
-def require_package(name):
-    try:
-        import pkg_resources
-
-        pkg_resources.working_set.require(name)
-        return True
-    except:  # noqa: E722
-        return False
 
 
 def get_json(url, desc):

--- a/spacy/tests/test_misc.py
+++ b/spacy/tests/test_misc.py
@@ -26,10 +26,12 @@ def test_util_ensure_path_succeeds(text):
     assert isinstance(path, Path)
 
 
-@pytest.mark.parametrize("package", ["numpy"])
-def test_util_is_package(package):
+@pytest.mark.parametrize(
+    "package,result", [("numpy", True), ("sfkodskfosdkfpsdpofkspdof", False)]
+)
+def test_util_is_package(package, result):
     """Test that an installed package via pip is recognised by util.is_package."""
-    assert util.is_package(package)
+    assert util.is_package(package) is result
 
 
 @pytest.mark.parametrize("package", ["thinc"])

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -341,14 +341,11 @@ def is_package(name):
     name (unicode): Name of package.
     RETURNS (bool): True if installed package, False if not.
     """
-    import pkg_resources
-
-    name = name.lower()  # compare package name against lowercase name
-    packages = pkg_resources.working_set.by_key.keys()
-    for package in packages:
-        if package.lower().replace("-", "_") == name:
-            return True
-    return False
+    try:
+        importlib_metadata.distribution(name)
+        return True
+    except:  # noqa: E722
+        return False
 
 
 def get_package_path(name):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Turns out this works as well, and correctly returns `True`, even if the package was installed in the same Python session 🤷‍♀️ (This wasn't the case for the `pkg_resources.working_set` approach, so it needed the `require` workaround, which in turn would do very strict requirement resolution and lead to `is_package` returning `False` if the current environment was in a bad state and had incompatible dependencies installed.)

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
