### PR TITLE
fix to pretrain script

### DIFF
--- a/spacy/cli/pretrain.py
+++ b/spacy/cli/pretrain.py
@@ -183,7 +183,7 @@ def pretrain(
         for batch_id, batch in enumerate(batches):
             docs, count = make_docs(
                 nlp,
-                [ex.doc for ex in batch],
+                batch,
                 max_length=pretrain_config["max_length"],
                 min_length=pretrain_config["min_length"],
             )

--- a/spacy/cli/pretrain.py
+++ b/spacy/cli/pretrain.py
@@ -15,7 +15,6 @@ from ..ml.models.multi_task import build_masked_language_model
 from ..tokens import Doc
 from ..attrs import ID, HEAD
 from .. import util
-from ..gold import Example
 
 
 @app.command("pretrain")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
At some point, `util.minibatch_by_words` was only taking `Example`'s, which is why we started using `Example` in the `pretrain` script, just to wrap the raw text in an object and get it back out. A little silly.

As `util.minibatch_by_words` has been generalized, we can just stick to batches of texts here.

This runs for me like so:
```
spacy_develop>python -m spacy init-model "en" output_init_dev -j lexemes.jsonl -v vectors.npz -V 20000

spacy_develop>python -m spacy pretrain examples\training\textcat_example_data\jigsaw-toxic-comment.jsonl output_init_dev output_pretrain examples\experiments\onto-joint\pretrain.cfg
```

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
