### PR TITLE
bugfix exec usage in dvc.yaml

### DIFF
--- a/spacy/cli/project.py
+++ b/spacy/cli/project.py
@@ -240,12 +240,16 @@ def project_clone(
         try:
             run_command(cmd)
         except SystemExit:
-            err = f"Could not clone the repo '{repo}' into the temp dir '{tmp_dir}'"
+            err = f"Could not clone the repo '{repo}' into the temp dir '{tmp_dir}'."
             msg.fail(err)
         with (tmp_dir / ".git" / "info" / "sparse-checkout").open("w") as f:
             f.write(name)
-        run_command(["git", "-C", str(tmp_dir), "fetch"])
-        run_command(["git", "-C", str(tmp_dir), "checkout"])
+        try:
+            run_command(["git", "-C", str(tmp_dir), "fetch"])
+            run_command(["git", "-C", str(tmp_dir), "checkout"])
+        except SystemExit:
+            err = f"Could not clone {name} in the repo '{repo}'."
+            msg.fail(err)
         shutil.move(str(tmp_dir / Path(name).name), str(project_dir))
     msg.good(f"Cloned project '{name}' from {repo} into {project_dir}")
     for sub_dir in DIRS:

--- a/spacy/cli/project.py
+++ b/spacy/cli/project.py
@@ -248,7 +248,7 @@ def project_clone(
             run_command(["git", "-C", str(tmp_dir), "fetch"])
             run_command(["git", "-C", str(tmp_dir), "checkout"])
         except SystemExit:
-            err = f"Could not clone {name} in the repo '{repo}'."
+            err = f"Could not clone '{name}' in the repo '{repo}'."
             msg.fail(err)
         shutil.move(str(tmp_dir / Path(name).name), str(project_dir))
     msg.good(f"Cloned project '{name}' from {repo} into {project_dir}")

--- a/spacy/cli/project.py
+++ b/spacy/cli/project.py
@@ -523,9 +523,9 @@ def update_dvc_config(
         outputs_no_cache = command.get("outputs_no_cache", [])
         if not deps and not outputs and not outputs_no_cache:
             continue
-        # Default to "." as the project path since dvc.yaml is auto-generated
+        # Default to the working dir as the project path since dvc.yaml is auto-generated
         # and we don't want arbitrary paths in there
-        project_cmd = ["python", "-m", NAME, "project", ".", "exec", name]
+        project_cmd = ["python", "-m", NAME, "project", "exec", name]
         deps_cmd = [c for cl in [["-d", p] for p in deps] for c in cl]
         outputs_cmd = [c for cl in [["-o", p] for p in outputs] for c in cl]
         outputs_nc_cmd = [c for cl in [["-O", p] for p in outputs_no_cache] for c in cl]


### PR DESCRIPTION
## Description
Bugfix following PR #5679

EDIT: also added `try`-`except` because the `git` commands otherwise exit unelegantly. e.g. when the subfolder in the default repo doesn't exist, it would say
> error: Sparse checkout leaves no entry on working directory

and nothing more. Now it gives a full stack trace, including messages such as 

> ✘ Could not clone 'woopsie' in the repo
'https://github.com/your-anon-repo'.

> FileNotFoundError: [Errno 2] No such file or directory: '...\\Temp\\tmpcx81e311\\woopsie'

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
