### PR TITLE
Add warning for loose version constraints

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -104,6 +104,12 @@ class Warnings(object):
             "string \"Field1=Value1,Value2|Field2=Value3\".")
 
     # TODO: fix numbering after merging develop into master
+    W094 = ("Model '{model}' ({model_version}) requires a spaCy version with "
+            "very loose constraints: {version}. This can lead to compatibility "
+            "problems as new spaCy versions are released, because the model "
+            "may say it's compatible when it's not. Consider changing the "
+            '"spacy_version" in your meta.json to a version range, '
+            "for example: {example}")
     W095 = ("Model '{model}' ({model_version}) requires spaCy {version} and is "
             "incompatible with the current version ({current}). This may lead "
             "to unexpected results or runtime errors. To resolve this, "

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -104,8 +104,8 @@ class Warnings(object):
             "string \"Field1=Value1,Value2|Field2=Value3\".")
 
     # TODO: fix numbering after merging develop into master
-    W094 = ("Model '{model}' ({model_version}) requires an under-constrained "
-            "spaCy version: {version}. This can lead to compatibility "
+    W094 = ("Model '{model}' ({model_version}) specifies an under-constrained "
+            "spaCy version requirement: {version}. This can lead to compatibility "
             "problems with older versions, or as new spaCy versions are "
             "released, because the model may say it's compatible when it's "
             'not. Consider changing the "spacy_version" in your meta.json to a '

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -104,12 +104,12 @@ class Warnings(object):
             "string \"Field1=Value1,Value2|Field2=Value3\".")
 
     # TODO: fix numbering after merging develop into master
-    W094 = ("Model '{model}' ({model_version}) requires a spaCy version with "
-            "very loose constraints: {version}. This can lead to compatibility "
-            "problems as new spaCy versions are released, because the model "
-            "may say it's compatible when it's not. Consider changing the "
-            '"spacy_version" in your meta.json to a version range, '
-            "for example: {example}")
+    W094 = ("Model '{model}' ({model_version}) requires an under-constrained "
+            "spaCy version: {version}. This can lead to compatibility "
+            "problems with older versions, or as new spaCy versions are "
+            "released, because the model may say it's compatible when it's "
+            'not. Consider changing the "spacy_version" in your meta.json to a '
+            "version range, with a lower and upper pin. For example: {example}")
     W095 = ("Model '{model}' ({model_version}) requires spaCy {version} and is "
             "incompatible with the current version ({current}). This may lead "
             "to unexpected results or runtime errors. To resolve this, "

--- a/spacy/tests/test_misc.py
+++ b/spacy/tests/test_misc.py
@@ -109,3 +109,21 @@ def test_ascii_filenames():
 )
 def test_is_compatible_version(version, constraint, compatible):
     assert util.is_compatible_version(version, constraint) is compatible
+
+
+@pytest.mark.parametrize(
+    "constraint,expected",
+    [
+        ("3.0.0", False),
+        ("==3.0.0", False),
+        (">=2.3.0", True),
+        (">2.0.0", True),
+        ("<=2.0.0", True),
+        (">2.0.0,<3.0.0", False),
+        (">=2.0.0,<3.0.0", False),
+        ("!=1.1,>=1.0,~=1.0", True),
+        ("n/a", None),
+    ],
+)
+def test_is_unconstrained_version(constraint, expected):
+    assert util.is_unconstrained_version(constraint) is expected

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -262,6 +262,31 @@ def is_compatible_version(version, constraint, prereleases=True):
     return version in spec
 
 
+def is_unconstrained_version(constraint, prereleases=True):
+    # We have an exact version, this is the ultimate constrained version
+    if constraint[0].isdigit():
+        return False
+    try:
+        spec = SpecifierSet(constraint)
+    except InvalidSpecifier:
+        return None
+    spec.prereleases = prereleases
+    specs = [sp for sp in spec]
+    # We only have one version spec and it defines > or >=
+    if len(specs) == 1 and specs[0].operator in (">", ">="):
+        return True
+    # One specifier is exact version
+    if any(sp.operator in ("==") for sp in specs):
+        return False
+    has_upper = any(sp.operator in ("<", "<=") for sp in specs)
+    has_lower = any(sp.operator in (">", ">=") for sp in specs)
+    # We have a version spec that defines an upper and lower bound
+    if has_upper and has_lower:
+        return False
+    # Everything else, like only an upper version, only a lower version etc.
+    return True
+
+
 def get_model_version_range(spacy_version):
     """Generate a version range like >=1.2.3,<1.3.0 based on a given spaCy
     version. Models are always compatible across patch versions but not
@@ -332,14 +357,21 @@ def get_model_meta(path):
             raise ValueError(Errors.E054.format(setting=setting))
     if "spacy_version" in meta:
         if not is_compatible_version(about.__version__, meta["spacy_version"]):
-            warnings.warn(
-                Warnings.W095.format(
-                    model=f"{meta['lang']}_{meta['name']}",
-                    model_version=meta["version"],
-                    version=meta["spacy_version"],
-                    current=about.__version__,
-                )
+            warn_msg = Warnings.W095.format(
+                model=f"{meta['lang']}_{meta['name']}",
+                model_version=meta["version"],
+                version=meta["spacy_version"],
+                current=about.__version__,
             )
+            warnings.warn(warn_msg)
+        if is_unconstrained_version(meta["spacy_version"]):
+            warn_msg = Warnings.W094.format(
+                model=f"{meta['lang']}_{meta['name']}",
+                model_version=meta["version"],
+                version=meta["spacy_version"],
+                example=get_model_version_range(about.__version__),
+            )
+            warnings.warn(warn_msg)
     return meta
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Show a warning if a model specifies a "loose" version constraint / unconstrained version / however we want to call it. Basically things like `>=3.0.0`, which means that the model will inevitably become incompatible (while still officially reporting that it is compatible). This case should only happen if a user manually edits the `meta.json` or if the version is old (v2.x). 

Wording could be improved here... communicating the point is a bit difficult.

### Example warning

```
UserWarning: [W094] Model 'en_model' (0.0.0) requires a spaCy version with very 
loose constraints: >=2.1.0. This can lead to compatibility problems as new 
spaCy versions are released, because the model may say it's compatible when it's 
not. Consider changing the "spacy_version" in your meta.json to a version range, 
for example: >=3.0.0.dev9,<3.1.0
```


### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
