### PR TITLE
Working dir by default

### DIFF
--- a/spacy/cli/project.py
+++ b/spacy/cli/project.py
@@ -149,8 +149,8 @@ def project_run_all_cli(
 def project_run_cli(
     # fmt: off
     ctx: typer.Context,
-    project_dir: Path = Arg(Path.cwd(), help="Location of project directory. Defaults to current working directory.", exists=True, file_okay=False),
     subcommand: str = Arg(None, help="Name of command defined in project config"),
+    project_dir: Path = Arg(Path.cwd(), help="Location of project directory. Defaults to current working directory.", exists=True, file_okay=False),
     show_help: bool = Opt(False, "--help", help="Show help message and available subcommands")
     # fmt: on
 ):
@@ -173,8 +173,8 @@ def project_run_cli(
 @project_cli.command("exec", hidden=True)
 def project_exec_cli(
     # fmt: off
-    project_dir: Path = Arg(Path.cwd(), help="Location of project directory. Defaults to current working directory.", exists=True, file_okay=False),
     subcommand: str = Arg(..., help="Name of command defined in project config"),
+    project_dir: Path = Arg(Path.cwd(), help="Location of project directory. Defaults to current working directory.", exists=True, file_okay=False),
     # fmt: on
 ):
     """Execute a command defined in the project config. This CLI command is

--- a/spacy/cli/project.py
+++ b/spacy/cli/project.py
@@ -88,7 +88,7 @@ def project_clone_cli(
 
 @project_cli.command("init")
 def project_init_cli(
-    path: Path = Arg(..., help="Path to cloned project", exists=True, file_okay=False),
+    path: Path = Arg(Path.cwd(), help="Path to cloned project. Defaults to current working directory.", exists=True, file_okay=False),
     git: bool = Opt(False, "--git", "-G", help="Initialize project as a Git repo"),
     force: bool = Opt(False, "--force", "-F", help="Force initiziation"),
 ):
@@ -104,7 +104,7 @@ def project_init_cli(
 @project_cli.command("assets")
 def project_assets_cli(
     # fmt: off
-    project_dir: Path = Arg(..., help="Path to cloned project", exists=True, file_okay=False),
+    project_dir: Path = Arg(Path.cwd(), help="Path to cloned project. Defaults to current working directory.", exists=True, file_okay=False),
     # fmt: on
 ):
     """Use DVC (Data Version Control) to fetch project assets. Assets are
@@ -125,7 +125,7 @@ def project_assets_cli(
 def project_run_all_cli(
     # fmt: off
     ctx: typer.Context,
-    project_dir: Path = Arg(..., help="Location of project directory", exists=True, file_okay=False),
+    project_dir: Path = Arg(Path.cwd(), help="Location of project directory. Defaults to current working directory.", exists=True, file_okay=False),
     show_help: bool = Opt(False, "--help", help="Show help message and available subcommands")
     # fmt: on
 ):
@@ -149,7 +149,7 @@ def project_run_all_cli(
 def project_run_cli(
     # fmt: off
     ctx: typer.Context,
-    project_dir: Path = Arg(..., help="Location of project directory", exists=True, file_okay=False),
+    project_dir: Path = Arg(Path.cwd(), help="Location of project directory. Defaults to current working directory.", exists=True, file_okay=False),
     subcommand: str = Arg(None, help="Name of command defined in project config"),
     show_help: bool = Opt(False, "--help", help="Show help message and available subcommands")
     # fmt: on
@@ -173,7 +173,7 @@ def project_run_cli(
 @project_cli.command("exec", hidden=True)
 def project_exec_cli(
     # fmt: off
-    project_dir: Path = Arg(..., help="Location of project directory", exists=True, file_okay=False),
+    project_dir: Path = Arg(Path.cwd(), help="Location of project directory. Defaults to current working directory.", exists=True, file_okay=False),
     subcommand: str = Arg(..., help="Name of command defined in project config"),
     # fmt: on
 ):
@@ -188,7 +188,7 @@ def project_exec_cli(
 @project_cli.command("update-dvc")
 def project_update_dvc_cli(
     # fmt: off
-    project_dir: Path = Arg(..., help="Location of project directory", exists=True, file_okay=False),
+    project_dir: Path = Arg(Path.cwd(), help="Location of project directory. Defaults to current working directory.", exists=True, file_okay=False),
     verbose: bool = Opt(False, "--verbose", "-V", help="Print more info"),
     force: bool = Opt(False, "--force", "-F", help="Force update DVC config"),
     # fmt: on

--- a/spacy/cli/project.py
+++ b/spacy/cli/project.py
@@ -609,7 +609,7 @@ def run_commands(
         elif len(command) and command[0] in ("pip", "pip3"):
             command = [sys.executable, "-m", "pip", *command[1:]]
         if not silent:
-            print(" ".join(command))
+            print(f"Running command: {command}")
         run_command(command)
 
 


### PR DESCRIPTION

## Description
Proposal: for all `spacy project` commands, use the working dir by default. This is really convenient when experimenting on the command line in your project folder, and you can type just `python -m spacy project run-all` or `python -m spacy project run visualize`

Note that for this to work, the positional `subcommand` argument needs to be moved one up.

### Types of change
enhancement proposal

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
