### PR TITLE
Spanish tokenizer exception and examples improvement

### DIFF
--- a/spacy/lang/es/examples.py
+++ b/spacy/lang/es/examples.py
@@ -18,5 +18,9 @@ sentences = [
     "El gato come pescado.",
     "Veo al hombre con el telescopio.",
     "La araña come moscas.",
-    "El pingüino incuba en su nido.",
+    "El pingüino incuba en su nido sobre el hielo.",
+    "¿Dónde estais?",
+    "¿Quién es el presidente Francés?",
+    "¿Dónde está encuentra la capital de Argentina?",
+    "¿Cuándo nació José de San Martín?",
 ]

--- a/spacy/lang/es/tokenizer_exceptions.py
+++ b/spacy/lang/es/tokenizer_exceptions.py
@@ -4,15 +4,24 @@ from __future__ import unicode_literals
 from ...symbols import ORTH, LEMMA, NORM, PRON_LEMMA
 
 
-_exc = {
+# Not used by default as they are only used in certains regional speech modes, left here for completeness
+_slang_exc = {
+    "pa'l": [{ORTH: "pa", LEMMA: "para"}, {ORTH: "l", LEMMA: "el", NORM: "el"}],
+    "pa'la": [{ORTH: "pa", LEMMA: "para"}, {ORTH: "la", LEMMA: "la", NORM: "la"}],
     "pal": [{ORTH: "pa", LEMMA: "para"}, {ORTH: "l", LEMMA: "el", NORM: "el"}],
     "pala": [{ORTH: "pa", LEMMA: "para"}, {ORTH: "la", LEMMA: "la", NORM: "la"}],
 }
 
+_exc = {}
+
 
 for exc_data in [
+    {ORTH: "n°", LEMMA: "número"},
+    {ORTH: "°C", LEMMA: "grados Celcius"},
     {ORTH: "aprox.", LEMMA: "aproximadamente"},
     {ORTH: "dna.", LEMMA: "docena"},
+    {ORTH: "dpto.", LEMMA: "departamento"},
+    {ORTH: "ej.", LEMMA: "ejemplo"},
     {ORTH: "esq.", LEMMA: "esquina"},
     {ORTH: "pág.", LEMMA: "página"},
     {ORTH: "p.ej.", LEMMA: "por ejemplo"},
@@ -20,6 +29,8 @@ for exc_data in [
     {ORTH: "Vd.", LEMMA: PRON_LEMMA, NORM: "usted"},
     {ORTH: "Uds.", LEMMA: PRON_LEMMA, NORM: "ustedes"},
     {ORTH: "Vds.", LEMMA: PRON_LEMMA, NORM: "ustedes"},
+    {ORTH: "vol.", NORM: "volúmen"},
+
 ]:
     _exc[exc_data[ORTH]] = [exc_data]
 
@@ -39,10 +50,14 @@ for h in range(1, 12 + 1):
 for orth in [
     "a.C.",
     "a.J.C.",
+    "d.C.",
+    "d.J.C.",
     "apdo.",
     "Av.",
     "Avda.",
     "Cía.",
+    "Dr.",
+    "Dra.",
     "EE.UU.",
     "etc.",
     "fig.",
@@ -58,8 +73,10 @@ for orth in [
     "Prof.",
     "Profa.",
     "q.e.p.d.",
+    "Q.E.P.D."
     "S.A.",
     "S.L.",
+    "S.R.L."
     "s.s.s.",
     "Sr.",
     "Sra.",

--- a/spacy/lang/es/tokenizer_exceptions.py
+++ b/spacy/lang/es/tokenizer_exceptions.py
@@ -4,14 +4,6 @@ from __future__ import unicode_literals
 from ...symbols import ORTH, LEMMA, NORM, PRON_LEMMA
 
 
-# Not used by default as they are only used in certains regional speech modes, left here for completeness
-_slang_exc = {
-    "pa'l": [{ORTH: "pa", LEMMA: "para"}, {ORTH: "l", LEMMA: "el", NORM: "el"}],
-    "pa'la": [{ORTH: "pa", LEMMA: "para"}, {ORTH: "la", LEMMA: "la", NORM: "la"}],
-    "pal": [{ORTH: "pa", LEMMA: "para"}, {ORTH: "l", LEMMA: "el", NORM: "el"}],
-    "pala": [{ORTH: "pa", LEMMA: "para"}, {ORTH: "la", LEMMA: "la", NORM: "la"}],
-}
-
 _exc = {}
 
 


### PR DESCRIPTION
Fixes #5530  Adds to #3056 

## Enhancement to lang/es tokenizer_exceptions.py and added Example sentences to lang/es/examples.py

File: spacy/lang/es/tokenizer_exceptions.py

Currently the lines 7-10 contain

```
_exc = {
    "pal": [{ORTH: "pa", LEMMA: "para"}, {ORTH: "l", LEMMA: "el", NORM: "el"}],
    "pala": [{ORTH: "pa", LEMMA: "para"}, {ORTH: "la", LEMMA: "la", NORM: "la"}],
}

```
These normalizations are "lunfardo" (slang) used in certain regions, but they can create errors in tokenization due to the actual meaning of the words, which follow:

From dle.rae.es (Real Academia Española)

"pal"
Del fr. pal, y este del lat. palus 'palo'.
1. m. Heráld. Palo o partición y mueble del escudo.
2. m. Mar. Linguete grande, y en especial, el del cabrestante.

It is basically a big stick

"pala" means shovel

I propose to put these two exceptions in another variable that can be selectively used if needed or wanted in the following alternative normalization, that would be more accurate (including the spelling pause that is made during the pronunciation):

```
_slang_exc = {
    "pa'l": [{ORTH: "pa", LEMMA: "para"}, {ORTH: "l", LEMMA: "el", NORM: "el"}],
    "pa'la": [{ORTH: "pa", LEMMA: "para"}, {ORTH: "la", LEMMA: "la", NORM: "la"}],
    "pal": [{ORTH: "pa", LEMMA: "para"}, {ORTH: "l", LEMMA: "el", NORM: "el"}],
    "pala": [{ORTH: "pa", LEMMA: "para"}, {ORTH: "la", LEMMA: "la", NORM: "la"}],
}

```


## Checklist
- [x ] I have submitted the spaCy Contributor Agreement.
- [ x] I ran the tests, and all new and existing tests passed.
- [ x] My changes don't require a change to the documentation, or if they do, I've added all required information.
