### PR TITLE
♻ Refactor CLI setup for completion

### DIFF
--- a/.github/contributors/tiangolo.md
+++ b/.github/contributors/tiangolo.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI GmbH](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [ ] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           | Sebastián Ramírez    |
+| Company name (if applicable)   |                      |
+| Title or role (if applicable)  |                      |
+| Date                           | 2020-07-01           |
+| GitHub username                | tiangolo             |
+| Website (optional)             |                      |

--- a/bin/spacy
+++ b/bin/spacy
@@ -1,2 +1,0 @@
-#! /bin/sh
-python -m spacy "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,8 @@ murmurhash>=0.28.0,<1.1.0
 wasabi>=0.7.0,<1.1.0
 srsly>=2.1.0,<3.0.0
 catalogue>=0.0.7,<1.1.0
-typer>=0.3.0,<1.0.0
+typer>=0.3.0,<0.4.0
+shellingham>=1.3.0,<1.4.0
 # Third party dependencies
 numpy>=1.15.0
 requests>=2.13.0,<3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ wasabi>=0.7.0,<1.1.0
 srsly>=2.1.0,<3.0.0
 catalogue>=0.0.7,<1.1.0
 typer>=0.3.0,<0.4.0
-shellingham>=1.3.0,<1.4.0
 # Third party dependencies
 numpy>=1.15.0
 requests>=2.13.0,<3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,8 @@ install_requires =
     wasabi>=0.7.0,<1.1.0
     srsly>=2.1.0,<3.0.0
     catalogue>=0.0.7,<1.1.0
-    typer>=0.3.0,<1.0.0
+    typer>=0.3.0,<0.4.0
+    shellingham>=1.3.0,<1.4.0
     # Third-party dependencies
     tqdm>=4.38.0,<5.0.0
     numpy>=1.15.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,6 @@ classifiers =
 [options]
 zip_safe = false
 include_package_data = true
-scripts =
-    bin/spacy
 python_requires = >=3.6
 setup_requires =
     wheel
@@ -58,6 +56,10 @@ install_requires =
     setuptools
     packaging
     importlib_metadata>=0.20; python_version < "3.8"
+
+[options.entry_points]
+console_scripts =
+    spacy = spacy.cli:app
 
 [options.extras_require]
 lookups =

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ install_requires =
     srsly>=2.1.0,<3.0.0
     catalogue>=0.0.7,<1.1.0
     typer>=0.3.0,<0.4.0
-    shellingham>=1.3.0,<1.4.0
     # Third-party dependencies
     tqdm>=4.38.0,<5.0.0
     numpy>=1.15.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

This PR does the following:

* Pin Typer to a version range safe from breaking changes (there could be breaking changes between `>=0.3.0` and `>=0.4.0`).
* Add `shellingham` as a dependency, a small library used by Typer to detect the current shell and be able to install completion automatically with:

```console
$ spacy --install-completion
```

Without `shellingham` it would have to be:

```console
$ spacy --install-completion zsh

// or

$ spacy --install-completion bash

// or

$ spacy --install-completion fish

// etc.
```
* Update the way the standalone `spacy` command is created, from an integrated shell script to a pure Python "entrypoint" in setuptools:
    * This fixes shell completion because with the current shell script the actual command called ends up being `python -m spacy some-args` instead of `spacy some-args`. And shell completion systems depend on that name of the command (otherwise, it triggers completion for `python`).

Here's how completion looks like afterwards:

[![asciicast](https://asciinema.org/a/GTlCdFuDLI0VnSoqotwqIH3NK.svg)](https://asciinema.org/a/GTlCdFuDLI0VnSoqotwqIH3NK)

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement. ...I think so? I actually don't know :thinking: 
- [x] I ran the tests, and all new and existing tests passed. (Didn't change any internals).
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
