### PR TITLE
Bugfix tagmap state

### DIFF
--- a/spacy/pipeline/tagger.pyx
+++ b/spacy/pipeline/tagger.pyx
@@ -152,7 +152,7 @@ class Tagger(Pipe):
         cdef Doc doc
         cdef int idx = 0
         cdef Vocab vocab = self.vocab
-        assign_morphology = self.cfg.get("set_morphology", True)
+        assign_morphology = self.cfg["set_morphology"]
         for i, doc in enumerate(docs):
             doc_tag_ids = batch_tag_ids[i]
             if hasattr(doc_tag_ids, "get"):

--- a/spacy/tests/doc/test_morphanalysis.py
+++ b/spacy/tests/doc/test_morphanalysis.py
@@ -1,10 +1,13 @@
 import pytest
 from spacy.symbols import POS, PRON, VERB
+from spacy.util import get_lang_class
 
 
 @pytest.fixture
-def i_has(en_tokenizer):
-    doc = en_tokenizer("I has")
+def i_has():
+    # don't use en_tokenizer to avoid setting state across the test suite
+    tokenizer = get_lang_class("en")().tokenizer
+    doc = tokenizer("I has")
     tag_map = {
         "PRP": {POS: PRON, "PronType": "prs"},
         "VBZ": {
@@ -15,7 +18,7 @@ def i_has(en_tokenizer):
             "Person": "three",
         },
     }
-    en_tokenizer.vocab.morphology.load_tag_map(tag_map)
+    tokenizer.vocab.morphology.load_tag_map(tag_map)
     doc[0].tag_ = "PRP"
     doc[1].tag_ = "VBZ"
     return doc

--- a/spacy/tests/lang/en/test_tagger.py
+++ b/spacy/tests/lang/en/test_tagger.py
@@ -1,8 +1,12 @@
 from spacy.symbols import POS, PRON, VERB, DET, NOUN, PUNCT
+
+from spacy.util import get_lang_class
 from ...util import get_doc
 
 
-def test_en_tagger_load_morph_exc(en_tokenizer):
+def test_en_tagger_load_morph_exc():
+    # don't use en_tokenizer to avoid setting state across the test suite
+    tokenizer = get_lang_class("en")().tokenizer
     text = "I like his style."
     tags = ["PRP", "VBP", "PRP$", "NN", "."]
     tag_map = {
@@ -13,9 +17,9 @@ def test_en_tagger_load_morph_exc(en_tokenizer):
         ".": {POS: PUNCT},
     }
     morph_exc = {"VBP": {"like": {"lemma": "luck"}}}
-    en_tokenizer.vocab.morphology.load_tag_map(tag_map)
-    en_tokenizer.vocab.morphology.load_morph_exceptions(morph_exc)
-    tokens = en_tokenizer(text)
+    tokenizer.vocab.morphology.load_tag_map(tag_map)
+    tokenizer.vocab.morphology.load_morph_exceptions(morph_exc)
+    tokens = tokenizer(text)
     doc = get_doc(tokens.vocab, words=[t.text for t in tokens], tags=tags)
     assert doc[1].tag_ == "VBP"
     assert doc[1].lemma_ == "luck"

--- a/spacy/tests/parser/test_parse.py
+++ b/spacy/tests/parser/test_parse.py
@@ -82,11 +82,12 @@ def test_parser_merge_pp(en_tokenizer):
     text = "A phrase with another phrase occurs"
     heads = [1, 4, -1, 1, -2, 0]
     deps = ["det", "nsubj", "prep", "det", "pobj", "ROOT"]
-    tags = ["DT", "NN", "IN", "DT", "NN", "VBZ"]
+    pos = ["DET", "NOUN", "ADP", "DET", "NOUN", "VERB"]
     tokens = en_tokenizer(text)
     doc = get_doc(
-        tokens.vocab, words=[t.text for t in tokens], deps=deps, heads=heads, tags=tags
+        tokens.vocab, words=[t.text for t in tokens], deps=deps, heads=heads, pos=pos
     )
+    assert len(list(doc.noun_chunks)) == 2
     with doc.retokenize() as retokenizer:
         for np in doc.noun_chunks:
             retokenizer.merge(np, attrs={"lemma": np.lemma_})


### PR DESCRIPTION


## Description
A bug in the test suite (accumulating `tag_map` state on `en_tokenizer`) was obscuring a bug in one specific test (which should use `pos` instead of `tags` in `get_doc`). The test however did fail when ran individually.

This PR fixes both bugs + removes an instance of a hidden default in `self.cfg.get("set_morphology", True)`

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
