### PR TITLE
Hyphen infix

### DIFF
--- a/spacy/lang/en/__init__.py
+++ b/spacy/lang/en/__init__.py
@@ -5,6 +5,7 @@ from .lex_attrs import LEX_ATTRS
 from .morph_rules import MORPH_RULES
 from .syntax_iterators import SYNTAX_ITERATORS
 
+from .punctuation import TOKENIZER_INFIXES
 from ..tokenizer_exceptions import BASE_EXCEPTIONS
 from ...language import Language
 from ...attrs import LANG
@@ -24,6 +25,7 @@ class EnglishDefaults(Language.Defaults):
     stop_words = STOP_WORDS
     morph_rules = MORPH_RULES
     syntax_iterators = SYNTAX_ITERATORS
+    infixes = TOKENIZER_INFIXES
     single_orth_variants = [
         {"tags": ["NFP"], "variants": ["…", "..."]},
         {"tags": [":"], "variants": ["-", "—", "–", "--", "---", "——"]},

--- a/spacy/lang/en/punctuation.py
+++ b/spacy/lang/en/punctuation.py
@@ -1,0 +1,19 @@
+from ..char_classes import LIST_ELLIPSES, LIST_ICONS, HYPHENS
+from ..char_classes import CONCAT_QUOTES, ALPHA_LOWER, ALPHA_UPPER, ALPHA, PUNCT
+
+_infixes = (
+    LIST_ELLIPSES
+    + LIST_ICONS
+    + [
+        r"(?<=[0-9])[+\-\*^](?=[0-9-])",
+        r"(?<=[{al}{q}])\.(?=[{au}{q}])".format(
+            al=ALPHA_LOWER, au=ALPHA_UPPER, q=CONCAT_QUOTES
+        ),
+        r"(?<=[{a}]),(?=[{a}])".format(a=ALPHA),
+        r"(?<=[{a}0-9])(?:{h})(?=[{a}])".format(a=ALPHA, h=HYPHENS),
+        r"(?<=[{a}0-9])[:<>=/](?=[{a}])".format(a=ALPHA),
+    ]
+)
+
+
+TOKENIZER_INFIXES = _infixes

--- a/spacy/lang/punctuation.py
+++ b/spacy/lang/punctuation.py
@@ -40,7 +40,7 @@ _infixes = (
             al=ALPHA_LOWER, au=ALPHA_UPPER, q=CONCAT_QUOTES
         ),
         r"(?<=[{a}]),(?=[{a}])".format(a=ALPHA),
-        r"(?<=[{a}])(?:{h})(?=[{a}])".format(a=ALPHA, h=HYPHENS),
+        r"(?<=[{a}0-9])(?:{h})(?=[{a}])".format(a=ALPHA, h=HYPHENS),
         r"(?<=[{a}0-9])[:<>=/](?=[{a}])".format(a=ALPHA),
     ]
 )

--- a/spacy/lang/punctuation.py
+++ b/spacy/lang/punctuation.py
@@ -40,7 +40,7 @@ _infixes = (
             al=ALPHA_LOWER, au=ALPHA_UPPER, q=CONCAT_QUOTES
         ),
         r"(?<=[{a}]),(?=[{a}])".format(a=ALPHA),
-        r"(?<=[{a}0-9])(?:{h})(?=[{a}])".format(a=ALPHA, h=HYPHENS),
+        r"(?<=[{a}])(?:{h})(?=[{a}])".format(a=ALPHA, h=HYPHENS),
         r"(?<=[{a}0-9])[:<>=/](?=[{a}])".format(a=ALPHA),
     ]
 )

--- a/spacy/tests/lang/en/test_text.py
+++ b/spacy/tests/lang/en/test_text.py
@@ -31,8 +31,6 @@ untimely death" of the rapier-tongued Scottish barrister and parliamentarian.
 )
 def test_en_tokenizer_handles_cnts(en_tokenizer, text, length):
     tokens = en_tokenizer(text)
-    for t in tokens:
-        print(t)
     assert len(tokens) == length
 
 

--- a/spacy/tests/lang/en/test_text.py
+++ b/spacy/tests/lang/en/test_text.py
@@ -26,13 +26,13 @@ untimely death" of the rapier-tongued Scottish barrister and parliamentarian.
         ("""Yes! "I'd rather have a walk", Ms. Comble sighed. """, 15),
         ("""'Me too!', Mr. P. Delaware cried. """, 11),
         ("They ran about 10km.", 6),
-        pytest.param(
-            "But then the 6,000-year ice age came...", 10, marks=pytest.mark.xfail()
-        ),
+        ("But then the 6,000-year ice age came...", 10),
     ],
 )
 def test_en_tokenizer_handles_cnts(en_tokenizer, text, length):
     tokens = en_tokenizer(text)
+    for t in tokens:
+        print(t)
     assert len(tokens) == length
 
 

--- a/spacy/tests/lang/fr/test_exceptions.py
+++ b/spacy/tests/lang/fr/test_exceptions.py
@@ -16,8 +16,6 @@ import pytest
         "grand'hamien",
         "Châteauneuf-la-Forêt",
         "Château-Guibert",
-        "11-septembre",
-        "11-Septembre",
         "refox-trottâmes",
         # u"K-POP",
         # u"K-Pop",


### PR DESCRIPTION

## Description
Currently, splitting on a hyphen as infix happens only when the hyphen is inbetween `ALPHA` characters. This PR extends that to also include cases where the previous word ends with a number `0-9`.

This solves a case like `6,000-year` which makes it 3 tokens (instead of 1).

Funnily enough, checking the test suite, we previously were testing that "11-septembre" would also be one token in French. I don't see the rationale for this? With the current edit, this would be 3 tokens and I think that's fine?

### Types of change
enhancement?

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
