### PR TITLE
Skip vocab in component config overrides

### DIFF
--- a/spacy/util.py
+++ b/spacy/util.py
@@ -208,6 +208,10 @@ def load_model_from_path(model_path, meta=False, **overrides):
         pipeline = nlp.Defaults.pipe_names
     elif pipeline in (False, None):
         pipeline = []
+    # skip "vocab" from overrides in component initialization since vocab is
+    # already configured from overrides when nlp is initialized above
+    if "vocab" in overrides:
+        del overrides["vocab"]
     for name in pipeline:
         if name not in disable:
             config = meta.get("pipeline_args", {}).get(name, {})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Allowing `vocab` in overrides leads to duplicate vocab arguments when initializing components since the vocab is already configured through overrides for `nlp`, so remove it before initializing individual components.

Fixes #5620.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bug fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
