### PR TITLE
Fix quote issue in spaczz universe.json

### DIFF
--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -40,7 +40,7 @@
                 "ruler.add_patterns([{'label': 'PERSON', 'pattern': 'Bill Gates', 'type': 'fuzzy'}])",
                 "nlp.add_pipe(ruler)",
                 "",
-                "doc = nlp('Oops, I spelled Bill Gattes' name wrong.')",
+                "doc = nlp('Oops, I spelled Bill Gatez wrong.')",
                 "print([(ent.text, ent.start, ent.end, ent.label_) for ent in doc.ents])"
             ],
             "code_language": "python",


### PR DESCRIPTION
<!---Removing an extra quote character from spaczz's code example in universe.json . -->

## Description
<!---Thank you for including spaczz into the spaCy universe. However, I mistakenly included an unescaped quote character in spaczz's code example in the universe.json This is a really small and low priority change. I'm sorry for the inconvenience! -->

### Types of change
<!-- Doc change to spaczz's resource entry in universe.json -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ x] I have submitted the spaCy Contributor Agreement.
- [ x] I ran the tests, and all new and existing tests passed.
- [ x] My changes don't require a change to the documentation, or if they do, I've added all required information.
