### PR TITLE
Prevent alignment when texts don't match

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -485,6 +485,7 @@ class Errors:
             "a string value from {expected} but got: '{arg}'")
     E948 = ("Matcher.add received invalid 'patterns' argument: expected "
             "a List, but got: {arg_type}")
+    E949 = ("Can only create an alignment when the texts are the same.")
     E952 = ("The section '{name}' is not a valid section in the provided config.")
     E953 = ("Mismatched IDs received by the Tok2Vec listener: {id1} vs. {id2}")
     E954 = ("The Tok2Vec listener did not receive a valid input.")

--- a/spacy/gold/align.py
+++ b/spacy/gold/align.py
@@ -4,6 +4,8 @@ from thinc.types import Ragged
 from dataclasses import dataclass
 import tokenizations
 
+from ..errors import Errors
+
 
 @dataclass
 class Alignment:
@@ -18,6 +20,8 @@ class Alignment:
 
     @classmethod
     def from_strings(cls, A: List[str], B: List[str]) -> "Alignment":
+        if "".join(A).replace(" ", "").lower() != "".join(B).replace(" ", "").lower():
+            raise ValueError(Errors.E949)
         x2y, y2x = tokenizations.get_alignments(A, B)
         return Alignment.from_indices(x2y=x2y, y2x=y2x)
 

--- a/spacy/tests/test_gold.py
+++ b/spacy/tests/test_gold.py
@@ -1,5 +1,5 @@
 import numpy
-from spacy.gold import biluo_tags_from_offsets, offsets_from_biluo_tags
+from spacy.gold import biluo_tags_from_offsets, offsets_from_biluo_tags, Alignment
 from spacy.gold import spans_from_biluo_tags, iob_to_biluo
 from spacy.gold import Corpus, docs_to_json
 from spacy.gold.example import Example
@@ -655,3 +655,13 @@ def test_split_sents(merged_dict):
     assert token_annotation_2["words"] == ["It", "is", "just", "me"]
     assert token_annotation_2["tags"] == ["PRON", "AUX", "ADV", "PRON"]
     assert token_annotation_2["sent_starts"] == [1, 0, 0, 0]
+
+
+def test_alignment():
+    other_tokens = ["obama", "'", "s", "podcasts", "."]
+    spacy_tokens = ["obama", "'s", "podcasts", "."]
+    align = Alignment.from_strings(other_tokens, spacy_tokens)
+    assert list(align.x2y.lengths) == [1, 1, 1, 1, 1]
+    assert list(align.x2y.dataXd) == [0, 1, 1, 2, 3] # the second and third token both refer to "'s"
+    assert list(align.y2x.lengths) == [1, 2, 1, 1]   # the second token "'s" splits out in two
+    assert list(align.y2x.dataXd) == [0, 1, 2, 3, 4]

--- a/spacy/tests/test_gold.py
+++ b/spacy/tests/test_gold.py
@@ -658,10 +658,37 @@ def test_split_sents(merged_dict):
 
 
 def test_alignment():
-    other_tokens = ["obama", "'", "s", "podcasts", "."]
-    spacy_tokens = ["obama", "'s", "podcasts", "."]
+    other_tokens = ["i", "listened", "to", "obama", "'", "s", "podcasts", "."]
+    spacy_tokens = ["i", "listened", "to", "obama", "'s", "podcasts", "."]
     align = Alignment.from_strings(other_tokens, spacy_tokens)
-    assert list(align.x2y.lengths) == [1, 1, 1, 1, 1]
-    assert list(align.x2y.dataXd) == [0, 1, 1, 2, 3] # the second and third token both refer to "'s"
-    assert list(align.y2x.lengths) == [1, 2, 1, 1]   # the second token "'s" splits out in two
-    assert list(align.y2x.dataXd) == [0, 1, 2, 3, 4]
+    assert list(align.x2y.lengths) == [1, 1, 1, 1, 1, 1, 1, 1]
+    assert list(align.x2y.dataXd) == [0, 1, 2, 3, 4, 4, 5, 6]  # two tokens both refer to "'s"
+    assert list(align.y2x.lengths) == [1, 1, 1, 1, 2, 1, 1]    # the token "'s" splits out in two tokens
+    assert list(align.y2x.dataXd) == [0, 1, 2, 3, 4, 5, 6, 7]
+
+
+def test_alignment_case_insensitive():
+    other_tokens = ["I", "listened", "to", "obama", "'", "s", "podcasts", "."]
+    spacy_tokens = ["i", "listened", "to", "Obama", "'s", "PODCASTS", "."]
+    align = Alignment.from_strings(other_tokens, spacy_tokens)
+    assert list(align.x2y.lengths) == [1, 1, 1, 1, 1, 1, 1, 1]
+    assert list(align.x2y.dataXd) == [0, 1, 2, 3, 4, 4, 5, 6]  # two tokens both refer to "'s"
+    assert list(align.y2x.lengths) == [1, 1, 1, 1, 2, 1, 1]  # the token "'s" splits out in two tokens
+    assert list(align.y2x.dataXd) == [0, 1, 2, 3, 4, 5, 6, 7]
+
+
+def test_alignment_complex():
+    other_tokens = ["i listened to", "obama", "'", "s", "podcasts", "."]
+    spacy_tokens = ["i", "listened", "to", "obama", "'s", "podcasts."]
+    align = Alignment.from_strings(other_tokens, spacy_tokens)
+    assert list(align.x2y.lengths) == [3, 1, 1, 1, 1, 1]
+    assert list(align.x2y.dataXd) == [0, 1, 2, 3, 4, 4, 5, 5]
+    assert list(align.y2x.lengths) == [1, 1, 1, 1, 2, 2]
+    assert list(align.y2x.dataXd) == [0, 0, 0, 1, 2, 3, 4, 5]
+
+
+def test_alignment_different_texts():
+    other_tokens = ["she", "listened", "to", "obama", "'s", "podcasts", "."]
+    spacy_tokens = ["i", "listened", "to", "obama", "'s", "podcasts", "."]
+    with pytest.raises(ValueError):
+        Alignment.from_strings(other_tokens, spacy_tokens)

--- a/spacy/tests/test_gold.py
+++ b/spacy/tests/test_gold.py
@@ -662,8 +662,8 @@ def test_alignment():
     spacy_tokens = ["i", "listened", "to", "obama", "'s", "podcasts", "."]
     align = Alignment.from_strings(other_tokens, spacy_tokens)
     assert list(align.x2y.lengths) == [1, 1, 1, 1, 1, 1, 1, 1]
-    assert list(align.x2y.dataXd) == [0, 1, 2, 3, 4, 4, 5, 6]  # two tokens both refer to "'s"
-    assert list(align.y2x.lengths) == [1, 1, 1, 1, 2, 1, 1]    # the token "'s" splits out in two tokens
+    assert list(align.x2y.dataXd) == [0, 1, 2, 3, 4, 4, 5, 6]
+    assert list(align.y2x.lengths) == [1, 1, 1, 1, 2, 1, 1]
     assert list(align.y2x.dataXd) == [0, 1, 2, 3, 4, 5, 6, 7]
 
 
@@ -672,8 +672,8 @@ def test_alignment_case_insensitive():
     spacy_tokens = ["i", "listened", "to", "Obama", "'s", "PODCASTS", "."]
     align = Alignment.from_strings(other_tokens, spacy_tokens)
     assert list(align.x2y.lengths) == [1, 1, 1, 1, 1, 1, 1, 1]
-    assert list(align.x2y.dataXd) == [0, 1, 2, 3, 4, 4, 5, 6]  # two tokens both refer to "'s"
-    assert list(align.y2x.lengths) == [1, 1, 1, 1, 2, 1, 1]  # the token "'s" splits out in two tokens
+    assert list(align.x2y.dataXd) == [0, 1, 2, 3, 4, 4, 5, 6]
+    assert list(align.y2x.lengths) == [1, 1, 1, 1, 2, 1, 1]
     assert list(align.y2x.dataXd) == [0, 1, 2, 3, 4, 5, 6, 7]
 
 
@@ -690,8 +690,12 @@ def test_alignment_complex():
 def test_alignment_complex_example(en_vocab):
     other_tokens = ["i listened to", "obama", "'", "s", "podcasts", "."]
     spacy_tokens = ["i", "listened", "to", "obama", "'s", "podcasts."]
-    predicted = Doc(en_vocab, words=other_tokens, spaces=[True, False, False, True, False, False])
-    reference = Doc(en_vocab, words=spacy_tokens, spaces=[True, True, True, False, True, False])
+    predicted = Doc(
+        en_vocab, words=other_tokens, spaces=[True, False, False, True, False, False]
+    )
+    reference = Doc(
+        en_vocab, words=spacy_tokens, spaces=[True, True, True, False, True, False]
+    )
     assert predicted.text == "i listened to obama's podcasts."
     assert reference.text == "i listened to obama's podcasts."
     example = Example(predicted, reference)

--- a/spacy/tests/test_gold.py
+++ b/spacy/tests/test_gold.py
@@ -687,6 +687,21 @@ def test_alignment_complex():
     assert list(align.y2x.dataXd) == [0, 0, 0, 1, 2, 3, 4, 5]
 
 
+def test_alignment_complex_example(en_vocab):
+    other_tokens = ["i listened to", "obama", "'", "s", "podcasts", "."]
+    spacy_tokens = ["i", "listened", "to", "obama", "'s", "podcasts."]
+    predicted = Doc(en_vocab, words=other_tokens, spaces=[True, False, False, True, False, False])
+    reference = Doc(en_vocab, words=spacy_tokens, spaces=[True, True, True, False, True, False])
+    assert predicted.text == "i listened to obama's podcasts."
+    assert reference.text == "i listened to obama's podcasts."
+    example = Example(predicted, reference)
+    align = example.alignment
+    assert list(align.x2y.lengths) == [3, 1, 1, 1, 1, 1]
+    assert list(align.x2y.dataXd) == [0, 1, 2, 3, 4, 4, 5, 5]
+    assert list(align.y2x.lengths) == [1, 1, 1, 1, 2, 2]
+    assert list(align.y2x.dataXd) == [0, 0, 0, 1, 2, 3, 4, 5]
+
+
 def test_alignment_different_texts():
     other_tokens = ["she", "listened", "to", "obama", "'s", "podcasts", "."]
     spacy_tokens = ["i", "listened", "to", "obama", "'s", "podcasts", "."]


### PR DESCRIPTION
## Description
Prevent alignment when texts don't match
- case-insensitive match

Also added some `Alignment` unit tests

### Types of change
enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
