### PR TITLE
Allow components to define package requirements

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -483,6 +483,7 @@ class Errors:
     E199 = ("Unable to merge 0-length span at doc[{start}:{end}].")
 
     # TODO: fix numbering after merging develop into master
+    E952 = ("Invalid requirement specified by component '{name}': {req}")
     E953 = ("Mismatched IDs received by the Tok2Vec listener: {id1} vs. {id2}")
     E954 = ("The Tok2Vec listener did not receive a valid input.")
     E955 = ("Can't find table '{table}' for language '{lang}' in spacy-lookups-data.")

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -203,6 +203,7 @@ class Language:
         self._meta.setdefault("url", "")
         self._meta.setdefault("license", "")
         self._meta.setdefault("spacy_git_version", GIT_VERSION)
+        self._meta.setdefault("requirements", [])
         self._meta["vectors"] = {
             "width": self.vocab.vectors_length,
             "vectors": len(self.vocab.vectors),
@@ -210,6 +211,8 @@ class Language:
             "name": self.vocab.vectors.name,
         }
         self._meta["labels"] = self.pipe_labels
+        reqs = {p: self.get_pipe_meta(p).package_requirements for p in self.pipe_names}
+        self._meta["requirements"].extend(util.merge_pipe_requirements(reqs))
         return self._meta
 
     @meta.setter
@@ -356,6 +359,7 @@ class Language:
         retokenizes: bool = False,
         scores: Iterable[str] = tuple(),
         default_score_weights: Dict[str, float] = SimpleFrozenDict(),
+        package_requirements: Iterable[str] = tuple(),
         func: Optional[Callable] = None,
     ) -> Callable:
         """Register a new pipeline component factory. Can be used as a decorator
@@ -410,6 +414,7 @@ class Language:
                 scores=scores,
                 default_score_weights=default_score_weights,
                 retokenizes=retokenizes,
+                package_requirements=package_requirements,
             )
             cls.set_factory_meta(name, factory_meta)
             # We're overwriting the class attr with a frozen dict to handle
@@ -435,6 +440,7 @@ class Language:
         retokenizes: bool = False,
         scores: Iterable[str] = tuple(),
         default_score_weights: Dict[str, float] = SimpleFrozenDict(),
+        package_requirements: Iterable[str] = tuple(),
         func: Optional[Callable[[Doc], Doc]] = None,
     ) -> Callable:
         """Register a new pipeline component. Can be used for stateless function
@@ -476,6 +482,7 @@ class Language:
                 retokenizes=retokenizes,
                 scores=scores,
                 default_score_weights=default_score_weights,
+                package_requirements=package_requirements,
                 func=factory_func,
             )
             return component_func
@@ -1513,6 +1520,7 @@ class FactoryMeta:
     retokenizes: bool = False
     scores: Iterable[str] = tuple()
     default_score_weights: Optional[Dict[str, float]] = None  # noqa: E704
+    package_requirements: Iterable[str] = tuple()
 
 
 def _get_config_overrides(

--- a/spacy/tests/test_misc.py
+++ b/spacy/tests/test_misc.py
@@ -157,3 +157,15 @@ def test_dot_to_dict(dot_notation, expected):
     result = util.dot_to_dict(dot_notation)
     assert result == expected
     assert util.dict_to_dot(result) == dot_notation
+
+
+@pytest.mark.parametrize(
+    "reqs,expected",
+    [
+        ([["a>=3.0,<2.0", "b[x]>2.1"], ["b<3.0"]], ["a<2.0,>=3.0", "b[x]<3.0,>2.1"],),
+        ([["a[foo]<1"], ["a[bar]>=5"]], ["a[bar,foo]<1,>=5"]),
+    ],
+)
+def test_merge_pipe_requirements(reqs, expected):
+    pipe_reqs = {str(i): req for i, req in enumerate(reqs)}
+    assert util.merge_pipe_requirements(pipe_reqs) == expected

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -406,7 +406,7 @@ def merge_pipe_requirements(pipe_requirements: Dict[str, Iterable[str]]) -> List
             try:
                 req = Requirement(req_str)
             except InvalidRequirement:
-                raise ValueError(Errors.E952.format(name=name, req=req_str))
+                raise ValueError(Errors.E951.format(name=name, req=req_str))
             if req.name not in result:
                 result[req.name] = req
             else:


### PR DESCRIPTION
## Description

I think this could be useful in practice?

```python
@Language.factory("my_component", package_requirements=["spacy_transformers>=1.0,<2.0"])
def make_my_component(nlp, name):
   ...
```

Any package requirements defined by the components will be included in a packaged model's install requirements automatically. So installing the model will install the dependencies.


### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
