### PR TITLE
Added Parameter to NEL to take n sentences into account

### DIFF
--- a/.github/contributors/theudas.md
+++ b/.github/contributors/theudas.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI UG (haftungsbeschränkt)](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your 
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                    |
+|------------------------------- | ------------------------ |
+| Name                           | Philipp Sodmann          |
+| Company name (if applicable)   | Empolis                  |
+| Title or role (if applicable)  |                          |
+| Date                           | 2017-05-06               |
+| GitHub username                | theudas                  |
+| Website (optional)             |                          |

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -1243,24 +1243,24 @@ class EntityLinker(Pipe):
                         try:
                             # find the sentence in the list of sentences.
                             sent_index = sentences.index(ent.sent)
-                            
-                            # get n previous sentences, if there are any
-                            start_sentence = max(0, sent_index - self.n_sents)
-
-                            # get n posterior sentences, or as many < n as there are
-                            end_sentence = min(len(sentences) -1, sent_index + self.n_sents)
-
-                            # get token positions
-                            start_token = sentences[start_sentence].start
-                            end_token = sentences[end_sentence].end
-
-                            # append that span as a doc to training
-                            sent_doc = doc[start_token:end_token].as_doc()
-                            sentence_docs.append(sent_doc)
 
                         except AttributeError:
                             # Catch the exception when ent.sent is None and provide a user-friendly warning
                             raise RuntimeError(Errors.E030)
+
+                        # get n previous sentences, if there are any
+                        start_sentence = max(0, sent_index - self.n_sents)
+
+                        # get n posterior sentences, or as many < n as there are
+                        end_sentence = min(len(sentences) -1, sent_index + self.n_sents)
+
+                        # get token positions
+                        start_token = sentences[start_sentence].start
+                        end_token = sentences[end_sentence].end
+
+                        # append that span as a doc to training
+                        sent_doc = doc[start_token:end_token].as_doc()
+                        sentence_docs.append(sent_doc)   
 
         sentence_encodings, bp_context = self.model.begin_update(sentence_docs, drop=drop)
         loss, d_scores = self.get_similarity_loss(scores=sentence_encodings, golds=golds, docs=None)

--- a/spacy/pipeline/pipes.pyx
+++ b/spacy/pipeline/pipes.pyx
@@ -1221,6 +1221,9 @@ class EntityLinker(Pipe):
 
         for doc, gold in zip(docs, golds):
             ents_by_offset = dict()
+
+            sentences = [s for s in doc.sents]
+
             for ent in doc.ents:
                 ents_by_offset[(ent.start_char, ent.end_char)] = ent
 
@@ -1231,13 +1234,30 @@ class EntityLinker(Pipe):
                 # the gold annotations should link to proper entities - if this fails, the dataset is likely corrupt
                 if not (start, end) in ents_by_offset:
                     raise RuntimeError(Errors.E188)
+
                 ent = ents_by_offset[(start, end)]
 
                 for kb_id, value in kb_dict.items():
                     # Currently only training on the positive instances
                     if value:
                         try:
-                            sentence_docs.append(ent.sent.as_doc())
+                            # find the sentence in the list of sentences.
+                            sent_index = sentences.index(ent.sent)
+                            
+                            # get n previous sentences, if there are any
+                            start_sentence = max(0, sent_index - self.n_sents)
+
+                            # get n posterior sentences, or as many < n as there are
+                            end_sentence = min(len(sentences) -1, sent_index + self.n_sents)
+
+                            # get token positions
+                            start_token = sentences[start_sentence].start
+                            end_token = sentences[end_sentence].end
+
+                            # append that span as a doc to training
+                            sent_doc = doc[start_token:end_token].as_doc()
+                            sentence_docs.append(sent_doc)
+
                         except AttributeError:
                             # Catch the exception when ent.sent is None and provide a user-friendly warning
                             raise RuntimeError(Errors.E030)
@@ -1312,7 +1332,6 @@ class EntityLinker(Pipe):
         if isinstance(docs, Doc):
             docs = [docs]
 
-        
 
         for i, doc in enumerate(docs):
             sentences = [s for s in doc.sents]
@@ -1321,72 +1340,73 @@ class EntityLinker(Pipe):
                 # Looping through each sentence and each entity
                 # This may go wrong if there are entities across sentences - which shouldn't happen normally.
                 for sent_index, sent in enumerate(sentences):
-                    # get n_neightbour sentences, clipped to the length of the document
-                    start_sentence = max(0, sent_index - self.n_sents)
-                    end_sentence = min(len(sentences) -1, sent_index + self.n_sents)
+                    if sent.ents:
+                        # get n_neightbour sentences, clipped to the length of the document
+                        start_sentence = max(0, sent_index - self.n_sents)
+                        end_sentence = min(len(sentences) -1, sent_index + self.n_sents)
 
-                    start_token = sentences[start_sentence].start
-                    end_token = sentences[end_sentence].end
+                        start_token = sentences[start_sentence].start
+                        end_token = sentences[end_sentence].end
 
-                    sent_doc = doc[start_token:end_token].as_doc()
+                        sent_doc = doc[start_token:end_token].as_doc()
 
-                    # currently, the context is the same for each entity in a sentence (should be refined)
-                    sentence_encoding = self.model([sent_doc])[0]
-                    xp = get_array_module(sentence_encoding)
-                    sentence_encoding_t = sentence_encoding.T
-                    sentence_norm = xp.linalg.norm(sentence_encoding_t)
+                        # currently, the context is the same for each entity in a sentence (should be refined)
+                        sentence_encoding = self.model([sent_doc])[0]
+                        xp = get_array_module(sentence_encoding)
+                        sentence_encoding_t = sentence_encoding.T
+                        sentence_norm = xp.linalg.norm(sentence_encoding_t)
 
-                    for ent in sent.ents:
-                        entity_count += 1
+                        for ent in sent.ents:
+                            entity_count += 1
 
-                        to_discard = self.cfg.get("labels_discard", [])
-                        if to_discard and ent.label_ in to_discard:
-                            # ignoring this entity - setting to NIL
-                            final_kb_ids.append(self.NIL)
-                            final_tensors.append(sentence_encoding)
-
-                        else:
-                            candidates = self.kb.get_candidates(ent.text)
-                            if not candidates:
-                                # no prediction possible for this entity - setting to NIL
+                            to_discard = self.cfg.get("labels_discard", [])
+                            if to_discard and ent.label_ in to_discard:
+                                # ignoring this entity - setting to NIL
                                 final_kb_ids.append(self.NIL)
                                 final_tensors.append(sentence_encoding)
 
-                            elif len(candidates) == 1:
-                                # shortcut for efficiency reasons: take the 1 candidate
-
-                                # TODO: thresholding
-                                final_kb_ids.append(candidates[0].entity_)
-                                final_tensors.append(sentence_encoding)
-
                             else:
-                                random.shuffle(candidates)
+                                candidates = self.kb.get_candidates(ent.text)
+                                if not candidates:
+                                    # no prediction possible for this entity - setting to NIL
+                                    final_kb_ids.append(self.NIL)
+                                    final_tensors.append(sentence_encoding)
 
-                                # this will set all prior probabilities to 0 if they should be excluded from the model
-                                prior_probs = xp.asarray([c.prior_prob for c in candidates])
-                                if not self.cfg.get("incl_prior", True):
-                                    prior_probs = xp.asarray([0.0 for c in candidates])
-                                scores = prior_probs
+                                elif len(candidates) == 1:
+                                    # shortcut for efficiency reasons: take the 1 candidate
 
-                                # add in similarity from the context
-                                if self.cfg.get("incl_context", True):
-                                    entity_encodings = xp.asarray([c.entity_vector for c in candidates])
-                                    entity_norm = xp.linalg.norm(entity_encodings, axis=1)
+                                    # TODO: thresholding
+                                    final_kb_ids.append(candidates[0].entity_)
+                                    final_tensors.append(sentence_encoding)
 
-                                    if len(entity_encodings) != len(prior_probs):
-                                        raise RuntimeError(Errors.E147.format(method="predict", msg="vectors not of equal length"))
+                                else:
+                                    random.shuffle(candidates)
 
-                                    # cosine similarity
-                                    sims = xp.dot(entity_encodings, sentence_encoding_t) / (sentence_norm * entity_norm)
-                                    if sims.shape != prior_probs.shape:
-                                        raise ValueError(Errors.E161)
-                                    scores = prior_probs + sims - (prior_probs*sims)
+                                    # this will set all prior probabilities to 0 if they should be excluded from the model
+                                    prior_probs = xp.asarray([c.prior_prob for c in candidates])
+                                    if not self.cfg.get("incl_prior", True):
+                                        prior_probs = xp.asarray([0.0 for c in candidates])
+                                    scores = prior_probs
 
-                                # TODO: thresholding
-                                best_index = scores.argmax()
-                                best_candidate = candidates[best_index]
-                                final_kb_ids.append(best_candidate.entity_)
-                                final_tensors.append(sentence_encoding)
+                                    # add in similarity from the context
+                                    if self.cfg.get("incl_context", True):
+                                        entity_encodings = xp.asarray([c.entity_vector for c in candidates])
+                                        entity_norm = xp.linalg.norm(entity_encodings, axis=1)
+
+                                        if len(entity_encodings) != len(prior_probs):
+                                            raise RuntimeError(Errors.E147.format(method="predict", msg="vectors not of equal length"))
+
+                                        # cosine similarity
+                                        sims = xp.dot(entity_encodings, sentence_encoding_t) / (sentence_norm * entity_norm)
+                                        if sims.shape != prior_probs.shape:
+                                            raise ValueError(Errors.E161)
+                                        scores = prior_probs + sims - (prior_probs*sims)
+
+                                    # TODO: thresholding
+                                    best_index = scores.argmax()
+                                    best_candidate = candidates[best_index]
+                                    final_kb_ids.append(best_candidate.entity_)
+                                    final_tensors.append(sentence_encoding)
 
         if not (len(final_tensors) == len(final_kb_ids) == entity_count):
             raise RuntimeError(Errors.E147.format(method="predict", msg="result variables not of equal length"))


### PR DESCRIPTION
I am dealing with a lot of short sentences. For disambiguation, it is sometimes needed to also include the neighbor sentences.


## Description
I changed the predict method of NEL to include n_sents neighbour sentences when generating the vector for the model. There was no change to the training needed, since training ignores sentence scopes.

### Types of change
Enhancement

## Checklist
- [X] I have submitted the spaCy Contributor Agreement.
- [X] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information. (It probably needs some description.)
