### PR TITLE
Bugfix/nel v3

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -556,8 +556,6 @@ class Errors(object):
     E979 = ("Cannot convert {type} to an Example object.")
     E980 = ("Each link annotation should refer to a dictionary with at most one "
             "identifier mapping to 1.0, and all others to 0.0.")
-    E981 = ("The offsets of the annotations for 'links' need to refer exactly "
-            "to the offsets of the 'entities' annotations.")
     E982 = ("The 'ent_iob' attribute of a Token should be an integer indexing "
             "into {values}, but found {value}.")
     E983 = ("Invalid key for '{dict}': {key}. Available keys: "

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -556,6 +556,8 @@ class Errors(object):
     E979 = ("Cannot convert {type} to an Example object.")
     E980 = ("Each link annotation should refer to a dictionary with at most one "
             "identifier mapping to 1.0, and all others to 0.0.")
+    E981 = ("The offsets of the annotations for 'links' could not be aligned "
+            "to token boundaries.")
     E982 = ("The 'ent_iob' attribute of a Token should be an integer indexing "
             "into {values}, but found {value}.")
     E983 = ("Invalid key for '{dict}': {key}. Available keys: "

--- a/spacy/gold/example.pyx
+++ b/spacy/gold/example.pyx
@@ -235,10 +235,7 @@ def _annot2array(vocab, tok_annot, doc_annot):
             if key == "entities":
                 pass
             elif key == "links":
-                entities = doc_annot.get("entities", {})
-                if not entities:
-                    raise ValueError(Errors.E981)
-                ent_kb_ids = _parse_links(vocab, tok_annot["ORTH"], value, entities)
+                ent_kb_ids = _parse_links(vocab, tok_annot["ORTH"], tok_annot["SPACY"], value)
                 tok_annot["ENT_KB_ID"] = ent_kb_ids
             elif key == "cats":
                 pass
@@ -381,18 +378,11 @@ def _parse_ner_tags(biluo_or_offsets, vocab, words, spaces):
                 ent_types.append("")
     return ent_iobs, ent_types
 
-def _parse_links(vocab, words, links, entities):
-    reference = Doc(vocab, words=words)
+def _parse_links(vocab, words, spaces, links):
+    reference = Doc(vocab, words=words, spaces=spaces)
     starts = {token.idx: token.i for token in reference}
     ends = {token.idx + len(token): token.i for token in reference}
     ent_kb_ids = ["" for _ in reference]
-    entity_map = [(ent[0], ent[1]) for ent in entities]
-
-    # links annotations need to refer 1-1 to entity annotations - throw error otherwise
-    for index, annot_dict in links.items():
-        start_char, end_char = index
-        if (start_char, end_char) not in entity_map:
-            raise ValueError(Errors.E981)
 
     for index, annot_dict in links.items():
         true_kb_ids = []

--- a/spacy/gold/example.pyx
+++ b/spacy/gold/example.pyx
@@ -396,6 +396,8 @@ def _parse_links(vocab, words, spaces, links):
             start_char, end_char = index
             start_token = starts.get(start_char)
             end_token = ends.get(end_char)
+            if start_token is None or end_token is None:
+                raise ValueError(Errors.E981)
             for i in range(start_token, end_token+1):
                 ent_kb_ids[i] = true_kb_ids[0]
 

--- a/spacy/tests/test_new_example.py
+++ b/spacy/tests/test_new_example.py
@@ -230,8 +230,7 @@ def test_Example_from_dict_with_links(annots):
     [
         {
             "words": ["I", "like", "New", "York", "and", "Berlin", "."],
-            "entities": [(7, 15, "LOC"), (20, 26, "LOC")],
-            "links": {(0, 1): {"Q7381115": 1.0, "Q2146908": 0.0}},
+            "links": {(7, 14): {"Q7381115": 1.0, "Q2146908": 0.0}},
         }
     ],
 )


### PR DESCRIPTION

## Description
Bugfixes for parsing NEL gold data in spaCy v.3
* Not sure what I was thinking, but `entities` shouldn't be required in the gold annotations if `links` are specified.
* The links do need to align with token boundaries
* The `_parse_links` needs access to the reference spaces to check the token boundaries

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
