### PR TITLE
Fixes to project CLI

### DIFF
--- a/spacy/cli/project.py
+++ b/spacy/cli/project.py
@@ -243,8 +243,8 @@ def project_clone(
             raise RuntimeError(f"Could not clone the repo '{repo}' into the temp dir '{tmp_dir}'.")
         with (tmp_dir / ".git" / "info" / "sparse-checkout").open("w") as f:
             f.write(name)
-        run_command(["git", "-C", tmp_dir, "fetch"])
-        run_command(["git", "-C", tmp_dir, "checkout"])
+        run_command(["git", "-C", str(tmp_dir), "fetch"])
+        run_command(["git", "-C", str(tmp_dir), "checkout"])
         shutil.move(str(tmp_dir / Path(name).name), str(project_dir))
     msg.good(f"Cloned project '{name}' from {repo}")
     for sub_dir in DIRS:

--- a/spacy/cli/project.py
+++ b/spacy/cli/project.py
@@ -202,7 +202,7 @@ def project_update_dvc_cli(
         msg.info(f"No changes found in {CONFIG_FILE}, no update needed")
 
 
-app.add_typer(project_cli, name="project")
+app.add_typer(project_cli, name="project", no_args_is_help=True)
 
 
 #################

--- a/spacy/cli/project.py
+++ b/spacy/cli/project.py
@@ -107,7 +107,7 @@ def project_assets_cli(
     """Use DVC (Data Version Control) to fetch project assets. Assets are
     defined in the "assets" section of the project config. If possible, DVC
     will try to track the files so you can pull changes from upstream. It will
-    also try and store the checksum so the assets are versioned. If th file
+    also try and store the checksum so the assets are versioned. If the file
     can't be tracked or checked, it will be downloaded without DVC. If a checksum
     is provided in the project config, the file is only downloaded if no local
     file with the same checksum exists.
@@ -567,7 +567,7 @@ def run_commands(
     variables (Dict[str, str]): Dictionary of variable names, mapped to their
         values. Will be used to substitute format string variables in the
         commands.
-    silent (boll): Don't print the commands.
+    silent (bool): Don't print the commands.
     """
     for command in commands:
         # Substitute variables, e.g. "./{NAME}.json"

--- a/spacy/cli/project.py
+++ b/spacy/cli/project.py
@@ -246,7 +246,7 @@ def project_clone(
         run_command(["git", "-C", str(tmp_dir), "fetch"])
         run_command(["git", "-C", str(tmp_dir), "checkout"])
         shutil.move(str(tmp_dir / Path(name).name), str(project_dir))
-    msg.good(f"Cloned project '{name}' from {repo}")
+    msg.good(f"Cloned project '{name}' from {repo} into {project_dir}")
     for sub_dir in DIRS:
         dir_path = project_dir / sub_dir
         if not dir_path.exists():
@@ -484,7 +484,7 @@ def update_dvc_config(
     path = path.resolve()
     dvc_config_path = path / DVC_CONFIG
     if dvc_config_path.exists():
-        # Cneck if the file was generated using the current config, if not, redo
+        # Check if the file was generated using the current config, if not, redo
         with dvc_config_path.open("r", encoding="utf8") as f:
             ref_hash = f.readline().strip().replace("# ", "")
         if ref_hash == config_hash and not force:
@@ -578,7 +578,7 @@ def run_commands(
     for command in commands:
         # Substitute variables, e.g. "./{NAME}.json"
         command = command.format(**variables)
-        command = shlex.split(command)
+        command = shlex.split(command, posix=not is_windows)
         # TODO: is this needed / a good idea?
         if len(command) and command[0] == "python":
             command[0] = sys.executable

--- a/spacy/cli/project.py
+++ b/spacy/cli/project.py
@@ -284,8 +284,8 @@ def project_init(
         # opt-in explicitly. If they want it, they can always enable it.
         if not analytics:
             run_command(["dvc", "config", "core.analytics", "false"])
-        config = load_project_config(project_dir)
-        setup_check_dvc(project_dir, config)
+    config = load_project_config(project_dir)
+    setup_check_dvc(project_dir, config)
 
 
 def project_assets(project_dir: Path) -> None:

--- a/spacy/cli/project.py
+++ b/spacy/cli/project.py
@@ -4,7 +4,6 @@ import srsly
 from pathlib import Path
 from wasabi import msg
 import subprocess
-import shlex
 import os
 import re
 import shutil
@@ -14,10 +13,9 @@ import tqdm
 
 from ._app import app, Arg, Opt, COMMAND, NAME
 from .. import about
-from ..compat import is_windows
 from ..schemas import ProjectConfigSchema, validate
 from ..util import ensure_path, run_command, make_tempdir, working_dir
-from ..util import get_hash, get_checksum
+from ..util import get_hash, get_checksum, split_command
 
 
 CONFIG_FILE = "project.yml"
@@ -240,7 +238,7 @@ def project_clone(
     with make_tempdir() as tmp_dir:
         cmd = f"git clone {repo} {tmp_dir} --no-checkout --depth 1 --config core.sparseCheckout=true"
         try:
-            run_command(shlex.split(cmd, posix=not is_windows))
+            run_command(split_command(cmd))
         except:
             raise RuntimeError(f"Could not clone the repo '{repo}' into the temp dir '{tmp_dir}'.")
         with (tmp_dir / ".git" / "info" / "sparse-checkout").open("w") as f:
@@ -599,7 +597,7 @@ def run_commands(
     for command in commands:
         # Substitute variables, e.g. "./{NAME}.json"
         command = command.format(**variables)
-        command = shlex.split(command, posix=not is_windows)
+        command = split_command(command)
         # TODO: is this needed / a good idea?
         if len(command) and command[0] in ("python", "python3"):
             command[0] = sys.executable

--- a/spacy/cli/project.py
+++ b/spacy/cli/project.py
@@ -82,6 +82,8 @@ def project_clone_cli(
     initializing DVC (Data Version Control). This allows DVC to integrate with
     Git.
     """
+    if dest == Path.cwd():
+        dest = dest / name
     project_clone(name, dest, repo=repo, git=git, no_init=no_init)
 
 

--- a/spacy/cli/project.py
+++ b/spacy/cli/project.py
@@ -207,7 +207,7 @@ def project_update_dvc_cli(
         msg.info(f"No changes found in {CONFIG_FILE}, no update needed")
 
 
-app.add_typer(project_cli, name="project", no_args_is_help=True)
+app.add_typer(project_cli, name="project")
 
 
 #################

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -132,6 +132,7 @@ class Warnings(object):
             "are currently: da, de, el, en, id, lb, pt, ru, sr, ta, th.")
 
     # TODO: fix numbering after merging develop into master
+    W091 = ("Could not clean/remove the temp directory at {dir}.")
     W092 = ("Ignoring annotations for sentence starts, as dependency heads are set.")
     W093 = ("Could not find any data to train the {name} on. Is your "
             "input data correctly formatted ?")

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -132,7 +132,7 @@ class Warnings(object):
             "are currently: da, de, el, en, id, lb, pt, ru, sr, ta, th.")
 
     # TODO: fix numbering after merging develop into master
-    W091 = ("Could not clean/remove the temp directory at {dir}.")
+    W091 = ("Could not clean/remove the temp directory at {dir}: {msg}.")
     W092 = ("Ignoring annotations for sentence starts, as dependency heads are set.")
     W093 = ("Could not find any data to train the {name} on. Is your "
             "input data correctly formatted ?")

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -22,7 +22,7 @@ from contextlib import contextmanager
 import tempfile
 import shutil
 import hashlib
-
+import shlex
 
 try:
     import cupy.random
@@ -35,7 +35,7 @@ except ImportError:
     import importlib_metadata
 
 from .symbols import ORTH
-from .compat import cupy, CudaStream
+from .compat import cupy, CudaStream, is_windows
 from .errors import Errors, Warnings
 from . import about
 
@@ -925,7 +925,11 @@ def from_disk(path, readers, exclude):
         # Split to support file names like meta.json
         if key.split(".")[0] not in exclude:
             reader(path / key)
-    return path
+    return
+
+
+def split_command(command):
+    return shlex.split(command, posix=not is_windows)
 
 
 def import_file(name, loc):

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -469,8 +469,8 @@ def make_tempdir():
     yield d
     try:
         shutil.rmtree(str(d))
-    except PermissionError:
-        warnings.warn(Warnings.W091.format(dir=d))
+    except PermissionError as e:
+        warnings.warn(Warnings.W091.format(dir=d, msg=e))
 
 
 def get_hash(data) -> str:

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -467,7 +467,10 @@ def make_tempdir():
     """
     d = Path(tempfile.mkdtemp())
     yield d
-    shutil.rmtree(str(d))
+    try:
+        shutil.rmtree(str(d))
+    except PermissionError:
+        warnings.warn(Warnings.W091.format(dir=d))
 
 
 def get_hash(data) -> str:


### PR DESCRIPTION
Some small fixes:

## Description
- `shlex.split` needs the `posix` flag to work on Windows
- added some more informative Error messages here and there, because debugging wasn't always straightforward
- cloning a project in the working dir (no `dest` parameter) didn't work for me, because it would always say the working dir already exists. I added 
```
if dest == Path.cwd():
    dest = dest / name
```
so that it would create the new dir in the subdir of the working dir. Hopefully that doesn't break anything on Linux?

## Remaining trouble
After cloning the GH repo in the temp dir and moving it, on my system (running as admin), the script can't clean up the temp directory:
>  UserWarning: [W091] Could not clean/remove the temp directory at ...\Temp\tmp889ccvy9: [WinError 5] Access is denied: '...\\Temp\\tmp889ccvy9\\.git\\objects\\pack\\pack-661d6ea746862ec352be736c4ec67d142cb230c3.idx'.

This could be a Windows thing. I changed the `make_tempdir` context manager to throw this warning instead of crashing though.

### Types of change
bug fixes

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
