### PR TITLE
Added Langauge Examples

### DIFF
--- a/.github/contributors/aj-medianet.md
+++ b/.github/contributors/aj-medianet.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI GmbH](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           | Andrew Joseph        |
+| Company name (if applicable)   |                      |
+| Title or role (if applicable)  |                      |
+| Date                           | June 4, 2020         |
+| GitHub username                | aj-medianet          |
+| Website (optional)             | aj-media.net         |

--- a/spacy/lang/af/examples.py
+++ b/spacy/lang/af/examples.py
@@ -1,0 +1,22 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+
+"""
+Example sentences to test spaCy and its language models.
+
+>>> from spacy.lang.en.examples import sentences
+>>> docs = nlp.pipe(sentences)
+"""
+
+
+sentences = [
+    "Apple wil die Britse onderneming vir $ 1 miljard koop",
+    "Outonome motors verskuif die versekeringsaanspreeklikheid teenoor vervaardigers",
+    "San Francisco oorweeg dit om afleweringsrobotte op sypaadjies te verbied",
+    "Londen is 'n groot stad in die Verenigde Koninkryk.",
+    "Waar is jy?",
+    "Wie is die president van Frankryk?",
+    "Wat is die hoofstad van die Verenigde State?",
+    "Wanneer is Barack Obama gebore?",
+]

--- a/spacy/lang/cs/examples.py
+++ b/spacy/lang/cs/examples.py
@@ -1,0 +1,22 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+
+"""
+Example sentences to test spaCy and its language models.
+
+>>> from spacy.lang.en.examples import sentences
+>>> docs = nlp.pipe(sentences)
+"""
+
+
+sentences = [
+    "Apple hledá nákup U.K. za 1 miliardu dolarů",
+    "Autonomní auta přesouvají pojištění na výrobce",
+    "San Francisco zvažuje zákaz robotů pro chodce",
+    "Londýn je velké město ve Velké Británii.",
+    "Kde jsi?",
+    "Kdo je prezidentem Francie?",
+    "Jaké je hlavní město Spojených států?",
+    "Kdy se narodil Barack Obama?",
+]

--- a/spacy/lang/ga/examples.py
+++ b/spacy/lang/ga/examples.py
@@ -1,0 +1,22 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+
+"""
+Example sentences to test spaCy and its language models.
+
+>>> from spacy.lang.en.examples import sentences
+>>> docs = nlp.pipe(sentences)
+"""
+
+
+sentences = [
+    "Tá Apple ag féachaint le tosaithe U.K. a cheannach ar $ 1 billiún",
+    "Athraíonn gluaisteáin uathrialacha dliteanas árachais i dtreo déantúsóirí",
+    "Measann San Francisco robots seachadta taobhlíne a thoirmeasc",
+    "Is cathair mhór í Londain sa Ríocht Aontaithe.",
+    "Cá bhfuil tú?",
+    "Cé hé uachtarán na Fraince?",
+    "Cad é príomhchathair na Stát Aontaithe?",
+    "Cathain a rugadh Barack Obama?",
+]

--- a/spacy/lang/is/examples.py
+++ b/spacy/lang/is/examples.py
@@ -1,0 +1,22 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+
+"""
+Example sentences to test spaCy and its language models.
+
+>>> from spacy.lang.en.examples import sentences
+>>> docs = nlp.pipe(sentences)
+"""
+
+
+sentences = [
+    "Apple er að skoða að kaupa bandarískt gangsetning fyrir einn milljarð dala",
+    "Sjálfstæðir bílar færa ábyrgðartryggingu gagnvart framleiðendum",
+    "San Francisco íhugar að banna afhendingu vélmenni á gangstéttum",
+    "London er stór borg í Bretlandi.",
+    "Hvar ertu?",
+    "Hver er forseti Frakklands?",
+    "Hver er höfuðborg Bandaríkjanna?",
+    "Hvenær fæddist Barack Obama?",
+]

--- a/spacy/lang/lv/examples.py
+++ b/spacy/lang/lv/examples.py
@@ -1,0 +1,22 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+
+"""
+Example sentences to test spaCy and its language models.
+
+>>> from spacy.lang.en.examples import sentences
+>>> docs = nlp.pipe(sentences)
+"""
+
+
+sentences = [
+    "Apple vēlas iegādāties Apvienotās Karalistes sākumcenu par USD 1 miljardu",
+    "Autonomās automašīnas nodod apdrošināšanas atbildību ražotājiem",
+    "Sanfrancisko apsver iespēju aizliegt ietvju piegādes robotus",
+    "Londona ir liela Apvienotās Karalistes pilsēta.",
+    "Kur tu esi?",
+    "Kas ir Francijas prezidents?",
+    "Kāda ir Amerikas Savienoto Valstu galvaspilsēta?",
+    "Kad dzimis Baraks Obama?",
+]

--- a/spacy/lang/sl/examples.py
+++ b/spacy/lang/sl/examples.py
@@ -1,0 +1,22 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+
+"""
+Example sentences to test spaCy and its language models.
+
+>>> from spacy.lang.en.examples import sentences
+>>> docs = nlp.pipe(sentences)
+"""
+
+
+sentences = [
+    "Apple išče nakup ameriškega zagona za milijardo dolarjev",
+    "Avtonomni avtomobili zavarovalno odgovornost preusmerijo na proizvajalce",
+    "San Francisco razmišlja o prepovedi robov za dostavo pločnikov",
+    "London je veliko mesto v Veliki Britaniji.",
+    "Kje si?",
+    "Kdo je predsednik Francije?",
+    "Kakšno je glavno mesto ZDA?",
+    "Kdaj se je rodil Barack Obama?",
+]

--- a/spacy/lang/vi/examples.py
+++ b/spacy/lang/vi/examples.py
@@ -1,0 +1,22 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+
+"""
+Example sentences to test spaCy and its language models.
+
+>>> from spacy.lang.en.examples import sentences
+>>> docs = nlp.pipe(sentences)
+"""
+
+
+sentences = [
+    "Apple đang xem xét việc mua công ty khởi nghiệp ở Vương quốc Anh với giá 1 tỷ đô la",
+    "Xe tự hành thay đổi trách nhiệm bảo hiểm đối với các nhà sản xuất",
+    "San Francisco xem xét việc cấm robot giao hàng vỉa hè",
+    "London là một thành phố lớn ở Vương quốc Anh.",
+    "Bạn ở đâu?",
+    "Tổng thống Pháp là ai?",
+    "Thủ đô của Hoa Kỳ là gì?",
+    "Barack Obama được sinh ra khi nào?",
+]


### PR DESCRIPTION
I added language examples for Vietnamese, Czech, Irish, Icelandic, Afrikaans, Latvian and Slovenian.

## Description
I based my translations off of lang/en/examples.py and used google translate.  I was unsure if I needed to run tests for this pull request, I ran 'python3 -m pytest tests/lang' and got the same results before and after I added my examples.

### Types of change
Enhancement - adding example sentences for testing languages 

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
