### PR TITLE
fix bug in Korean language, resulting in 100x speedup by reducing overhead of mecab

### DIFF
--- a/.github/contributors/mikeizbicki.md
+++ b/.github/contributors/mikeizbicki.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI GmbH](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           | Mike Izbicki         |
+| Company name (if applicable)   |                      |
+| Title or role (if applicable)  |                      |
+| Date                           | 02 Jun 2020          |
+| GitHub username                | mikeizbicki          |
+| Website (optional)             | https://izbicki.me   |

--- a/spacy/lang/ko/__init__.py
+++ b/spacy/lang/ko/__init__.py
@@ -42,7 +42,10 @@ def check_spaces(text, tokens):
 class KoreanTokenizer(DummyTokenizer):
     def __init__(self, cls, nlp=None):
         self.vocab = nlp.vocab if nlp is not None else cls.create_vocab(nlp)
-        self.Tokenizer = try_mecab_import()
+        self.MeCab = try_mecab_import()("-F%f[0],%f[7]")
+
+    def __del__(self):
+        self.MeCab.__del__()
 
     def __call__(self, text):
         dtokens = list(self.detailed_tokens(text))
@@ -58,17 +61,16 @@ class KoreanTokenizer(DummyTokenizer):
     def detailed_tokens(self, text):
         # 품사 태그(POS)[0], 의미 부류(semantic class)[1],	종성 유무(jongseong)[2], 읽기(reading)[3],
         # 타입(type)[4], 첫번째 품사(start pos)[5],	마지막 품사(end pos)[6], 표현(expression)[7], *
-        with self.Tokenizer("-F%f[0],%f[7]") as tokenizer:
-            for node in tokenizer.parse(text, as_nodes=True):
-                if node.is_eos():
-                    break
-                surface = node.surface
-                feature = node.feature
-                tag, _, expr = feature.partition(",")
-                lemma, _, remainder = expr.partition("/")
-                if lemma == "*":
-                    lemma = surface
-                yield {"surface": surface, "lemma": lemma, "tag": tag}
+        for node in self.MeCab.parse(text, as_nodes=True):
+            if node.is_eos():
+                break
+            surface = node.surface
+            feature = node.feature
+            tag, _, expr = feature.partition(",")
+            lemma, _, remainder = expr.partition("/")
+            if lemma == "*":
+                lemma = surface
+            yield {"surface": surface, "lemma": lemma, "tag": tag}
 
 
 class KoreanDefaults(Language.Defaults):

--- a/spacy/lang/ko/__init__.py
+++ b/spacy/lang/ko/__init__.py
@@ -42,10 +42,11 @@ def check_spaces(text, tokens):
 class KoreanTokenizer(DummyTokenizer):
     def __init__(self, cls, nlp=None):
         self.vocab = nlp.vocab if nlp is not None else cls.create_vocab(nlp)
-        self.MeCab = try_mecab_import()("-F%f[0],%f[7]")
+        MeCab = try_mecab_import()
+        self.mecab_tokenizer = MeCab("-F%f[0],%f[7]")
 
     def __del__(self):
-        self.MeCab.__del__()
+        self.mecab_tokenizer.__del__()
 
     def __call__(self, text):
         dtokens = list(self.detailed_tokens(text))
@@ -61,7 +62,7 @@ class KoreanTokenizer(DummyTokenizer):
     def detailed_tokens(self, text):
         # 품사 태그(POS)[0], 의미 부류(semantic class)[1],	종성 유무(jongseong)[2], 읽기(reading)[3],
         # 타입(type)[4], 첫번째 품사(start pos)[5],	마지막 품사(end pos)[6], 표현(expression)[7], *
-        for node in self.MeCab.parse(text, as_nodes=True):
+        for node in self.mecab_tokenizer.parse(text, as_nodes=True):
             if node.is_eos():
                 break
             surface = node.surface


### PR DESCRIPTION
**The Bug:** The original code in the `Korean` class called the `MeCab` constructor once for each document being parsed.  This code has a large overhead, however, because it must launch and kill a system process for each document.  (Each `MeCab` class communicates with the `mecab` executable via a system process).

**The Fix:** This pull request changes the behavior so that the `MeCab` constructor is called exactly once when the `Korean` class is executed, and the constructor is reused for each of the documents.  This is how `MeCab` was intended to be used, and the reduced overhead results in a 100x speedup.  On the original code, running
```
>>> import timeit
>>> import spacy.lang.ko
>>> nlp = spacy.lang.ko.Korean()
>>> timeit.timeit(lambda: nlp('이거은 테스트 케이스를 생성하기 위해 Google Translate에 넣은 예제 테스트 문장입니다.'), number=1000)
```
gives a runtime of
```
37.5136206799998
```
but on the new code, the runtime is only
```
0.34927031499955774
```

**Note:** The original call to the `MeCab` class was within a `with` block, which is the recommended way to call the class per the `natto-py` documentation.  Inspecting the `__exit__` function of the `MeCab` class, however, we can see that all that it does is call the `__del__` function directly.  Therefore, to prevent resource leaks, the new code also calls `MeCab`'s `__del__` function within `Korean`'s `__del__` function.