### PR TITLE
bot for answered issues

### DIFF
--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: tiangolo/issue-manager@0.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-	      config: '{"answered": {
+          config: '{"answered": {
                      "delay": "P3D",
                      "message": "This issue has been automatically closed because it was answered and there was no follow-up discussion.",
                      "remove_label": false,

--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -1,0 +1,25 @@
+name: Issue Manager
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  issue_comment:
+    types:
+      - created
+      - edited
+  issues:
+    types:
+      - labeled
+
+jobs:
+  issue-manager:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tiangolo/issue-manager@0.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+	  config: '{"answered": {
+                     "delay": "P3D",
+                     "message": "This issue has been automatically closed because it was answered and there was no follow-up discussion.",
+                     "remove_label": false,
+                }}'

--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config: >
-          {
-            "answered": {
-              "delay": "P3D",
-              "message": "This issue has been automatically closed because it was answered and there was no follow-up discussion.",
-              "remove_label": true
+            {
+              "answered": {
+                "delay": "P3D",
+                "message": "This issue has been automatically closed because it was answered and there was no follow-up discussion.",
+                "remove_label": true
+              }
             }
-          }

--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -18,8 +18,11 @@ jobs:
       - uses: tiangolo/issue-manager@0.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          config: '{"answered": {
+          config: >
+          {
+            "answered": {
                      "delay": "P3D",
                      "message": "This issue has been automatically closed because it was answered and there was no follow-up discussion.",
-                     "remove_label": false,
-                }}'
+                     "remove_label": true,
+                }
+          }

--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -21,8 +21,8 @@ jobs:
           config: >
           {
             "answered": {
-                     "delay": "P3D",
-                     "message": "This issue has been automatically closed because it was answered and there was no follow-up discussion.",
-                     "remove_label": true,
-                }
+              "delay": "P3D",
+              "message": "This issue has been automatically closed because it was answered and there was no follow-up discussion.",
+              "remove_label": true
+            }
           }

--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: tiangolo/issue-manager@0.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-	  config: '{"answered": {
+	      config: '{"answered": {
                      "delay": "P3D",
                      "message": "This issue has been automatically closed because it was answered and there was no follow-up discussion.",
                      "remove_label": false,


### PR DESCRIPTION
## Description

Adding bot by @tiangolo to follow up on issues that got the label `answered`
* Currently runs at midnight
* Removes the label when someone (anyone) replies
* Automatically closes after 3 days 
* Writes a message "_This issue has been automatically closed because it was answered and there was no follow-up discussion_."

All of these parameters can be changed. Though the bot currently can't make a distinction between anyone replying, or restricting to only the original poster for instance.

This bot can be generalized to manage multiple labels. If we want it to cover also `more-info-needed` for instance, we could have a .yml file like this one: https://github.com/svlandeg/TestRepo/blob/master/.github/workflows/issue-manager.yml

Let's merge-squash these commits - JSON as a string in YAML proved to be a bit of a challenge at least for me 😇 

### Types of change
enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
