### PR TITLE
fix meta serialization in train

### DIFF
--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -576,6 +576,8 @@ def train(
         with nlp.use_params(optimizer.averages):
             final_model_path = output_path / "model-final"
             nlp.to_disk(final_model_path)
+            srsly.write_json(final_model_path / "meta.json", meta)
+
             meta_loc = output_path / "model-final" / "meta.json"
             final_meta = srsly.read_json(meta_loc)
             final_meta.setdefault("accuracy", {})


### PR DESCRIPTION

## Description
The meta serialized in the _final_ model in `cli/train.py` is actually the model's meta, not the meta provided via the commandline. This overwrites the meta in the `final-model` directory before reading it in again, so it is up to date.

### Types of change
bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x ] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [ x] My changes don't require a change to the documentation, or if they do, I've added all required information.
