### PR TITLE
fix doc.to_utf8 on GPU

### DIFF
--- a/spacy/ml/_character_embed.py
+++ b/spacy/ml/_character_embed.py
@@ -34,7 +34,7 @@ def forward(model, docs, is_train):
     # for the tip.
     nCv = model.ops.xp.arange(nC)
     for doc in docs:
-        doc_ids = doc.to_utf8_array(nr_char=nC)
+        doc_ids = model.ops.asarray(doc.to_utf8_array(nr_char=nC))
         doc_vectors = model.ops.alloc3f(len(doc), nC, nM)
         # Let's say I have a 2d array of indices, and a 3d table of data. What numpy
         # incantation do I chant to get


### PR DESCRIPTION
## Description
Fix `doc.to_utf8` for usage of `CharacterEmbed` on GPU (was already fixed on `master`)

Together with https://github.com/explosion/thinc/pull/365, makes `CharEmbed` / the morphologizer work again on GPU.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
