### PR TITLE
Minor fix in PhraseMatcher api docs: pipe(docs) instead of pipe(texts)

### DIFF
--- a/website/docs/api/phrasematcher.md
+++ b/website/docs/api/phrasematcher.md
@@ -91,7 +91,7 @@ Match a stream of documents, yielding them in turn.
 > ```python
 >   from spacy.matcher import PhraseMatcher
 >   matcher = PhraseMatcher(nlp.vocab)
->   for doc in matcher.pipe(texts, batch_size=50):
+>   for doc in matcher.pipe(docs, batch_size=50):
 >       pass
 > ```
 


### PR DESCRIPTION
## Description

Very minor fix in docs, specifically in this part:

```
 matcher = PhraseMatcher(nlp.vocab)
>   for doc in matcher.pipe(texts, batch_size=50):
>       pass
```

`texts` suggests the input is an iterable of strings. I replaced it for `docs`.

<!--- Provide a general summary of your changes in the title. -->

### Types of change
Minor change in documentation

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ x ] I have submitted the spaCy Contributor Agreement.
- [Does not apply] I ran the tests, and all new and existing tests passed.
- [ x ] My changes don't require a change to the documentation, or if they do, I've added all required information.
