### PR TITLE
Refactored util.py Registry class to use CamelCase for class name

### DIFF
--- a/.github/contributors/aj-medianet.md
+++ b/.github/contributors/aj-medianet.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI GmbH](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [ ] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           | Andrew Joseph        |
+| Company name (if applicable)   |                      |
+| Title or role (if applicable)  |                      |
+| Date                           | June 4, 2020         |
+| GitHub username                | aj-medianet          |
+| Website (optional)             | aj-media.net         |

--- a/spacy/__init__.py
+++ b/spacy/__init__.py
@@ -15,7 +15,7 @@ from .glossary import explain
 from .about import __version__
 from .errors import Errors, Warnings
 from . import util
-from .util import registry
+from .util import Registry
 from .language import component
 
 

--- a/spacy/displacy/render.py
+++ b/spacy/displacy/render.py
@@ -11,7 +11,7 @@ from .templates import (
     TPL_ENTS,
 )
 from .templates import TPL_ENT, TPL_ENT_RTL, TPL_FIGURE, TPL_TITLE, TPL_PAGE
-from ..util import minify_html, escape_html, registry
+from ..util import minify_html, escape_html, Registry
 from ..errors import Errors
 
 
@@ -257,7 +257,7 @@ class EntityRenderer(object):
             "CARDINAL": "#e4e7d2",
             "PERCENT": "#e4e7d2",
         }
-        user_colors = registry.displacy_colors.get_all()
+        user_colors = Registry.displacy_colors.get_all()
         for user_color in user_colors.values():
             colors.update(user_color)
         colors.update(options.get("colors", {}))

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -54,8 +54,8 @@ class BaseDefaults(object):
         filenames = {name: root / filename for name, filename in cls.resources}
         if LANG in cls.lex_attr_getters:
             lang = cls.lex_attr_getters[LANG](None)
-            if lang in util.registry.lookups:
-                filenames.update(util.registry.lookups.get(lang))
+            if lang in util.Registry.lookups:
+                filenames.update(util.Registry.lookups.get(lang))
         lookups = Lookups()
         for name, filename in filenames.items():
             data = util.load_language_data(filename)
@@ -166,7 +166,7 @@ class Language(object):
             100,000 characters in one text.
         RETURNS (Language): The newly constructed object.
         """
-        user_factories = util.registry.factories.get_all()
+        user_factories = util.Registry.factories.get_all()
         self.factories.update(user_factories)
         self._meta = dict(meta)
         self._path = None

--- a/spacy/ml/common.py
+++ b/spacy/ml/common.py
@@ -3,10 +3,10 @@ from __future__ import unicode_literals
 from thinc.api import chain
 from thinc.v2v import Maxout
 from thinc.misc import LayerNorm
-from ..util import registry, make_layer
+from ..util import Registry, make_layer
 
 
-@registry.architectures.register("thinc.FeedForward.v1")
+@Registry.architectures.register("thinc.FeedForward.v1")
 def FeedForward(config):
     layers = [make_layer(layer_cfg) for layer_cfg in config["layers"]]
     model = chain(*layers)
@@ -14,7 +14,7 @@ def FeedForward(config):
     return model
 
 
-@registry.architectures.register("spacy.LayerNormalizedMaxout.v1")
+@Registry.architectures.register("spacy.LayerNormalizedMaxout.v1")
 def LayerNormalizedMaxout(config):
     width = config["width"]
     pieces = config["pieces"]

--- a/spacy/ml/tok2vec.py
+++ b/spacy/ml/tok2vec.py
@@ -6,11 +6,11 @@ from thinc.v2v import Maxout, Model
 from thinc.i2v import HashEmbed, StaticVectors
 from thinc.t2t import ExtractWindow
 from thinc.misc import Residual, LayerNorm, FeatureExtracter
-from ..util import make_layer, registry
+from ..util import make_layer, Registry
 from ._wire import concatenate_lists
 
 
-@registry.architectures.register("spacy.Tok2Vec.v1")
+@Registry.architectures.register("spacy.Tok2Vec.v1")
 def Tok2Vec(config):
     doc2feats = make_layer(config["@doc2feats"])
     embed = make_layer(config["@embed"])
@@ -24,13 +24,13 @@ def Tok2Vec(config):
     return tok2vec
 
 
-@registry.architectures.register("spacy.Doc2Feats.v1")
+@Registry.architectures.register("spacy.Doc2Feats.v1")
 def Doc2Feats(config):
     columns = config["columns"]
     return FeatureExtracter(columns)
 
 
-@registry.architectures.register("spacy.MultiHashEmbed.v1")
+@Registry.architectures.register("spacy.MultiHashEmbed.v1")
 def MultiHashEmbed(config):
     # For backwards compatibility with models before the architecture registry,
     # we have to be careful to get exactly the same model structure. One subtle
@@ -78,7 +78,7 @@ def MultiHashEmbed(config):
     return layer
 
 
-@registry.architectures.register("spacy.CharacterEmbed.v1")
+@Registry.architectures.register("spacy.CharacterEmbed.v1")
 def CharacterEmbed(config):
     from .. import _ml
 
@@ -94,7 +94,7 @@ def CharacterEmbed(config):
     return model
 
 
-@registry.architectures.register("spacy.MaxoutWindowEncoder.v1")
+@Registry.architectures.register("spacy.MaxoutWindowEncoder.v1")
 def MaxoutWindowEncoder(config):
     nO = config["width"]
     nW = config["window_size"]
@@ -110,7 +110,7 @@ def MaxoutWindowEncoder(config):
     return model
 
 
-@registry.architectures.register("spacy.MishWindowEncoder.v1")
+@Registry.architectures.register("spacy.MishWindowEncoder.v1")
 def MishWindowEncoder(config):
     from thinc.v2v import Mish
 
@@ -124,12 +124,12 @@ def MishWindowEncoder(config):
     return model
 
 
-@registry.architectures.register("spacy.PretrainedVectors.v1")
+@Registry.architectures.register("spacy.PretrainedVectors.v1")
 def PretrainedVectors(config):
     return StaticVectors(config["vectors_name"], config["width"], config["column"])
 
 
-@registry.architectures.register("spacy.TorchBiLSTMEncoder.v1")
+@Registry.architectures.register("spacy.TorchBiLSTMEncoder.v1")
 def TorchBiLSTMEncoder(config):
     import torch.nn
     from thinc.extra.wrappers import PyTorchWrapperRNN

--- a/spacy/tests/test_architectures.py
+++ b/spacy/tests/test_architectures.py
@@ -2,18 +2,18 @@
 from __future__ import unicode_literals
 
 import pytest
-from spacy import registry
+from spacy import Registry
 from thinc.v2v import Affine
 from catalogue import RegistryError
 
 
-@registry.architectures.register("my_test_function")
+@Registry.architectures.register("my_test_function")
 def create_model(nr_in, nr_out):
     return Affine(nr_in, nr_out)
 
 
 def test_get_architecture():
-    arch = registry.architectures.get("my_test_function")
+    arch = Registry.architectures.get("my_test_function")
     assert arch is create_model
     with pytest.raises(RegistryError):
-        registry.architectures.get("not_an_existing_key")
+        Registry.architectures.get("not_an_existing_key")

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -40,7 +40,7 @@ _PRINT_ENV = False
 OOV_RANK = numpy.iinfo(numpy.uint64).max
 
 
-class registry(object):
+class Registry(object):
     languages = catalogue.create("spacy", "languages", entry_points=True)
     architectures = catalogue.create("spacy", "architectures", entry_points=True)
     lookups = catalogue.create("spacy", "lookups", entry_points=True)
@@ -61,7 +61,7 @@ def lang_class_is_loaded(lang):
     lang (unicode): Two-letter language code, e.g. 'en'.
     RETURNS (bool): Whether a Language class has been loaded.
     """
-    return lang in registry.languages
+    return lang in Registry.languages
 
 
 def get_lang_class(lang):
@@ -71,15 +71,15 @@ def get_lang_class(lang):
     RETURNS (Language): Language class.
     """
     # Check if language is registered / entry point is available
-    if lang in registry.languages:
-        return registry.languages.get(lang)
+    if lang in Registry.languages:
+        return Registry.languages.get(lang)
     else:
         try:
             module = importlib.import_module(".lang.%s" % lang, "spacy")
         except ImportError as err:
             raise ImportError(Errors.E048.format(lang=lang, err=err))
         set_lang_class(lang, getattr(module, module.__all__[0]))
-    return registry.languages.get(lang)
+    return Registry.languages.get(lang)
 
 
 def set_lang_class(name, cls):
@@ -88,7 +88,7 @@ def set_lang_class(name, cls):
     name (unicode): Name of Language class.
     cls (Language): Language class.
     """
-    registry.languages.register(name, func=cls)
+    Registry.languages.register(name, func=cls)
 
 
 def get_data_path(require_exists=True):
@@ -113,7 +113,7 @@ def set_data_path(path):
 
 
 def make_layer(arch_config):
-    arch_func = registry.architectures.get(arch_config["arch"])
+    arch_func = Registry.architectures.get(arch_config["arch"])
     return arch_func(arch_config["config"])
 
 

--- a/spacy/vocab.pyx
+++ b/spacy/vocab.pyx
@@ -546,8 +546,8 @@ cdef class Vocab:
 
     def load_extra_lookups(self, table_name):
         if table_name not in self.lookups_extra:
-            if self.lang + "_extra" in util.registry.lookups:
-                tables = util.registry.lookups.get(self.lang + "_extra")
+            if self.lang + "_extra" in util.Registry.lookups:
+                tables = util.Registry.lookups.get(self.lang + "_extra")
                 for name, filename in tables.items():
                     if table_name == name:
                         data = util.load_language_data(filename)


### PR DESCRIPTION
I refactored the util.py file because the Registry class was not using CamelCase.

## Description
I used PyCharm IDE to refactor util.py and all of the references to the registry class. I ran the full test suite before and after I refactored and got the same results. 

### Types of change
Style Enhancement? It's not really a bug or a problem, it just wasn't adhering to the style guidelines of Python.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [X] I have submitted the spaCy Contributor Agreement.
- [X] I ran the tests, and all new and existing tests passed.
- [X] My changes don't require a change to the documentation, or if they do, I've added all required information.
