### PR TITLE
Reduce memory usage of Lookup's BloomFilter

### DIFF
--- a/.github/contributors/PluieElectrique.md
+++ b/.github/contributors/PluieElectrique.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI GmbH](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [X] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           | Pluie                |
+| Company name (if applicable)   |                      |
+| Title or role (if applicable)  |                      |
+| Date                           | 2020-06-18           |
+| GitHub username                | PluieElectrique      |
+| Website (optional)             |                      |

--- a/spacy/lookups.py
+++ b/spacy/lookups.py
@@ -121,7 +121,6 @@ class Lookups(object):
         self._tables = OrderedDict()
         for key, value in srsly.msgpack_loads(bytes_data).items():
             self._tables[key] = Table(key, value)
-            self._tables[key].update(value)
         return self
 
     def to_disk(self, path, filename="lookups.bin", **kwargs):

--- a/spacy/lookups.py
+++ b/spacy/lookups.py
@@ -120,7 +120,7 @@ class Lookups(object):
         """
         self._tables = OrderedDict()
         for key, value in srsly.msgpack_loads(bytes_data).items():
-            self._tables[key] = Table(key)
+            self._tables[key] = Table(key, value)
             self._tables[key].update(value)
         return self
 
@@ -192,7 +192,7 @@ class Table(OrderedDict):
         self.name = name
         # Assume a default size of 1M items
         self.default_size = 1e6
-        size = len(data) if data and len(data) > 0 else self.default_size
+        size = max(len(data), 1) if data is not None else self.default_size
         self.bloom = BloomFilter.from_error_rate(size)
         if data:
             self.update(data)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

When loading a model's vocab, `Lookups` creates several `Table`s. Each `Table` creates a `BloomFilter` with a default size of 1 million items. For small models, this size is too big. (This is assuming that the lookup tables are read-only and that we don't need to allocate extra space--I may be wrong about this.)

 For example, here are the sizes (`len(data)`) of `en_core_web_sm-2.3.0`'s vocab:
```
lookups.bin
    lemma_lookup: 41582
    lexeme_norm: 3506
    lemma_rules: 5
    lemma_index: 4
    lemma_exc: 4
lookups_extra.bin
    lexeme_cluster: 0
    lexeme_prob: 0
    lexeme_settings: 0
```
With a default error rate of `1e-4`, a `BloomFilter` of 1 million items takes up about 18.3 MiB, which results in a total of 146.4 MiB for the eight tables above. If we instead use the sizes of the data to hint the `BloomFilter`, we only use about 0.82 MiB.

Note: I used `max(len(data), 1)` because a divide by zero error is thrown in [`preshed.bloom.calculate_size_and_hash_count`](https://github.com/explosion/preshed/blob/985cf43445b8ab7ecb0ca78856c9446f03915253/preshed/bloom.pyx#L14) if we pass in `0` for `members`. We could do `BloomFilter(0, 0)` to use as little memory as possible, but it only saves 16 bytes over `BloomFilter.from_error_rate(1)`.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [X] I have submitted the spaCy Contributor Agreement.
- [X] I ran the tests, and all new and existing tests passed.
- [X] My changes don't require a change to the documentation, or if they do, I've added all required information.
