### PR TITLE
Simplify config overrides in CLI and deserialization

### DIFF
--- a/spacy/__init__.py
+++ b/spacy/__init__.py
@@ -8,6 +8,7 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")  # noqa
 
 # These are imported as part of the API
 from thinc.api import prefer_gpu, require_gpu  # noqa: F401
+from thinc.api import Config
 
 from . import pipeline  # noqa: F401
 from .cli.info import info  # noqa: F401
@@ -26,17 +27,17 @@ if sys.maxunicode == 65535:
 def load(
     name: Union[str, Path],
     disable: Iterable[str] = tuple(),
-    component_cfg: Dict[str, Dict[str, Any]] = util.SimpleFrozenDict(),
+    config: Union[Dict[str, Any], Config] = util.SimpleFrozenDict(),
 ) -> Language:
     """Load a spaCy model from an installed package or a local path.
 
     name (str): Package name or model path.
     disable (Iterable[str]): Names of pipeline components to disable.
-    component_cfg (Dict[str, dict]): Config overrides for pipeline components,
-        keyed by component names.
+    config (Dict[str, Any] / Config): Config overrides as nested dict or dict
+        keyed by section values in dot notation.
     RETURNS (Language): The loaded nlp object.
     """
-    return util.load_model(name, disable=disable, component_cfg=component_cfg)
+    return util.load_model(name, disable=disable, config=config)
 
 
 def blank(name: str, **overrides) -> Language:

--- a/spacy/cli/debug_data.py
+++ b/spacy/cli/debug_data.py
@@ -49,11 +49,9 @@ def debug_config_cli(
     overrides = parse_config_overrides(ctx.args)
     import_code(code_path)
     with show_validation_error(config_path):
-        config = Config().from_disk(config_path)
+        config = Config().from_disk(config_path, overrides=overrides)
         try:
-            nlp, _ = util.load_model_from_config(
-                config, overrides=overrides, auto_fill=auto_fill
-            )
+            nlp, _ = util.load_model_from_config(config, auto_fill=auto_fill)
         except ValueError as e:
             msg.fail(str(e), exits=1)
     if auto_fill:
@@ -136,8 +134,8 @@ def debug_data(
     if not config_path.exists():
         msg.fail("Config file not found", config_path, exists=1)
     with show_validation_error(config_path):
-        cfg = Config().from_disk(config_path)
-        nlp, config = util.load_model_from_config(cfg, overrides=config_overrides)
+        cfg = Config().from_disk(config_path, overrides=config_overrides)
+        nlp, config = util.load_model_from_config(cfg)
     # Use original config here, not resolved version
     sourced_components = get_sourced_components(cfg)
     frozen_components = config["training"]["frozen_components"]

--- a/spacy/cli/debug_model.py
+++ b/spacy/cli/debug_model.py
@@ -49,9 +49,9 @@ def debug_model_cli(
     }
     config_overrides = parse_config_overrides(ctx.args)
     with show_validation_error(config_path):
-        cfg = Config().from_disk(config_path)
+        cfg = Config().from_disk(config_path, overrides=config_overrides)
         try:
-            nlp, config = util.load_model_from_config(cfg, overrides=config_overrides)
+            nlp, config = util.load_model_from_config(cfg)
         except ValueError as e:
             msg.fail(str(e), exits=1)
     seed = config.get("training", {}).get("seed", None)

--- a/spacy/cli/pretrain.py
+++ b/spacy/cli/pretrain.py
@@ -88,8 +88,8 @@ def pretrain(
         msg.info("Using CPU")
     msg.info(f"Loading config from: {config_path}")
     with show_validation_error(config_path):
-        config = Config().from_disk(config_path)
-        nlp, config = util.load_model_from_config(config, overrides=config_overrides)
+        config = Config().from_disk(config_path, overrides=config_overrides)
+        nlp, config = util.load_model_from_config(config)
     # TODO: validate that [pretraining] block exists
     if not output_dir.exists():
         output_dir.mkdir()

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -75,13 +75,13 @@ def train(
         msg.info("Using CPU")
     msg.info(f"Loading config and nlp from: {config_path}")
     with show_validation_error(config_path):
-        config = Config().from_disk(config_path)
+        config = Config().from_disk(config_path, overrides=config_overrides)
     if config.get("training", {}).get("seed") is not None:
         fix_random_seed(config["training"]["seed"])
     # Use original config here before it's resolved to functions
     sourced_components = get_sourced_components(config)
     with show_validation_error(config_path):
-        nlp, config = util.load_model_from_config(config, overrides=config_overrides)
+        nlp, config = util.load_model_from_config(config)
     if config["training"]["vectors"] is not None:
         util.load_vectors_into_model(nlp, config["training"]["vectors"])
     verify_config(nlp)
@@ -144,7 +144,7 @@ def train(
         max_steps=T_cfg["max_steps"],
         eval_frequency=T_cfg["eval_frequency"],
         raw_text=None,
-        exclude=frozen_components
+        exclude=frozen_components,
     )
     msg.info(f"Training. Initial learn rate: {optimizer.learn_rate}")
     print_row = setup_printer(T_cfg, nlp)

--- a/spacy/tests/regression/test_issue5137.py
+++ b/spacy/tests/regression/test_issue5137.py
@@ -27,6 +27,6 @@ def test_issue5137():
 
     with make_tempdir() as tmpdir:
         nlp.to_disk(tmpdir)
-        overrides = {"my_component": {"categories": "my_categories"}}
-        nlp2 = spacy.load(tmpdir, component_cfg=overrides)
+        overrides = {"components": {"my_component": {"categories": "my_categories"}}}
+        nlp2 = spacy.load(tmpdir, config=overrides)
         assert nlp2.get_pipe("my_component").categories == "my_categories"

--- a/website/docs/api/top-level.md
+++ b/website/docs/api/top-level.md
@@ -32,13 +32,13 @@ loaded in via [`Language.from_disk`](/api/language#from_disk).
 > nlp = spacy.load("en_core_web_sm", disable=["parser", "tagger"])
 > ```
 
-| Name                                       | Type              | Description                                                                       |
-| ------------------------------------------ | ----------------- | --------------------------------------------------------------------------------- |
-| `name`                                     | str / `Path`      | Model to load, i.e. package name or path.                                         |
-| _keyword-only_                             |                   |                                                                                   |
-| `disable`                                  | `List[str]`       | Names of pipeline components to [disable](/usage/processing-pipelines#disabling). |
-| `component_cfg` <Tag variant="new">3</Tag> | `Dict[str, dict]` | Optional config overrides for pipeline components, keyed by component names.      |
-| **RETURNS**                                | `Language`        | A `Language` object with the loaded model.                                        |
+| Name                                | Type                                                                   | Description                                                                                                                      |
+| ----------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                              | str / `Path`                                                           | Model to load, i.e. package name or path.                                                                                        |
+| _keyword-only_                      |                                                                        |                                                                                                                                  |
+| `disable`                           | `List[str]`                                                            | Names of pipeline components to [disable](/usage/processing-pipelines#disabling).                                                |
+| `config` <Tag variant="new">3</Tag> | `Dict[str, Any]` / [`Config`](https://thinc.ai/docs/api-config#config) | Optional config overrides, either as nested dict or dict keyed by section value in dot notation, e.g. `"components.name.value"`. |
+| **RETURNS**                         | `Language`                                                             | A `Language` object with the loaded model.                                                                                       |
 
 Essentially, `spacy.load()` is a convenience wrapper that reads the language ID
 and pipeline components from a model's `meta.json`, initializes the `Language`


### PR DESCRIPTION
## Description

Now that Thinc allows passing config overrides directly to `Config` (and merging them _before_ variable interpolation!) we can simplify the overrides across the CLI and `Language` API.

- [x] pass CLI overrides directly to `Config`
- [x] make all model loading helpers take `config` argument containing config overrides (except `load_model_from_config`, which already takes a config – in that case, you can just pass in a config that already has the overrides)
- [x] don't name any of this `component_cfg` – that argument name is confusing because it clashes with the `component_cfg` on methods like `Language.update`, which is actually very different

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
