### PR TITLE
debug-model script

### DIFF
--- a/spacy/cli/__init__.py
+++ b/spacy/cli/__init__.py
@@ -11,6 +11,7 @@ from .profile import profile  # noqa: F401
 from .train import train_cli  # noqa: F401
 from .pretrain import pretrain  # noqa: F401
 from .debug_data import debug_data  # noqa: F401
+from .debug_model import debug_model  # noqa: F401
 from .evaluate import evaluate  # noqa: F401
 from .convert import convert  # noqa: F401
 from .init_model import init_model  # noqa: F401

--- a/spacy/cli/debug_model.py
+++ b/spacy/cli/debug_model.py
@@ -1,0 +1,82 @@
+from typing import List
+from pathlib import Path
+from wasabi import Printer
+
+from ._app import app, Arg, Opt
+from .. import util
+
+
+@app.command("debug-model")
+def debug_model_cli(
+    # fmt: off
+    config_path: Path = Arg(..., help="Path to config file", exists=True),
+    layers: str = Opt("", "--layers", "-l", help="Comma-separated names of pipeline components to train"),
+    dimensions: bool = Opt(False, "--dimensions", "-d", help="Show dimensions"),
+    parameters: bool = Opt(False, "--parameters", "-p", help="Show parameters"),
+    gradients: bool = Opt(False, "--gradients", "-g", help="Show gradients"),
+    attributes: bool = Opt(False, "--attributes", "-a", help="Show attributes"),
+    ignore_warnings: bool = Opt(False, "--ignore-warnings", "-IW", help="Ignore warnings, only show stats and errors"),
+    no_format: bool = Opt(False, "--no-format", "-NF", help="Don't pretty-print the results"),
+    # fmt: on
+):
+    """
+    Analyze a Thinc ML model - internal structure (TODO: and activations during training)
+    """
+    debug_model(
+        config_path,
+        layers=[int(l.strip()) for l in layers.split(",")] if layers else [],
+        dimensions=dimensions,
+        parameters=parameters,
+        gradients=gradients,
+        attributes=attributes,
+        ignore_warnings=ignore_warnings,
+        no_format=no_format,
+        silent=False
+    )
+
+
+def debug_model(
+    config_path: Path,
+    *,
+    layers: List[str] = None,
+    dimensions: bool = False,
+    parameters: bool = False,
+    gradients: bool = False,
+    attributes: bool = False,
+    ignore_warnings: bool = False,
+    no_format: bool = True,
+    silent: bool = True,
+):
+    msg = Printer(
+        no_print=silent, pretty=not no_format, ignore_warnings=ignore_warnings
+    )
+    model = util.load_config(config_path, create_objects=True)["model"]
+
+    msg.info(f"Analysing model with ID {model.id}: '{model.name}'")
+    for i, node in enumerate(model.walk()):
+        if not layers or i in layers:
+            msg.info(f"Layer {i}: model ID {node.id}: '{node.name}'")
+
+            if dimensions:
+                for name in node.dim_names:
+                    if node.has_dim(name):
+                        msg.info(f" - dim {name}: {node.get_dim(name)}")
+                    else:
+                        msg.info(f" - dim {name}: {node.has_dim(name)}")
+
+            if parameters:
+                for name in node.param_names:
+                    if node.has_param(name):
+                        msg.info(f" - param {name}: {node.get_param(name)}")
+                    else:
+                        msg.info(f" - param {name}: {node.has_param(name)}")
+            if gradients:
+                for name in node.param_names:
+                    if node.has_grad(name):
+                        msg.info(f" - grad {name}: {node.get_grad(name)}")
+                    else:
+                        msg.info(f" - grad {name}: {node.has_grad(name)}")
+            if attributes:
+                attrs = node.attrs
+                for name, value in attrs.items():
+                    msg.info(f" - attr {name}: {value}")

--- a/spacy/cli/debug_model.py
+++ b/spacy/cli/debug_model.py
@@ -1,9 +1,11 @@
 from typing import List
 from pathlib import Path
-from wasabi import Printer
+from wasabi import msg
 
 from ._app import app, Arg, Opt
 from .. import util
+from thinc.api import require_gpu, fix_random_seed, set_dropout_rate, Adam
+from ..lang.en import English
 
 
 @app.command("debug-model")
@@ -11,48 +13,118 @@ def debug_model_cli(
     # fmt: off
     config_path: Path = Arg(..., help="Path to config file", exists=True),
     layers: str = Opt("", "--layers", "-l", help="Comma-separated names of pipeline components to train"),
-    dimensions: bool = Opt(False, "--dimensions", "-d", help="Show dimensions"),
-    parameters: bool = Opt(False, "--parameters", "-p", help="Show parameters"),
-    gradients: bool = Opt(False, "--gradients", "-g", help="Show gradients"),
-    attributes: bool = Opt(False, "--attributes", "-a", help="Show attributes"),
-    ignore_warnings: bool = Opt(False, "--ignore-warnings", "-IW", help="Ignore warnings, only show stats and errors"),
-    no_format: bool = Opt(False, "--no-format", "-NF", help="Don't pretty-print the results"),
+    dimensions: bool = Opt(False, "--dimensions", "-DIM", help="Show dimensions"),
+    parameters: bool = Opt(False, "--parameters", "-PAR", help="Show parameters"),
+    gradients: bool = Opt(False, "--gradients", "-GRAD", help="Show gradients"),
+    attributes: bool = Opt(False, "--attributes", "-ATTR", help="Show attributes"),
+    P0: bool = Opt(False, "--print-step0", "-P0", help="Print model before training"),
+    P1: bool = Opt(False, "--print-step1", "-P1", help="Print model after initialization"),
+    P2: bool = Opt(False, "--print-step2", "-P2", help="Print model after training"),
+    P3: bool = Opt(True, "--print-step3", "-P3", help="Print final predictions"),
+    use_gpu: int = Opt(-1, "--use-gpu", "-g", help="Use GPU"),
+    seed: int = Opt(None, "--seed", "-s", help="Use GPU"),
     # fmt: on
 ):
     """
     Analyze a Thinc ML model - internal structure (TODO: and activations during training)
     """
+    print_settings = {
+        "dimensions": dimensions,
+        "parameters": parameters,
+        "gradients": gradients,
+        "attributes": attributes,
+        "layers": [int(l.strip()) for l in layers.split(",")] if layers else [],
+        "print_before_training": P0,
+        "print_after_init": P1,
+        "print_after_training": P2,
+        "print_prediction": P3,
+    }
+
+    if seed is not None:
+        msg.info(f"Fixing random seed: {seed}")
+        fix_random_seed(seed)
+    if use_gpu >= 0:
+        msg.info(f"Using GPU: {use_gpu}")
+        require_gpu(use_gpu)
+    else:
+        msg.info(f"Using CPU")
+
     debug_model(
         config_path,
-        layers=[int(l.strip()) for l in layers.split(",")] if layers else [],
-        dimensions=dimensions,
-        parameters=parameters,
-        gradients=gradients,
-        attributes=attributes,
-        ignore_warnings=ignore_warnings,
-        no_format=no_format,
-        silent=False
+        print_settings=print_settings,
     )
 
 
 def debug_model(
     config_path: Path,
     *,
-    layers: List[str] = None,
-    dimensions: bool = False,
-    parameters: bool = False,
-    gradients: bool = False,
-    attributes: bool = False,
-    ignore_warnings: bool = False,
-    no_format: bool = True,
-    silent: bool = True,
+    print_settings=None
 ):
-    msg = Printer(
-        no_print=silent, pretty=not no_format, ignore_warnings=ignore_warnings
-    )
+    if print_settings is None:
+        print_settings = {}
+
     model = util.load_config(config_path, create_objects=True)["model"]
 
-    msg.info(f"Analysing model with ID {model.id}: '{model.name}'")
+    # STEP 0: Printing before training
+    msg.info(f"Analysing model with ID {model.id}")
+    if print_settings.get("print_before_training"):
+        msg.info(f"Before training:")
+        _print_model(model, print_settings)
+
+    # STEP 1: Initializing the model and printing again
+    model.initialize(X=_get_docs(), Y=_get_output(model.ops.xp))
+    if print_settings.get("print_after_init"):
+        msg.info(f"After initialization:")
+        _print_model(model, print_settings)
+
+    # STEP 2: Updating the model and printing again
+    optimizer = Adam(0.001)
+    set_dropout_rate(model, 0.2)
+    for e in range(3):
+        Y, get_dX = model.begin_update(_get_docs())
+        dY = get_gradient(model, Y)
+        _ = get_dX(dY)
+        model.finish_update(optimizer)
+    if print_settings.get("print_after_training"):
+        msg.info(f"After training:")
+        _print_model(model, print_settings)
+
+    # STEP 3: the final prediction
+    prediction = model.predict(_get_docs())
+    if print_settings.get("print_prediction"):
+        msg.info(f"Prediction:", str(prediction))
+
+
+def get_gradient(model, Y):
+    goldY = _get_output(model.ops.xp)
+    return Y - goldY
+
+
+def _sentences():
+    return [
+        "Apple is looking at buying U.K. startup for $1 billion",
+        "Autonomous cars shift insurance liability toward manufacturers",
+        "San Francisco considers banning sidewalk delivery robots",
+        "London is a big city in the United Kingdom.",
+    ]
+
+
+def _get_docs():
+    nlp = English()
+    return (list(nlp.pipe(_sentences())))
+
+
+def _get_output(xp):
+    return xp.asarray([xp.asarray([i+10, i+20, i+30], dtype="float32") for i, _ in enumerate(_get_docs())])
+
+
+def _print_model(model, print_settings):
+    layers = print_settings.get("layers", "")
+    parameters = print_settings.get("parameters", False)
+    dimensions = print_settings.get("dimensions", False)
+    gradients = print_settings.get("gradients", False)
+    attributes = print_settings.get("attributes", False)
+
     for i, node in enumerate(model.walk()):
         if not layers or i in layers:
             msg.info(f"Layer {i}: model ID {node.id}: '{node.name}'")
@@ -67,16 +139,30 @@ def debug_model(
             if parameters:
                 for name in node.param_names:
                     if node.has_param(name):
-                        msg.info(f" - param {name}: {node.get_param(name)}")
+                        print_value = _print_matrix(node.get_param(name))
+                        msg.info(f" - param {name}: {print_value}")
                     else:
                         msg.info(f" - param {name}: {node.has_param(name)}")
             if gradients:
                 for name in node.param_names:
                     if node.has_grad(name):
-                        msg.info(f" - grad {name}: {node.get_grad(name)}")
+                        print_value = _print_matrix(node.get_grad(name))
+                        msg.info(f" - grad {name}: {print_value}")
                     else:
                         msg.info(f" - grad {name}: {node.has_grad(name)}")
             if attributes:
                 attrs = node.attrs
                 for name, value in attrs.items():
                     msg.info(f" - attr {name}: {value}")
+
+
+def _print_matrix(value):
+    if value is None or isinstance(value, bool):
+        return value
+    result = str(value.shape) + " - sample: "
+    sample_matrix = value
+    for d in range(value.ndim-1):
+        sample_matrix = sample_matrix[0]
+    sample_matrix = sample_matrix[0:5]
+    result = result + str(sample_matrix)
+    return result

--- a/spacy/cli/debug_model.py
+++ b/spacy/cli/debug_model.py
@@ -26,14 +26,14 @@ def debug_model_cli(
     # fmt: on
 ):
     """
-    Analyze a Thinc ML model - internal structure (TODO: and activations during training)
+    Analyze a Thinc ML model - internal structure and activations during training
     """
     print_settings = {
         "dimensions": dimensions,
         "parameters": parameters,
         "gradients": gradients,
         "attributes": attributes,
-        "layers": [int(l.strip()) for l in layers.split(",")] if layers else [],
+        "layers": [int(x.strip()) for x in layers.split(",")] if layers else [],
         "print_before_training": P0,
         "print_after_init": P1,
         "print_after_training": P2,
@@ -111,7 +111,7 @@ def _sentences():
 
 def _get_docs():
     nlp = English()
-    return (list(nlp.pipe(_sentences())))
+    return list(nlp.pipe(_sentences()))
 
 
 def _get_output(xp):

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -154,7 +154,7 @@ def train_cli(
             weights_data = file_.read()
 
     if use_gpu >= 0:
-        msg.info("Using GPU: {use_gpu}")
+        msg.info(f"Using GPU: {use_gpu}")
         require_gpu(use_gpu)
     else:
         msg.info("Using CPU")
@@ -182,7 +182,8 @@ def train(
     msg.info(f"Loading config from: {config_path}")
     # Read the config first without creating objects, to get to the original nlp_config
     config = util.load_config(config_path, create_objects=False)
-    fix_random_seed(config["training"]["seed"])
+    if config["training"].get("seed"):
+        fix_random_seed(config["training"]["seed"])
     if config["training"].get("use_pytorch_for_gpu_memory"):
         # It feels kind of weird to not have a default for this.
         use_pytorch_for_gpu_memory()

--- a/spacy/tests/test_models.py
+++ b/spacy/tests/test_models.py
@@ -32,7 +32,7 @@ def get_gradient(model, Y):
     elif isinstance(Y, List):
         return [get_gradient(model, y) for y in Y]
     else:
-        raise ValueError(f"Could not compare type {type(Y)}")
+        raise ValueError(f"Could not get gradient for type {type(Y)}")
 
 
 def default_tok2vec():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
On Matt's suggestion, I implemented a script that will hopefully help us debug ML models easier in the future. I think over the past few months, we've all written many versions of this, so probably a good idea to make this a central tool/script.

I think this may also really help users understand how their model is built, and what happens internally when initializing / training.

The idea is that you feed it with a model config and it'll run on some toy data. By default, it only shows you the final predictions:
```
python -m spacy debug-model entity_linker_defaults.cfg
ℹ Using CPU
ℹ Analysing model with ID 52
ℹ Prediction:
[[ 6.06358    5.3513675 14.997823 ]  [ 7.18159    8.246782  18.731634 ]  [
6.0793247  7.8958707 15.619816 ]  [ 4.023115   4.7302594 14.28684  ]]
```
You can check for reproducibility by setting a seed and/or GPU:
```
python -m spacy debug-model entity_linker_defaults.cfg --seed 342 -g 0
ℹ Fixing random seed: 342
ℹ Using GPU: 0
ℹ Analysing model with ID 52
ℹ Prediction:
[[ 4.5341725  7.0218644  8.648376 ]  [ 5.516054   9.717929  11.947002 ]  [
6.112659   8.21046   11.73882  ]  [ 5.6167803  8.703386   9.123089 ]]
```

But you can also print out **so much more** information (pipe this to a log file!)
* Print different internals:
  *  layer ID and name are always printed
  * `-DIM` prints the model's dimensions
  * `-PAR` prints the model's parameters
  * `-GRAD` prints the model's gradients
  * `-ATTR` prints the model's attributes
* Print different steps:
  * `-P0` prints the internals of the model before initialization 
  * `-P1` prints the internals of the model after initialization
  * `-P2` prints the internals of the model after training
  * `-P3` prints the final prediction (the only one that is `True` by default)
* Print different layers
  * by default all:
  * `-l` to define a string-separated list of layer IDs to focus on a subnetwork : "3, 40, 5"

One more example:
```
python -m spacy debug-model entity_linker_defaults.cfg -l "15,42" -DIM -PAR -P0 -P1 -P2 --seed 342 -g 0
ℹ Fixing random seed: 342
ℹ Using GPU: 0
ℹ Analysing model with ID 52
ℹ Before training:
ℹ Layer 15: model ID 20:
'uniqued-ints-getitem>>hashembed|ints-getitem>>hashembed|ints-getitem>>hashembed|ints-getitem>>hashembed>>maxout>>layernorm>>dropout'
ℹ  - dim nO: None
ℹ  - dim nI: None
ℹ Layer 42: model ID 14: 'maxout'
ℹ  - dim nO: 96
ℹ  - dim nI: 384
ℹ  - dim nP: 3
ℹ  - param W: None
ℹ  - param b: None
ℹ After initialization:
ℹ Layer 15: model ID 20:
'uniqued-ints-getitem>>hashembed|ints-getitem>>hashembed|ints-getitem>>hashembed|ints-getitem>>hashembed>>maxout>>layernorm>>dropout'
ℹ  - dim nO: 96
ℹ  - dim nI: None
ℹ Layer 42: model ID 14: 'maxout'
ℹ  - dim nO: 96
ℹ  - dim nI: 384
ℹ  - dim nP: 3
ℹ  - param W: (96, 3, 384) - sample: [ 0.10144017  0.23711151  0.07326661
-0.131299   -0.03610286]
ℹ  - param b: (96, 3) - sample: [0. 0. 0.]
ℹ After training:
ℹ Layer 15: model ID 20:
'uniqued-ints-getitem>>hashembed|ints-getitem>>hashembed|ints-getitem>>hashembed|ints-getitem>>hashembed>>maxout>>layernorm>>dropout'
ℹ  - dim nO: 96
ℹ  - dim nI: None
ℹ Layer 42: model ID 14: 'maxout'
ℹ  - dim nO: 96
ℹ  - dim nI: 384
ℹ  - dim nP: 3
ℹ  - param W: (96, 3, 384) - sample: [ 0.1027267   0.2345472   0.07046553
-0.13412628 -0.03398749]
ℹ  - param b: (96, 3) - sample: [0.00296839 0.00295723 0.00296982]
ℹ Prediction:
[[ 4.534172   7.021865   8.648376 ]  [ 5.516054   9.71793   11.947004 ]  [
6.1126595  8.210459  11.738819 ]  [ 5.6167803  8.703385   9.123089 ]]
```

For those of us who love staring at their monitor, tracking matrix multiplications, a true delight.
Note that currently, only the first 5 elements of a matrix are printed, which can surely be changed, just wanted some quick printer-friendly format for now.

### Types of change
enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
