### PR TITLE
Example Dict format consistency

### DIFF
--- a/spacy/gold/example.pyx
+++ b/spacy/gold/example.pyx
@@ -346,8 +346,6 @@ def _fix_legacy_dict_data(example_dict):
         # If heads are set, we don't also redundantly specify SENT_START.
         token_dict.pop("SENT_START")
         warnings.warn(Warnings.W092)
-    print("token_dict", token_dict)
-    print("doc_dict", doc_dict)
     return {
         "token_annotation": token_dict,
         "doc_annotation": doc_dict

--- a/spacy/gold/example.pyx
+++ b/spacy/gold/example.pyx
@@ -179,7 +179,6 @@ cdef class Example:
                 "links": self._links_to_dict()
             },
             "token_annotation": {
-                "ID": [t.i+1 for t in self.reference],
                 "ORTH": [t.text for t in self.reference],
                 "SPACY": [bool(t.whitespace_) for t in self.reference],
                 "TAG": [t.tag_ for t in self.reference],

--- a/spacy/pipeline/senter.pyx
+++ b/spacy/pipeline/senter.pyx
@@ -108,7 +108,7 @@ class SentenceRecognizer(Tagger):
         truths = []
         for eg in examples:
             eg_truth = []
-            for x in eg.get_aligned("sent_start"):
+            for x in eg.get_aligned("SENT_START"):
                 if x is None:
                     eg_truth.append(None)
                 elif x == 1:

--- a/spacy/pipeline/tagger.pyx
+++ b/spacy/pipeline/tagger.pyx
@@ -259,7 +259,7 @@ class Tagger(Pipe):
         DOCS: https://spacy.io/api/tagger#get_loss
         """
         loss_func = SequenceCategoricalCrossentropy(names=self.labels, normalize=False)
-        truths = [eg.get_aligned("tag", as_string=True) for eg in examples]
+        truths = [eg.get_aligned("TAG", as_string=True) for eg in examples]
         d_scores, loss = loss_func(scores, truths)
         if self.model.ops.xp.isnan(loss):
             raise ValueError("nan value when computing loss")

--- a/spacy/tests/test_gold.py
+++ b/spacy/tests/test_gold.py
@@ -647,11 +647,11 @@ def test_split_sents(merged_dict):
     assert split_examples[1].text == "It is just me"
 
     token_annotation_1 = split_examples[0].to_dict()["token_annotation"]
-    assert token_annotation_1["words"] == ["Hi", "there", "everyone"]
-    assert token_annotation_1["tags"] == ["INTJ", "ADV", "PRON"]
-    assert token_annotation_1["sent_starts"] == [1, 0, 0]
+    assert token_annotation_1["ORTH"] == ["Hi", "there", "everyone"]
+    assert token_annotation_1["TAG"] == ["INTJ", "ADV", "PRON"]
+    assert token_annotation_1["SENT_START"] == [1, 0, 0]
 
     token_annotation_2 = split_examples[1].to_dict()["token_annotation"]
-    assert token_annotation_2["words"] == ["It", "is", "just", "me"]
-    assert token_annotation_2["tags"] == ["PRON", "AUX", "ADV", "PRON"]
-    assert token_annotation_2["sent_starts"] == [1, 0, 0, 0]
+    assert token_annotation_2["ORTH"] == ["It", "is", "just", "me"]
+    assert token_annotation_2["TAG"] == ["PRON", "AUX", "ADV", "PRON"]
+    assert token_annotation_2["SENT_START"] == [1, 0, 0, 0]

--- a/spacy/tests/test_new_example.py
+++ b/spacy/tests/test_new_example.py
@@ -42,7 +42,7 @@ def test_Example_from_dict_with_tags(pred_words, annots):
     example = Example.from_dict(predicted, annots)
     for i, token in enumerate(example.reference):
         assert token.tag_ == annots["tags"][i]
-    aligned_tags = example.get_aligned("tag", as_string=True)
+    aligned_tags = example.get_aligned("TAG", as_string=True)
     assert aligned_tags == ["NN" for _ in predicted]
 
 
@@ -53,9 +53,13 @@ def test_aligned_tags():
     annots = {"words": gold_words, "tags": gold_tags}
     vocab = Vocab()
     predicted = Doc(vocab, words=pred_words)
-    example = Example.from_dict(predicted, annots)
-    aligned_tags = example.get_aligned("tag", as_string=True)
-    assert aligned_tags == ["VERB", "DET", "NOUN", "SCONJ", "PRON", "VERB", "VERB"]
+    example1 = Example.from_dict(predicted, annots)
+    aligned_tags1 = example1.get_aligned("TAG", as_string=True)
+    assert aligned_tags1 == ["VERB", "DET", "NOUN", "SCONJ", "PRON", "VERB", "VERB"]
+    # ensure that to_dict works correctly
+    example2 = Example.from_dict(predicted, example1.to_dict())
+    aligned_tags2 = example2.get_aligned("TAG", as_string=True)
+    assert aligned_tags2 == ["VERB", "DET", "NOUN", "SCONJ", "PRON", "VERB", "VERB"]
 
 
 def test_aligned_tags_multi():
@@ -66,7 +70,7 @@ def test_aligned_tags_multi():
     vocab = Vocab()
     predicted = Doc(vocab, words=pred_words)
     example = Example.from_dict(predicted, annots)
-    aligned_tags = example.get_aligned("tag", as_string=True)
+    aligned_tags = example.get_aligned("TAG", as_string=True)
     assert aligned_tags == [None, None, "SCONJ", "PRON", "VERB", "VERB"]
 
 


### PR DESCRIPTION
## Description
For `Example`, we support two kind of dictionaries. 

1.  A simple one with entries like "tags", "words", etc
2. A more complex one with a sub-level `token_annotation` which should contain fields from `attr.IDS` such as "TAG" and "ORTH".

The function`get_aligned` uses the `IDS` fields (cf format 2) and I think we should put them in uppercase always to avoid confusion ("TAG" vs "tags" vs "tag" gets confusing)  

The `example.to_dict` method should output a format that is consistent (it was now a mixture of the two), and this format should be supported by the `example.from_dict` method (which wasn't the case if e.g. the dictionary had an entry `[token_annotation][TAG]`). As format 1 is considered "legacy", I think it makes sense to have `to_dict` output results in format 2.

Working on the documentation in a separate branch.

### Types of change
enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
