### PR TITLE
Bugfix in nlp.replace_pipe

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -771,8 +771,10 @@ class Language:
         self.remove_pipe(name)
         if not len(self.pipeline):  # we have no components to insert before/after
             self.add_pipe(factory_name, name=name)
-        else:
+        elif pipe_index < len(self.pipeline):
             self.add_pipe(factory_name, name=name, before=pipe_index)
+        else:
+            self.add_pipe(factory_name, name=name, after=pipe_index-1)
 
     def rename_pipe(self, old_name: str, new_name: str) -> None:
         """Rename a pipeline component.

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -769,12 +769,11 @@ class Language:
         # to Language.pipeline to make sure the configs are handled correctly
         pipe_index = self.pipe_names.index(name)
         self.remove_pipe(name)
-        if not len(self.pipeline):  # we have no components to insert before/after
+        if not len(self.pipeline) or pipe_index == len(self.pipeline):
+            # we have no components to insert before/after, or we're replacing the last component
             self.add_pipe(factory_name, name=name)
-        elif pipe_index < len(self.pipeline):
-            self.add_pipe(factory_name, name=name, before=pipe_index)
         else:
-            self.add_pipe(factory_name, name=name, after=pipe_index-1)
+            self.add_pipe(factory_name, name=name, before=pipe_index)
 
     def rename_pipe(self, old_name: str, new_name: str) -> None:
         """Rename a pipeline component.

--- a/spacy/tests/pipeline/test_pipe_methods.py
+++ b/spacy/tests/pipeline/test_pipe_methods.py
@@ -70,6 +70,14 @@ def test_replace_pipe(nlp, name, replacement, invalid_replacement):
     assert nlp.get_pipe(name) == nlp.create_pipe(replacement)
 
 
+def test_replace_last_pipe(nlp):
+    nlp.add_pipe("sentencizer")
+    nlp.add_pipe("ner")
+    assert nlp.pipe_names == ["sentencizer", "ner"]
+    nlp.replace_pipe("ner", "ner")
+    assert nlp.pipe_names == ["sentencizer", "ner"]
+
+
 @pytest.mark.parametrize("old_name,new_name", [("old_pipe", "new_pipe")])
 def test_rename_pipe(nlp, old_name, new_name):
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Description
Current bug: if a pipeline would contain more than one component (let's say 3), and you `nlp.replace_pipe` the last one, you would get an `E959` error about "Can't insert component before index 2", because that last (old) component would already be removed so the pipeline is temporarily smaller. Fixed it by using  insertion with `after` for these edge cases.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
