### PR TITLE
fix deserialization order

### DIFF
--- a/spacy/vectors.pyx
+++ b/spacy/vectors.pyx
@@ -425,9 +425,9 @@ cdef class Vectors:
                 self.data = xp.load(str(path))
 
         serializers = OrderedDict((
-            ("key2row", load_key2row),
-            ("keys", load_keys),
             ("vectors", load_vectors),
+            ("keys", load_keys),
+            ("key2row", load_key2row),
         ))
         util.from_disk(path, serializers, [])
         self._sync_unset()


### PR DESCRIPTION
## Description

The pretrain command didn't work anymore when giving it a vectors model:

`spacy pretrain my_data.jsonl en_vectors_web_lg my_output -i 20`

gave a
```
  File "vectors.pyx", line 420, in spacy.vectors.Vectors.from_disk.load_keys
  File "vectors.pyx", line 309, in spacy.vectors.Vectors.add
ValueError: [E197] Row out of bounds, unable to add row 0 for key 64.
```

It looks like the order of deserialization was wrong - the vectors (`self.data`) needs to be loaded first?

This code hasn't changed in ages though, so why did it stop working? My best guess is that this edit https://github.com/explosion/spaCy/pull/5430/files#diff-2e6a697a4ce7f5268000e28254546b00L306 in a recent PR by @adrianeboyd fixed a bug that was hiding the current bug ?

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
