### PR TITLE
Improve model version dependency handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,11 @@ numpy>=1.15.0
 requests>=2.13.0,<3.0.0
 plac>=0.9.6,<1.2.0
 tqdm>=4.38.0,<5.0.0
-importlib_metadata>=0.20; python_version < "3.8"
 pydantic>=1.3.0,<2.0.0
+# Official Python utilities
+setuptools
+packaging
+importlib_metadata>=0.20; python_version < "3.8"
 # Development dependencies
 cython>=0.25
 pytest>=4.6.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,15 +47,16 @@ install_requires =
     wasabi>=0.4.0,<1.1.0
     srsly>=2.0.0,<3.0.0
     catalogue>=0.0.7,<1.1.0
-    ml_datasets
+    ml_datasets>=0.1.1
     # Third-party dependencies
     tqdm>=4.38.0,<5.0.0
-    setuptools
     numpy>=1.15.0
     plac>=0.9.6,<1.2.0
     requests>=2.13.0,<3.0.0
     pydantic>=1.3.0,<2.0.0
-    tqdm>=4.38.0,<5.0.0
+    # Official Python utilities
+    setuptools
+    packaging
     importlib_metadata>=0.20; python_version < "3.8"
 
 [options.extras_require]

--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -5,7 +5,7 @@ import sys
 from wasabi import msg
 
 from .. import about
-from ..util import is_package
+from ..util import is_package, get_base_version
 
 
 def download(
@@ -63,8 +63,7 @@ def get_json(url, desc):
 
 
 def get_compatibility():
-    version = about.__version__
-    version = version.rsplit(".dev", 1)[0]
+    version = get_base_version(about.__version__)
     comp_table = get_json(about.__compatibility__, "compatibility table")
     comp = comp_table["spacy"]
     if version not in comp:
@@ -73,7 +72,7 @@ def get_compatibility():
 
 
 def get_version(model, comp):
-    model = model.rsplit(".dev", 1)[0]
+    model = get_base_version(model)
     if model not in comp:
         msg.fail(
             f"No compatible model found for '{model}' (spaCy v{about.__version__})",

--- a/spacy/cli/package.py
+++ b/spacy/cli/package.py
@@ -90,7 +90,7 @@ def generate_meta(model_path, existing_meta, msg):
         ("license", "License", meta.get("license", "MIT")),
     ]
     nlp = util.load_model_from_path(Path(model_path))
-    meta["spacy_version"] = about.__version__
+    meta["spacy_version"] = util.get_model_version_range(about.__version__)
     meta["pipeline"] = nlp.pipe_names
     meta["vectors"] = {
         "width": nlp.vocab.vectors_length,
@@ -138,7 +138,7 @@ def list_files(data_dir):
 
 def list_requirements(meta):
     parent_package = meta.get('parent_package', 'spacy')
-    requirements = [parent_package + '>=' + meta['spacy_version']]
+    requirements = [parent_package + meta['spacy_version']]
     if 'setup_requires' in meta:
         requirements += meta['setup_requires']
     if 'requirements' in meta:

--- a/spacy/cli/package.py
+++ b/spacy/cli/package.py
@@ -138,7 +138,7 @@ def list_files(data_dir):
 
 def list_requirements(meta):
     parent_package = meta.get('parent_package', 'spacy')
-    requirements = [parent_package + meta['spacy_version']]
+    requirements = [parent_package + '>=' + meta['spacy_version']]
     if 'setup_requires' in meta:
         requirements += meta['setup_requires']
     if 'requirements' in meta:

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -467,7 +467,6 @@ def train(
                     # Update model meta.json
                     meta["lang"] = nlp.lang
                     meta["pipeline"] = nlp.pipe_names
-                    meta["spacy_version"] = about.__version__
                     if beam_width == 1:
                         meta["speed"] = {
                             "nwords": nwords,

--- a/spacy/cli/validate.py
+++ b/spacy/cli/validate.py
@@ -5,7 +5,7 @@ from wasabi import msg
 
 from .. import about
 from ..util import get_package_version, get_installed_models, get_base_version
-from ..util import get_package_path, get_model_meta, is_compatible_model
+from ..util import get_package_path, get_model_meta, is_compatible_version
 
 
 def validate():
@@ -83,7 +83,7 @@ def get_model_pkgs():
             model_path = get_package_path(package)
             model_meta = get_model_meta(model_path)
             spacy_version = model_meta.get("spacy_version", "n/a")
-            is_compat = is_compatible_model(spacy_version)
+            is_compat = is_compatible_version(about.__version__, spacy_version)
         pkgs[pkg_name] = {
             "name": package,
             "version": version,

--- a/spacy/cli/validate.py
+++ b/spacy/cli/validate.py
@@ -4,7 +4,7 @@ import requests
 from wasabi import msg
 
 from .. import about
-from ..util import get_package_version, get_installed_models, split_version
+from ..util import get_package_version, get_installed_models, get_base_version
 from ..util import get_package_path, get_model_meta, is_compatible_model
 
 
@@ -14,7 +14,7 @@ def validate():
     with the installed models. Should be run after `pip install -U spacy`.
     """
     model_pkgs, compat = get_model_pkgs()
-    spacy_version = about.__version__.rsplit(".dev", 1)[0]
+    spacy_version = get_base_version(about.__version__)
     current_compat = compat.get(spacy_version, {})
     if not current_compat:
         msg.warn(f"No compatible models found for v{spacy_version} of spaCy")
@@ -78,13 +78,12 @@ def get_model_pkgs():
         version = get_package_version(pkg_name)
         if package in compat:
             is_compat = version in compat[package]
-            v_maj, v_min = split_version(about.__version__)
-            spacy_version = f"{v_maj}.{v_min}"
+            spacy_version = about.__version__
         else:
             model_path = get_package_path(package)
             model_meta = get_model_meta(model_path)
-            is_compat = is_compatible_model(model_meta)
             spacy_version = model_meta.get("spacy_version", "n/a")
+            is_compat = is_compatible_model(spacy_version)
         pkgs[pkg_name] = {
             "name": package,
             "version": version,

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -104,6 +104,12 @@ class Warnings(object):
             "string \"Field1=Value1,Value2|Field2=Value3\".")
 
     # TODO: fix numbering after merging develop into master
+    W095 = ("Model '{model}' ({model_version}) requires spaCy {version} and is "
+            "incompatible with the current version ({current}). This may lead "
+            "to unexpected results or runtime errors. To resolve this, "
+            "download a newer compatible model or retrain your custom model "
+            "with the current spaCy version. For more details and available "
+            "updates, run: python -m spacy validate")
     W096 = ("The method 'disable_pipes' has become deprecated - use 'select_pipes' "
             "instead.")
     W097 = ("No Model config was provided to create the '{name}' component, "

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -191,13 +191,14 @@ class Language(object):
 
     @property
     def meta(self):
+        spacy_version = util.get_model_version_range(about.__version__)
         if self.vocab.lang:
             self._meta.setdefault("lang", self.vocab.lang)
         else:
             self._meta.setdefault("lang", self.lang)
         self._meta.setdefault("name", "model")
         self._meta.setdefault("version", "0.0.0")
-        self._meta.setdefault("spacy_version", about.__version__)
+        self._meta.setdefault("spacy_version", spacy_version)
         self._meta.setdefault("description", "")
         self._meta.setdefault("author", "")
         self._meta.setdefault("email", "")

--- a/spacy/tests/test_misc.py
+++ b/spacy/tests/test_misc.py
@@ -94,16 +94,18 @@ def test_ascii_filenames():
 
 
 @pytest.mark.parametrize(
-    "version,compatible",
+    "version,constraint,compatible",
     [
-        (spacy_version, True),
-        (f">={spacy_version}", True),
-        ("2.0.0", False),
-        (">=2.0.0", True),
-        (">=1.0.0,<2.1.1", False),
-        (">=1.2.3,<4.5.6", True),
-        ("n/a", None),
+        (spacy_version, spacy_version, True),
+        (spacy_version, f">={spacy_version}", True),
+        ("3.0.0", "2.0.0", False),
+        ("3.2.1", ">=2.0.0", True),
+        ("2.2.10a1", ">=1.0.0,<2.1.1", False),
+        ("3.0.0.dev3", ">=1.2.3,<4.5.6", True),
+        ("n/a", ">=1.2.3,<4.5.6", None),
+        ("1.2.3", "n/a", None),
+        ("n/a", "n/a", None),
     ],
 )
-def test_is_compatible_model(version, compatible):
-    assert util.is_compatible_model(version) is compatible
+def test_is_compatible_version(version, constraint, compatible):
+    assert util.is_compatible_version(version, constraint) is compatible

--- a/spacy/tests/test_misc.py
+++ b/spacy/tests/test_misc.py
@@ -95,7 +95,15 @@ def test_ascii_filenames():
 
 @pytest.mark.parametrize(
     "version,compatible",
-    [(spacy_version, True), ("2.0.0", False), (">=1.2.3,<4.5.6", False)],
+    [
+        (spacy_version, True),
+        (f">={spacy_version}", True),
+        ("2.0.0", False),
+        (">=2.0.0", True),
+        (">=1.0.0,<2.1.1", False),
+        (">=1.2.3,<4.5.6", True),
+        ("n/a", None),
+    ],
 )
 def test_is_compatible_model(version, compatible):
-    assert util.is_compatible_model({"spacy_version": version}) is compatible
+    assert util.is_compatible_model(version) is compatible

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -330,6 +330,16 @@ def get_model_meta(path):
     for setting in ["lang", "name", "version"]:
         if setting not in meta or not meta[setting]:
             raise ValueError(Errors.E054.format(setting=setting))
+    if "spacy_version" in meta:
+        if not is_compatible_version(about.__version__, meta["spacy_version"]):
+            warnings.warn(
+                Warnings.W095.format(
+                    model=f"{meta['lang']}_{meta['name']}",
+                    model_version=meta["version"],
+                    version=meta["spacy_version"],
+                    current=about.__version__,
+                )
+            )
     return meta
 
 

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -238,17 +238,27 @@ def get_package_version(name):
         return None
 
 
-def is_compatible_model(constraint):
-    version = Version(about.__version__)
+def is_compatible_version(version, constraint, prereleases=True):
+    """Check if a version (e.g. "2.0.0") is compatible given a version
+    constraint (e.g. ">=1.9.0,<2.2.1"). If the constraint is a specific version,
+    it's interpreted as =={version}.
+
+    version (str): The version to check.
+    constraint (str): The constraint string.
+    prereleases (bool): Whether to allow prereleases. If set to False,
+        prerelease versions will be considered incompatible.
+    RETURNS (bool / None): Whether the version is compatible, or None if the
+        version or constraint are invalid.
+    """
+    # Handle cases where exact version is provided as constraint
     if constraint[0].isdigit():
-        # Handle cases where exact version is provided as constraint
         constraint = f"=={constraint}"
     try:
         spec = SpecifierSet(constraint)
-    except InvalidSpecifier:
+        version = Version(version)
+    except (InvalidSpecifier, InvalidVersion):
         return None
-    # Allow prereleases and dev versions
-    spec.prereleases = True
+    spec.prereleases = prereleases
     return version in spec
 
 
@@ -262,6 +272,11 @@ def get_model_version_range(spacy_version):
 
 
 def get_base_version(version):
+    """Generate the base version without any prerelease identifiers.
+
+    version (str): The version, e.g. "3.0.0.dev1".
+    RETURNS (str): The base version, e.g. "3.0.0".
+    """
     return Version(version).base_version
 
 

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -265,6 +265,15 @@ def is_compatible_model(meta):
     return True
 
 
+def get_model_version_range(version):
+    """Generate a version range like >=1.2.3,<1.3.0 based on a given spaCy
+    version. Models are always compatible across patch versions but not
+    across minor or major versions.
+    """
+    major, minor = split_version(version)
+    return f">={version},<{major}.{minor + 1}.0"
+
+
 def load_config(path, create_objects=False):
     """Load a Thinc-formatted config file, optionally filling in objects where
     the config references registry entries. See "Thinc config files" for details.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- [x] accept `spacy_version` in meta to define any version range
- [x] use `setuptools`/`packaging` ([relevant docs](https://packaging.pypa.io/en/latest/)) to parse version ranges so we know whether a model is compatible with the current version (or any version) of spaCy
- [x] generate default version ranges: current version that the model was created with, up to next minor
- [x] tidy up requirements
- [x] show warning in model loading helpers if loaded model is not compatible with current version (according to model's version specs)

### Open questions

- [ ] How do we include our backwards compatibility hack that also considers models specifying stuff like `>=2.2.2` as incompatible, even though they're _technically_ compatible?

#### Example warning

```
UserWarning: [W095] Model 'en_model' (0.0.0) requires spaCy >=3.1.0,<3.2.0 and 
is incompatible with the current version (3.0.0.dev9). This may lead to 
unexpected results or runtime errors. To resolve this, download a newer 
compatible model or retrain your custom model with the current spaCy version. 
For more details and available updates, run: python -m spacy validate
```

### Types of change

ehnancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
