### PR TITLE
Fix polarity of Token.is_oov and Lexeme.is_oov

### DIFF
--- a/spacy/lexeme.pyx
+++ b/spacy/lexeme.pyx
@@ -349,7 +349,7 @@ cdef class Lexeme:
     @property
     def is_oov(self):
         """RETURNS (bool): Whether the lexeme is out-of-vocabulary."""
-        return self.orth in self.vocab.vectors
+        return self.orth not in self.vocab.vectors
 
     property is_stop:
         """RETURNS (bool): Whether the lexeme is a stop word."""

--- a/spacy/tests/vocab_vectors/test_vectors.py
+++ b/spacy/tests/vocab_vectors/test_vectors.py
@@ -376,6 +376,6 @@ def test_vector_is_oov():
     data[1] = 2.0
     vocab.set_vector("cat", data[0])
     vocab.set_vector("dog", data[1])
-    assert vocab["cat"].is_oov is True
-    assert vocab["dog"].is_oov is True
-    assert vocab["hamster"].is_oov is False
+    assert vocab["cat"].is_oov is False
+    assert vocab["dog"].is_oov is False
+    assert vocab["hamster"].is_oov is True

--- a/spacy/tokens/token.pyx
+++ b/spacy/tokens/token.pyx
@@ -923,7 +923,7 @@ cdef class Token:
     @property
     def is_oov(self):
         """RETURNS (bool): Whether the token is out-of-vocabulary."""
-        return self.c.lex.orth in self.vocab.vectors
+        return self.c.lex.orth not in self.vocab.vectors
 
     @property
     def is_stop(self):


### PR DESCRIPTION
Fix `Token.is_oov` and `Lexeme.is_oov` so they return `True` when the lexeme does **not** have a vector.

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
