### PR TITLE
Sentence transformers added to spaCy universe

### DIFF
--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -1,6 +1,31 @@
 {
     "resources": [
         {
+            "id": "spacy-sentence-bert",
+            "title": "SpaCy - sentence-transformers",
+            "slogan": "Pipelines for pretrained sentence-transformers (BERT, RoBERTa, XLM-RoBERTa & Co.) directly within SpaCy",
+            "description": "This library lets you use the embeddings from [sentence-transformers](https://github.com/UKPLab/sentence-transformers) of Docs, Spans and Tokens directly from spaCy. Most models are for the english language but three of them are multilingual.",
+            "github": "MartinoMensio/spacy-sentence-bert",
+            "pip": "spacy-sentence-bert",
+            "code_example": [
+                "import spacy_sentence_bert",
+                "# load one of the models listed at https://github.com/MartinoMensio/spacy-sentence-bert/",
+                "nlp = spacy_sentence_bert.load_model('en_roberta_large_nli_stsb_mean_tokens')",
+                "# get two documents",
+                "doc_1 = nlp('Hi there, how are you?')",
+                "doc_2 = nlp('Hello there, how are you doing today?')",
+                "# use the similarity method that is based on the vectors, on Doc, Span or Token",
+                "print(doc_1.similarity(doc_2[0:7]))"
+            ],
+            "category": ["models", "pipeline"],
+            "author": "Martino Mensio",
+            "author_links": {
+                "twitter": "MartinoMensio",
+                "github": "MartinoMensio",
+                "website": "https://martinomensio.github.io"
+            }
+        },
+        {
             "id": "spacy-streamlit",
             "title": "spacy-streamlit",
             "slogan": "spaCy building blocks for Streamlit apps",

--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -58,10 +58,11 @@
             "title": "SpaCy - Universal Sentence Encoder",
             "slogan": "Make use of Google's Universal Sentence Encoder directly within SpaCy",
             "description": "This library lets you use Universal Sentence Encoder embeddings of Docs, Spans and Tokens directly from TensorFlow Hub",
-            "github": "MartinoMensio/spacy-universal-sentence-encoder-tfhub",
+            "github": "MartinoMensio/spacy-universal-sentence-encoder",
+            "pip": "spacy-universal-sentence-encoder",
             "code_example": [
                 "import spacy_universal_sentence_encoder",
-                "load one of the models: ['en_use_md', 'en_use_lg', 'xx_use_md', 'xx_use_lg']",
+                "# load one of the models: ['en_use_md', 'en_use_lg', 'xx_use_md', 'xx_use_lg']",
                 "nlp = spacy_universal_sentence_encoder.load_model('en_use_lg')",
                 "# get two documents",
                 "doc_1 = nlp('Hi there, how are you?')",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

This PR affects spaCy universe:

- some details of `spacy-universal-sentence-encoder` have been fixed (URL of repository, pypi version available, code example fixed)
- a new wrapper for spacy pipelines is added: sentence-transformers. With this package, it's possible to use [sentence-transformers](https://github.com/UKPLab/sentence-transformers) within spaCy. The package uses the `user_hooks` to retrieve an external vector representation that comes from a [siamese network](https://arxiv.org/abs/1908.10084) trained on NLI and STS data, providing therefore accurate semantic similarity measures 

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
This PR is a change in the documentation (https://spacy.io/universe)

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
