### PR TITLE
Record whether Doc objects are built from known spacing

### DIFF
--- a/spacy/cli/convert.py
+++ b/spacy/cli/convert.py
@@ -137,7 +137,7 @@ def _print_docs_to_stdout(docs, output_type):
     if output_type == "json":
         srsly.write_json("-", docs_to_json(docs))
     else:
-        sys.stdout.buffer.write(DocBin(docs=docs).to_bytes())
+        sys.stdout.buffer.write(DocBin(docs=docs, store_user_data=True).to_bytes())
 
 
 def _write_docs_to_file(docs, output_file, output_type):
@@ -146,7 +146,7 @@ def _write_docs_to_file(docs, output_file, output_type):
     if output_type == "json":
         srsly.write_json(output_file, docs_to_json(docs))
     else:
-        data = DocBin(docs=docs).to_bytes()
+        data = DocBin(docs=docs, store_user_data=True).to_bytes()
         with output_file.open("wb") as file_:
             file_.write(data)
  

--- a/spacy/gold/converters/json2docs.py
+++ b/spacy/gold/converters/json2docs.py
@@ -17,8 +17,6 @@ def json2docs(input_data, model=None, **kwargs):
         for json_para in json_to_annotations(json_doc):
             example_dict = _fix_legacy_dict_data(json_para)
             tok_dict, doc_dict = _parse_example_dict_data(example_dict)
-            if json_para.get("raw"):
-                assert tok_dict.get("SPACY")
             doc = annotations2doc(nlp.vocab, tok_dict, doc_dict)
             docs.append(doc)
     return docs

--- a/spacy/gold/corpus.py
+++ b/spacy/gold/corpus.py
@@ -91,7 +91,7 @@ class Corpus:
             loc = util.ensure_path(loc)
             if loc.parts[-1].endswith(".spacy"):
                 with loc.open("rb") as file_:
-                    doc_bin = DocBin(store_user_data=True).from_bytes(file_.read())
+                    doc_bin = DocBin().from_bytes(file_.read())
                 docs = doc_bin.get_docs(vocab)
                 for doc in docs:
                     if len(doc):

--- a/spacy/gold/example.pyx
+++ b/spacy/gold/example.pyx
@@ -15,7 +15,7 @@ from ..syntax import nonproj
 
 
 cpdef Doc annotations2doc(vocab, tok_annot, doc_annot):
-    """ Create a Doc from dictionaries with token and doc annotations. Assumes ORTH & SPACY are set. """
+    """ Create a Doc from dictionaries with token and doc annotations. """
     attrs, array = _annot2array(vocab, tok_annot, doc_annot)
     output = Doc(vocab, words=tok_annot["ORTH"], spaces=tok_annot["SPACY"])
     if "entities" in doc_annot:
@@ -414,7 +414,7 @@ def _parse_links(vocab, words, links, entities):
 
 def _guess_spaces(text, words):
     if text is None:
-        return [True] * len(words)
+        return None
     spaces = []
     text_pos = 0
     # align words with text

--- a/spacy/tests/serialize/test_serialize_doc.py
+++ b/spacy/tests/serialize/test_serialize_doc.py
@@ -85,7 +85,7 @@ def test_serialize_doc_bin_unknown_spaces(en_vocab):
     assert not doc2.has_unknown_spaces
     assert doc2.text == "that's"
 
-    doc_bin = DocBin(docs=[doc1, doc2])
+    doc_bin = DocBin().from_bytes(DocBin(docs=[doc1, doc2]).to_bytes())
     re_doc1, re_doc2 = doc_bin.get_docs(en_vocab)
     assert re_doc1.has_unknown_spaces
     assert re_doc1.text == "that 's "

--- a/spacy/tests/serialize/test_serialize_doc.py
+++ b/spacy/tests/serialize/test_serialize_doc.py
@@ -75,3 +75,19 @@ def test_serialize_doc_bin():
     for i, doc in enumerate(reloaded_docs):
         assert doc.text == texts[i]
         assert doc.cats == cats
+
+
+def test_serialize_doc_bin_unknown_spaces(en_vocab):
+    doc1 = Doc(en_vocab, words=["that", "'s"])
+    assert doc1.has_unknown_spaces
+    assert doc1.text == "that 's "
+    doc2 = Doc(en_vocab, words=["that", "'s"], spaces=[False, False])
+    assert not doc2.has_unknown_spaces
+    assert doc2.text == "that's"
+
+    doc_bin = DocBin(docs=[doc1, doc2])
+    re_doc1, re_doc2 = doc_bin.get_docs(en_vocab)
+    assert re_doc1.has_unknown_spaces
+    assert re_doc1.text == "that 's "
+    assert not re_doc2.has_unknown_spaces
+    assert re_doc2.text == "that's"

--- a/spacy/tokens/_serialize.py
+++ b/spacy/tokens/_serialize.py
@@ -59,6 +59,7 @@ class DocBin(object):
         self.spaces = []
         self.cats = []
         self.user_data = []
+        self.flags = []
         self.strings = set()
         self.store_user_data = store_user_data
         for doc in docs:
@@ -79,13 +80,13 @@ class DocBin(object):
         if len(array.shape) == 1:
             array = array.reshape((array.shape[0], 1))
         self.tokens.append(array)
-        if doc.has_unknown_spaces:
-            self.spaces.append(numpy.zeros((0, 1), dtype=bool))
-        else:
-            spaces = doc.to_array(SPACY)
-            assert array.shape[0] == spaces.shape[0]  # this should never happen
-            spaces = spaces.reshape((spaces.shape[0], 1))
-            self.spaces.append(numpy.asarray(spaces, dtype=bool))
+        spaces = doc.to_array(SPACY)
+        assert array.shape[0] == spaces.shape[0]  # this should never happen
+        spaces = spaces.reshape((spaces.shape[0], 1))
+        self.spaces.append(numpy.asarray(spaces, dtype=bool))
+        self.flags.append({
+            "has_unknown_spaces": doc.has_unknown_spaces
+        })
         for token in doc:
             self.strings.add(token.text)
             self.strings.add(token.tag_)
@@ -108,9 +109,10 @@ class DocBin(object):
             vocab[string]
         orth_col = self.attrs.index(ORTH)
         for i in range(len(self.tokens)):
+            flags = self.flags[i]
             tokens = self.tokens[i]
             spaces = self.spaces[i]
-            if spaces.size == 0 and tokens.size != 0:
+            if flags.get("has_unknown_spaces"):
                 spaces = None
             doc = Doc(vocab, words=tokens[:, orth_col], spaces=spaces)
             doc = doc.from_array(self.attrs, tokens)
@@ -135,6 +137,7 @@ class DocBin(object):
         self.spaces.extend(other.spaces)
         self.strings.update(other.strings)
         self.cats.extend(other.cats)
+        self.flags.extend(other.flags)
         if self.store_user_data:
             self.user_data.extend(other.user_data)
 
@@ -158,6 +161,7 @@ class DocBin(object):
             "lengths": numpy.asarray(lengths, dtype="int32").tobytes("C"),
             "strings": list(self.strings),
             "cats": self.cats,
+            "flags": self.flags,
         }
         if self.store_user_data:
             msg["user_data"] = self.user_data
@@ -183,6 +187,7 @@ class DocBin(object):
         self.tokens = NumpyOps().unflatten(flat_tokens, lengths)
         self.spaces = NumpyOps().unflatten(flat_spaces, lengths)
         self.cats = msg["cats"]
+        self.flags = msg.get("flags", [{} for _ in lengths])
         if self.store_user_data and "user_data" in msg:
             self.user_data = list(msg["user_data"])
         for tokens in self.tokens:

--- a/spacy/tokens/_serialize.py
+++ b/spacy/tokens/_serialize.py
@@ -79,10 +79,13 @@ class DocBin(object):
         if len(array.shape) == 1:
             array = array.reshape((array.shape[0], 1))
         self.tokens.append(array)
-        spaces = doc.to_array(SPACY)
-        assert array.shape[0] == spaces.shape[0]  # this should never happen
-        spaces = spaces.reshape((spaces.shape[0], 1))
-        self.spaces.append(numpy.asarray(spaces, dtype=bool))
+        if doc.has_unknown_spaces:
+            self.spaces.append(numpy.zeros((0, 1), dtype=bool))
+        else:
+            spaces = doc.to_array(SPACY)
+            assert array.shape[0] == spaces.shape[0]  # this should never happen
+            spaces = spaces.reshape((spaces.shape[0], 1))
+            self.spaces.append(numpy.asarray(spaces, dtype=bool))
         for token in doc:
             self.strings.add(token.text)
             self.strings.add(token.tag_)
@@ -107,6 +110,8 @@ class DocBin(object):
         for i in range(len(self.tokens)):
             tokens = self.tokens[i]
             spaces = self.spaces[i]
+            if spaces.size == 0 and tokens.size != 0:
+                spaces = None
             doc = Doc(vocab, words=tokens[:, orth_col], spaces=spaces)
             doc = doc.from_array(self.attrs, tokens)
             doc.cats = self.cats[i]

--- a/spacy/tokens/doc.pxd
+++ b/spacy/tokens/doc.pxd
@@ -59,10 +59,13 @@ cdef class Doc:
     cdef public dict user_token_hooks
     cdef public dict user_span_hooks
 
+    cdef public bint has_unknown_spaces
+
     cdef public list _py_tokens
 
     cdef int length
     cdef int max_length
+
 
     cdef public object noun_chunks_iterator
 

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -171,8 +171,7 @@ cdef class Doc:
             raise ValueError(Errors.E046.format(name=name))
         return Underscore.doc_extensions.pop(name)
 
-    def __init__(self, Vocab vocab, words=None, spaces=None, user_data=None,
-                 orths_and_spaces=None):
+    def __init__(self, Vocab vocab, words=None, spaces=None, user_data=None):
         """Create a Doc object.
 
         vocab (Vocab): A vocabulary object, which must match any models you
@@ -214,28 +213,25 @@ cdef class Doc:
         self._vector = None
         self.noun_chunks_iterator = _get_chunker(self.vocab.lang)
         cdef bint has_space
-        if orths_and_spaces is None and words is not None:
-            if spaces is None:
-                spaces = [True] * len(words)
-            elif len(spaces) != len(words):
-                raise ValueError(Errors.E027)
-            orths_and_spaces = zip(words, spaces)
+        if words is None and spaces is not None:
+            raise ValueError("words must be set if spaces is set")
+        elif spaces is None and words is not None:
+            self.has_unknown_spaces = True
+        else:
+            self.has_unknown_spaces = False
+        words = words if words is not None else []
+        spaces = spaces if spaces else ([True] * len(words))
+        if len(spaces) != len(words):
+            raise ValueError(Errors.E027)
         cdef const LexemeC* lexeme
-        if orths_and_spaces is not None:
-            orths_and_spaces = list(orths_and_spaces)
-            for orth_space in orths_and_spaces:
-                if isinstance(orth_space, unicode):
-                    lexeme = self.vocab.get(self.mem, orth_space)
-                    has_space = True
-                elif isinstance(orth_space, bytes):
-                    raise ValueError(Errors.E028.format(value=orth_space))
-                elif isinstance(orth_space[0], unicode):
-                    lexeme = self.vocab.get(self.mem, orth_space[0])
-                    has_space = orth_space[1]
-                else:
-                    lexeme = self.vocab.get_by_orth(self.mem, orth_space[0])
-                    has_space = orth_space[1]
-                self.push_back(lexeme, has_space)
+        for word, has_space in zip(words, spaces):
+            if isinstance(word, unicode):
+                lexeme = self.vocab.get(self.mem, word)
+            elif isinstance(word, bytes):
+                raise ValueError(Errors.E028.format(value=word))
+            else:
+                lexeme = self.vocab.get_by_orth(self.mem, word)
+            self.push_back(lexeme, has_space)
         # Tough to decide on policy for this. Is an empty doc tagged and parsed?
         # There's no information we'd like to add to it, so I guess so?
         if self.length == 0:
@@ -1000,6 +996,7 @@ cdef class Doc:
             "sentiment": lambda: self.sentiment,
             "tensor": lambda: self.tensor,
             "cats": lambda: self.cats,
+            "has_unknown_spaces": self.has_unknown_spaces
         }
         for key in kwargs:
             if key in serializers or key in ("user_data", "user_data_keys", "user_data_values"):
@@ -1032,6 +1029,7 @@ cdef class Doc:
             "cats": lambda b: None,
             "user_data_keys": lambda b: None,
             "user_data_values": lambda b: None,
+            "has_unknown_spaces": self.has_unknown_spaces
         }
         for key in kwargs:
             if key in deserializers or key in ("user_data",):

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -220,7 +220,7 @@ cdef class Doc:
         else:
             self.has_unknown_spaces = False
         words = words if words is not None else []
-        spaces = spaces if spaces else ([True] * len(words))
+        spaces = spaces if spaces is not None else ([True] * len(words))
         if len(spaces) != len(words):
             raise ValueError(Errors.E027)
         cdef const LexemeC* lexeme
@@ -996,7 +996,7 @@ cdef class Doc:
             "sentiment": lambda: self.sentiment,
             "tensor": lambda: self.tensor,
             "cats": lambda: self.cats,
-            "has_unknown_spaces": self.has_unknown_spaces
+            "has_unknown_spaces": lambda: self.has_unknown_spaces
         }
         for key in kwargs:
             if key in serializers or key in ("user_data", "user_data_keys", "user_data_values"):
@@ -1029,7 +1029,7 @@ cdef class Doc:
             "cats": lambda b: None,
             "user_data_keys": lambda b: None,
             "user_data_values": lambda b: None,
-            "has_unknown_spaces": self.has_unknown_spaces
+            "has_unknown_spaces": lambda b: None
         }
         for key in kwargs:
             if key in deserializers or key in ("user_data",):
@@ -1050,6 +1050,8 @@ cdef class Doc:
             self.tensor = msg["tensor"]
         if "cats" not in exclude and "cats" in msg:
             self.cats = msg["cats"]
+        if "has_unknown_spaces" not in exclude and "has_unknown_spaces" in msg:
+            self.has_unknown_spaces = msg["has_unknown_spaces"]
         start = 0
         cdef const LexemeC* lex
         cdef unicode orth_


### PR DESCRIPTION
Now that we don't have the `GoldParse`, it's important that the `Doc` object be able to track whether it was created from actual text, or whether we filled in the `spaces` variable with just `True`. This addresses a bug in the conversion where incorrectly spaced text was being tokenized.

The name of the field is kind of janky, but I don't know what else to call it.

We should create a flags variable on the `Doc` to hold these flag values, it's getting a bit bad to have all this cruft on the object. We can just have accessors in Python.