### PR TITLE
Add smart_open dependency to fetch project assets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ requires = [
     "murmurhash>=0.28.0,<1.1.0",
     "thinc>=8.0.0a19,<8.0.0a30",
     "blis>=0.4.0,<0.5.0",
-    "pytokenizations"
+    "pytokenizations",
+    "smart_open>=2.0.0,<3.0.0"
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ requests>=2.13.0,<3.0.0
 tqdm>=4.38.0,<5.0.0
 pydantic>=1.3.0,<2.0.0
 pytokenizations
+smart_open>=2.0.0,<3.0.0
 # Official Python utilities
 setuptools
 packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ install_requires =
     requests>=2.13.0,<3.0.0
     pydantic>=1.3.0,<2.0.0
     pytokenizations
+    smart_open>=2.0.0,<3.0.0
     # Official Python utilities
     setuptools
     packaging

--- a/spacy/cli/project/assets.py
+++ b/spacy/cli/project/assets.py
@@ -4,6 +4,7 @@ from wasabi import msg
 import tqdm
 import re
 import shutil
+import requests
 import smart_open
 
 from ...util import ensure_path, working_dir
@@ -136,7 +137,7 @@ def convert_asset_url(url: str) -> str:
 
 
 def download_file(url: str, dest: Path, chunk_size: int = 1024) -> None:
-    """Download a file using requests.
+    """Download a file using smart_open.
 
     url (str): The URL of the file.
     dest (Path): The destination path.

--- a/spacy/cli/project/assets.py
+++ b/spacy/cli/project/assets.py
@@ -1,13 +1,14 @@
 from typing import Optional
 from pathlib import Path
 from wasabi import msg
-import requests
 import tqdm
 import re
 import shutil
+import smart_open
 
 from ...util import ensure_path, working_dir
 from .._util import project_cli, Arg, PROJECT_FILE, load_project_config, get_checksum
+
 
 
 # TODO: find a solution for caches
@@ -141,17 +142,6 @@ def download_file(url: str, dest: Path, chunk_size: int = 1024) -> None:
     dest (Path): The destination path.
     chunk_size (int): The size of chunks to read/write.
     """
-    response = requests.get(url, stream=True)
-    response.raise_for_status()
-    total = int(response.headers.get("content-length", 0))
-    progress_settings = {
-        "total": total,
-        "unit": "iB",
-        "unit_scale": True,
-        "unit_divisor": chunk_size,
-        "leave": False,
-    }
-    with dest.open("wb") as f, tqdm.tqdm(**progress_settings) as bar:
-        for data in response.iter_content(chunk_size=chunk_size):
-            size = f.write(data)
-            bar.update(size)
+    with smart_open.open(url, mode="rb") as input_file:
+        with dest.open(mode="wb") as output_file:
+            output_file.write(input_file.read())


### PR DESCRIPTION
The `spacy project assets` command really needs to support more transport options, e.g. s3, GCS etc. It's pretty limiting to only have https.

Radim developed a nice utility for this for Gensim: https://github.com/RaRe-Technologies/smart_open . It has extensions for many formats, but by default it only depends on requests, and it's been stable for quite some time now, it's quite widely used.

Using `smart_open`, the project asset download can remove our requests logic, and we'll grow support for whatever download helpers are installed alongside `smart_open`. I've tested and this works with GCS, for instance.

- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
