### PR TITLE
Allow adding pipeline components from source model

### DIFF
--- a/examples/experiments/onto-joint/defaults.cfg
+++ b/examples/experiments/onto-joint/defaults.cfg
@@ -28,8 +28,8 @@ batch_by = "words"
 raw_text = null
 tag_map = null
 vectors = null
-base_model = null
 morph_rules = null
+frozen_components = []
 
 [training.batch_size]
 @schedules = "compounding.v1"

--- a/spacy/cli/_util.py
+++ b/spacy/cli/_util.py
@@ -6,7 +6,7 @@ import hashlib
 import typer
 from typer.main import get_command
 from contextlib import contextmanager
-from thinc.config import ConfigValidationError
+from thinc.config import Config, ConfigValidationError
 from configparser import InterpolationError
 import sys
 
@@ -217,3 +217,15 @@ def import_code(code_path: Optional[Union[Path, str]]) -> None:
             import_file("python_code", code_path)
         except Exception as e:
             msg.fail(f"Couldn't load Python code: {code_path}", e, exits=1)
+
+
+def get_sourced_components(config: Union[Dict[str, Any], Config]) -> List[str]:
+    """RETURNS (List[str]): All sourced components in the original config,
+        e.g. {"source": "en_core_web_sm"}. If the config contains a key
+        "factory", we assume it refers to a component factory.
+    """
+    return [
+        name
+        for name, cfg in config.get("components", {}).items()
+        if "factory" not in cfg and "source" in cfg
+    ]

--- a/spacy/cli/debug_data.py
+++ b/spacy/cli/debug_data.py
@@ -8,7 +8,7 @@ import typer
 from thinc.api import Config
 
 from ._util import app, Arg, Opt, show_validation_error, parse_config_overrides
-from ._util import import_code, debug_cli
+from ._util import import_code, debug_cli, get_sourced_components
 from ..gold import Corpus, Example
 from ..pipeline._parser_internals import nonproj
 from ..language import Language
@@ -138,9 +138,10 @@ def debug_data(
     with show_validation_error(config_path):
         cfg = Config().from_disk(config_path)
         nlp, config = util.load_model_from_config(cfg, overrides=config_overrides)
-    # TODO: handle base model
-    lang = config["nlp"]["lang"]
-    base_model = config["training"]["base_model"]
+    # Use original config here, not resolved version
+    sourced_components = get_sourced_components(cfg)
+    frozen_components = config["training"]["frozen_components"]
+    resume_components = [p for p in sourced_components if p not in frozen_components]
     pipeline = nlp.pipe_names
     factory_names = [nlp.get_pipe_meta(pipe).factory for pipe in nlp.pipe_names]
     tag_map_path = util.ensure_path(config["training"]["tag_map"])
@@ -188,13 +189,15 @@ def debug_data(
 
     train_texts = gold_train_data["texts"]
     dev_texts = gold_dev_data["texts"]
+    frozen_components = config["training"]["frozen_components"]
 
     msg.divider("Training stats")
+    msg.text(f"Language: {config['nlp']['lang']}")
     msg.text(f"Training pipeline: {', '.join(pipeline)}")
-    if base_model:
-        msg.text(f"Starting with base model '{base_model}'")
-    else:
-        msg.text(f"Starting with blank model '{lang}'")
+    if resume_components:
+        msg.text(f"Components from other models: {', '.join(resume_components)}")
+    if frozen_components:
+        msg.text(f"Frozen components: {', '.join(frozen_components)}")
     msg.text(f"{len(train_dataset)} training docs")
     msg.text(f"{len(dev_dataset)} evaluation docs")
 
@@ -205,7 +208,9 @@ def debug_data(
         msg.warn(f"{overlap} training examples also in evaluation data")
     else:
         msg.good("No overlap between training and evaluation data")
-    if not base_model and len(train_dataset) < BLANK_MODEL_THRESHOLD:
+    # TODO: make this feedback more fine-grained and report on updated
+    # components vs. blank components
+    if not resume_components and len(train_dataset) < BLANK_MODEL_THRESHOLD:
         text = (
             f"Low number of examples to train from a blank model ({len(train_dataset)})"
         )

--- a/spacy/default_config.cfg
+++ b/spacy/default_config.cfg
@@ -41,10 +41,11 @@ discard_oversize = false
 raw_text = null
 tag_map = null
 morph_rules = null
-base_model = null
 vectors = null
 batch_by = "words"
 batch_size = 1000
+# Names of pipeline components that shouldn't be updated during training
+frozen_components = []
 
 [training.optimizer]
 @optimizers = "Adam.v1"

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -481,6 +481,10 @@ class Errors:
     E199 = ("Unable to merge 0-length span at doc[{start}:{end}].")
 
     # TODO: fix numbering after merging develop into master
+    E945 = ("Can't copy pipeline component '{name}' from source model '{model}': "
+            "not found in pipeline. Available components: {opts}")
+    E946 = ("Can't copy pipeline component '{name}' from source. Expected loaded "
+            "nlp object, but got: {source}")
     E947 = ("Matcher.add received invalid 'greedy' argument: expected "
             "a string value from {expected} but got: '{arg}'")
     E948 = ("Matcher.add received invalid 'patterns' argument: expected "
@@ -567,11 +571,13 @@ class Errors:
             "into {values}, but found {value}.")
     E983 = ("Invalid key for '{dict}': {key}. Available keys: "
             "{keys}")
-    E984 = ("Invalid component config for '{name}': no 'factory' key "
-            "specifying the registered function used to initialize the "
-            "component. For example, factory = \"ner\" will use the 'ner' "
-            "factory and all other settings in the block will be passed "
-            "to it as arguments.\n\n{config}")
+    E984 = ("Invalid component config for '{name}': component block needs either "
+            "a key 'factory' specifying the registered function used to "
+            "initialize the component, or a key 'source' key specifying a "
+            "spaCy model to copy the component from. For example, factory = "
+            "\"ner\" will use the 'ner' factory and all other settings in the "
+            "block will be passed to it as arguments. Alternatively, source = "
+            "\"en_core_web_sm\" will copy the component from that model.\n\n{config}")
     E985 = ("Can't load model from config file: no 'nlp' section found.\n\n{config}")
     E986 = ("Could not create any training batches: check your input. "
             "Perhaps discard_oversize should be set to False ?")

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1497,7 +1497,7 @@ class Language:
                         # We only need the components here, no other data
                         disable = ["vocab", "tokenizer"]
                         source_nlps[model] = util.load_model(model, disable=disable)
-                    source_name = pipe_cfg.get("name", pipe_name)
+                    source_name = pipe_cfg.get("component", pipe_name)
                     nlp.add_pipe(source_name, source=source_nlps[model], name=pipe_name)
         nlp.config = filled if auto_fill else config
         nlp.resolved = resolved

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -640,7 +640,7 @@ class Language:
         if not isinstance(source, self.__class__):
             raise ValueError(Errors.E946.format(name=source_name, source=type(source)))
         if not source.has_pipe(source_name):
-            raise ValueError(
+            raise KeyError(
                 Errors.E945.format(
                     name=source_name,
                     model=f"{source.meta['lang']}_{source.meta['name']}",

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -636,10 +636,17 @@ class Language:
         reset_weights (bool): Whether to reset the component's weights.
         RETURNS (Tuple[Callable, str]): The component and its factory name.
         """
-        # TODO: handle errors and mismatches
+        # TODO: handle errors and mismatches (vectors etc.)
         if not isinstance(source, self.__class__):
-            raise ValueError("TODO: source needs to be nlp object")
-        # TODO: custom errors if component not in source pipeline
+            raise ValueError(Errors.E946.format(name=source_name, source=type(source)))
+        if not source.has_pipe(source_name):
+            raise ValueError(
+                Errors.E945.format(
+                    name=source_name,
+                    model=f"{source.meta['lang']}_{source.meta['name']}",
+                    opts=", ".join(source.pipe_names),
+                )
+            )
         pipe = source.get_pipe(source_name)
         if reset_weights and hasattr(pipe, "begin_training"):
             pipe.begin_training()
@@ -1476,7 +1483,6 @@ class Language:
                 raise ValueError(Errors.E956.format(name=pipe_name, opts=opts))
             pipe_cfg = util.copy_config(pipeline[pipe_name])
             if pipe_name not in disable:
-                # TODO: update error message
                 if "factory" not in pipe_cfg and "source" not in pipe_cfg:
                     err = Errors.E984.format(name=pipe_name, config=pipe_cfg)
                     raise ValueError(err)

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1151,7 +1151,6 @@ class Language:
         scorer: Optional[Scorer] = None,
         component_cfg: Optional[Dict[str, Dict[str, Any]]] = None,
         scorer_cfg: Optional[Dict[str, Any]] = None,
-        exclude: Iterable[str] = tuple(),
     ) -> Dict[str, Union[float, dict]]:
         """Evaluate a model's pipeline components.
 
@@ -1164,7 +1163,6 @@ class Language:
             arguments for specific components.
         scorer_cfg (dict): An optional dictionary with extra keyword arguments
             for the scorer.
-        exclude (Iterable[str]): Names of components that shouldn't be evaluated.
         RETURNS (Scorer): The scorer containing the evaluation results.
 
         DOCS: https://spacy.io/api/language#evaluate
@@ -1198,8 +1196,6 @@ class Language:
         else:
             _ = list(self.tokenizer.pipe(texts))  # noqa: F841
         for name, pipe in self.pipeline:
-            if name in exclude:
-                continue
             kwargs = component_cfg.get(name, {})
             kwargs.setdefault("batch_size", batch_size)
             if not hasattr(pipe, "pipe"):

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -632,10 +632,10 @@ class Language:
         """
         # TODO: handle errors and mismatches (vectors etc.)
         if not isinstance(source, self.__class__):
-            raise ValueError(Errors.E946.format(name=source_name, source=type(source)))
+            raise ValueError(Errors.E945.format(name=source_name, source=type(source)))
         if not source.has_pipe(source_name):
             raise KeyError(
-                Errors.E945.format(
+                Errors.E944.format(
                     name=source_name,
                     model=f"{source.meta['lang']}_{source.meta['name']}",
                     opts=", ".join(source.pipe_names),

--- a/spacy/schemas.py
+++ b/spacy/schemas.py
@@ -181,7 +181,6 @@ class ModelMetaSchema(BaseModel):
 
 class ConfigSchemaTraining(BaseModel):
     # fmt: off
-    base_model: Optional[StrictStr] = Field(..., title="The base model to use")
     vectors: Optional[StrictStr] = Field(..., title="Path to vectors")
     gold_preproc: StrictBool = Field(..., title="Whether to train on gold-standard sentences and tokens")
     max_length: StrictInt = Field(..., title="Maximum length of examples (longer examples are divided into sentences if possible)")
@@ -205,6 +204,7 @@ class ConfigSchemaTraining(BaseModel):
     morph_rules: Optional[StrictStr] = Field(..., title="Path to morphology rules")
     batch_size: Union[Sequence[int], int] = Field(..., title="The batch size or batch size schedule")
     optimizer: Optimizer = Field(..., title="The optimizer to use")
+    frozen_components: List[str] = Field(..., title="Pipeline components that shouldn't be updated during training")
     # fmt: on
 
     class Config:

--- a/spacy/tests/pipeline/test_pipe_factories.py
+++ b/spacy/tests/pipeline/test_pipe_factories.py
@@ -8,6 +8,8 @@ from thinc.api import Model, Linear
 from thinc.config import ConfigValidationError
 from pydantic import StrictInt, StrictStr
 
+from ..util import make_tempdir
+
 
 def test_pipe_function_component():
     name = "test_component"
@@ -374,3 +376,65 @@ def test_language_factories_scores():
     cfg = nlp.config["training"]
     expected_weights = {"a1": 0.25, "a2": 0.25, "b1": 0.1, "b2": 0.35, "b3": 0.05}
     assert cfg["score_weights"] == expected_weights
+
+
+def test_pipe_factories_from_source():
+    """Test adding components from a source model."""
+    source_nlp = English()
+    source_nlp.add_pipe("tagger", name="my_tagger")
+    nlp = English()
+    with pytest.raises(ValueError):
+        nlp.add_pipe("my_tagger", source="en_core_web_sm")
+    nlp.add_pipe("my_tagger", source=source_nlp)
+    assert "my_tagger" in nlp.pipe_names
+    with pytest.raises(KeyError):
+        nlp.add_pipe("custom", source=source_nlp)
+
+
+def test_pipe_factories_from_source_custom():
+    """Test adding components from a source model with custom components."""
+    name = "test_pipe_factories_from_source_custom"
+
+    @Language.factory(name, default_config={"arg": "hello"})
+    def test_factory(nlp, name, arg: str):
+        return lambda doc: doc
+
+    source_nlp = English()
+    source_nlp.add_pipe("tagger")
+    source_nlp.add_pipe(name, config={"arg": "world"})
+    nlp = English()
+    nlp.add_pipe(name, source=source_nlp)
+    assert name in nlp.pipe_names
+    assert nlp.get_pipe_meta(name).default_config["arg"] == "hello"
+    config = nlp.config["components"][name]
+    assert config["factory"] == name
+    assert config["arg"] == "world"
+
+
+def test_pipe_factories_from_source_config():
+    name = "test_pipe_factories_from_source_config"
+
+    @Language.factory(name, default_config={"arg": "hello"})
+    def test_factory(nlp, name, arg: str):
+        return lambda doc: doc
+
+    source_nlp = English()
+    source_nlp.add_pipe("tagger")
+    source_nlp.add_pipe(name, name="yolo", config={"arg": "world"})
+    dest_nlp_cfg = {"lang": "en", "pipeline": ["parser", "custom"]}
+    with make_tempdir() as tempdir:
+        source_nlp.to_disk(tempdir)
+        dest_components_cfg = {
+            "parser": {"factory": "parser"},
+            "custom": {"source": str(tempdir), "name": "yolo"},
+        }
+        dest_config = {"nlp": dest_nlp_cfg, "components": dest_components_cfg}
+        nlp = English.from_config(dest_config)
+    assert nlp.pipe_names == ["parser", "custom"]
+    assert nlp.pipe_factories == {"parser": "parser", "custom": name}
+    meta = nlp.get_pipe_meta("custom")
+    assert meta.factory == name
+    assert meta.default_config["arg"] == "hello"
+    config = nlp.config["components"]["custom"]
+    assert config["factory"] == name
+    assert config["arg"] == "world"

--- a/spacy/tests/pipeline/test_pipe_factories.py
+++ b/spacy/tests/pipeline/test_pipe_factories.py
@@ -426,7 +426,7 @@ def test_pipe_factories_from_source_config():
         source_nlp.to_disk(tempdir)
         dest_components_cfg = {
             "parser": {"factory": "parser"},
-            "custom": {"source": str(tempdir), "name": "yolo"},
+            "custom": {"source": str(tempdir), "component": "yolo"},
         }
         dest_config = {"nlp": dest_nlp_cfg, "components": dest_components_cfg}
         nlp = English.from_config(dest_config)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

This PR adds support for adding pipeline components from other loadable models.

In code:
```python
source_nlp = spacy.load("en_core_web_sm")
nlp = spacy_blank("en")
nlp.add_pipe("parser", source=source_nlp)
```

In config:
```ini
[components.my_parser]
source = "en_core_web_sm"
component = "parser"
```

* `source`: loadable spaCy model
* `component`: optional name of component in the source pipeline, defaults to instance name in the target pipeline

This also solves the "training from a base model" problem: instead of providing a base model, the config can provide the components to source from the base model. It can also provide a list of `frozen_components` that are not updated. In this example, the final trained pipeline will contain 3 components that are updated/not updated in different ways:

```ini
[nlp]
lang = "en"
pipeline = ["tagger", "parser", "ner"]

[training]
frozen_components = ["ner"]

[components.parser]  # new component trained from scratch
factory = "parser"

[components.tagger]  # sourced component, updated with more examples
source = "en_core_web_sm"

[components.ner]  # frozen component, not updated
source = "en_core_web_sm"
```

### Notes

- `add_pipe` takes a loaded source object, which allows the user to load the model however they want and share the same loaded model across multiple calls
- In `Language.from_config` we cache `source` models of the same name so each source is only ever loaded once. We also disable loading the vocab, because we don't need that. (This means that we still load all pipeline components, but the overhead from this is hopefully minimal – the alternative would be implemending a mechanism for explicitly _enabling_ specific components only, so we can only load the `parser`, even if we don't know any of the other components in the pipeline.)
- The behaviour of `add_pipe` with a `source` set is slightly inconsistent: the first argument here doesn't specify the factory name but the component instance name in the source `nlp` object. It does feel pretty natural and logical, though, so I think it's okay? The name here corresponds to the `component` in the config, so you can copy a component called `some_parser` powered by the factory `parser` and add it to your pipeline as `my_parser`, without any conflicts.

### Todos

- [ ] What to do about basic compatibility checks, e.g. vectors? We can't know what needs/uses them and whether the incompatibility matters or not... Also, what else should we check? Language? That can be an issue, but doesn't have to be.
- [x] Improve error handling

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
