### PR TITLE
English: Identifies ordinal numbers as numbers

### DIFF
--- a/spacy/lang/en/lex_attrs.py
+++ b/spacy/lang/en/lex_attrs.py
@@ -44,6 +44,44 @@ _num_words = [
 ]
 
 
+_ordinal_words = [
+    "first",
+    "second",
+    "third",
+    "fourth",
+    "fifth",
+    "sixth",
+    "seventh",
+    "eighth",
+    "ninth",
+    "tenth",
+    "eleventh",
+    "twelfth",
+    "thirteenth",
+    "fourteenth",
+    "fifteenth",
+    "sixteenth",
+    "seventeenth",
+    "eighteenth",
+    "nineteenth",
+    "twentieth",
+    "thirtieth",
+    "fortieth",
+    "fiftieth",
+    "sixtieth",
+    "seventieth",
+    "eightieth",
+    "ninetieth",
+    "hundredth",
+    "thousandth",
+    "millionth",
+    "billionth",
+    "trillionth",
+    "quadrillionth",
+    "gajillionth",
+    "bazillionth",
+]
+
 def like_num(text):
     if text.startswith(("+", "-", "±", "~")):
         text = text[1:]
@@ -54,8 +92,18 @@ def like_num(text):
         num, denom = text.split("/")
         if num.isdigit() and denom.isdigit():
             return True
-    if text.lower() in _num_words:
+    
+    text_lower = text.lower()
+    if text_lower in _num_words:
         return True
+
+    # CHeck ordinal number
+    if text_lower in _ordinal_words:
+        return True
+    if text_lower.endswith("th"):
+        if text_lower[:-2].isdigit():
+            return True 
+
     return False
 
 

--- a/spacy/tests/lang/en/test_text.py
+++ b/spacy/tests/lang/en/test_text.py
@@ -61,6 +61,19 @@ def test_lex_attrs_like_number(en_tokenizer, text, match):
     assert tokens[0].like_num == match
 
 
+@pytest.mark.parametrize(
+    "word",
+    [
+        "third",
+        "Millionth",
+        "100th",
+        "Hundredth",
+    ]
+)
+def test_en_lex_attrs_like_number_for_ordinal(word):
+    assert like_num(word)
+
+
 @pytest.mark.parametrize("word", ["eleven"])
 def test_en_lex_attrs_capitals(word):
     assert like_num(word)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->
This PR adds support to identify ordinal numbers as numders. 

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
- A bug fix to an issue raised in https://github.com/explosion/spaCy/issues/5827

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
