### PR TITLE
Add better error for failed model shortcut loading

### DIFF
--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -7,23 +7,7 @@ import typer
 from ._util import app, Arg, Opt
 from .. import about
 from ..util import is_package, get_base_version, run_command
-
-# These are the old shortcuts we previously supported in spacy download. As of
-# v3, shortcuts are deprecated so we're not expecting to add anything to this
-# list. It only exists to show users warnings.
-OLD_SHORTCUTS = {
-    "en": "en_core_web_sm",
-    "de": "de_core_news_sm",
-    "es": "es_core_news_sm",
-    "pt": "pt_core_news_sm",
-    "fr": "fr_core_news_sm",
-    "it": "it_core_news_sm",
-    "nl": "nl_core_news_sm",
-    "el": "el_core_news_sm",
-    "nb": "nb_core_news_sm",
-    "lt": "lt_core_news_sm",
-    "xx": "xx_ent_wiki_sm",
-}
+from ..errors import OLD_MODEL_SHORTCUTS
 
 
 @app.command(
@@ -66,12 +50,12 @@ def download(model: str, direct: bool = False, *pip_args) -> None:
         download_model(dl_tpl.format(m=model_name, v=version), pip_args)
     else:
         model_name = model
-        if model in OLD_SHORTCUTS:
+        if model in OLD_MODEL_SHORTCUTS:
             msg.warn(
-                f"As of spaCy v3.0, shortcuts like '{model}' are deprecated. "
-                f"Please use the full model name '{OLD_SHORTCUTS[model]}' instead."
+                f"As of spaCy v3.0, shortcuts like '{model}' are deprecated. Please"
+                f"use the full model name '{OLD_MODEL_SHORTCUTS[model]}' instead."
             )
-            model_name = OLD_SHORTCUTS[model]
+            model_name = OLD_MODEL_SHORTCUTS[model]
         compatibility = get_compatibility()
         version = get_version(model_name, compatibility)
         download_model(dl_tpl.format(m=model_name, v=version), pip_args)

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -482,6 +482,11 @@ class Errors:
     E199 = ("Unable to merge 0-length span at doc[{start}:{end}].")
 
     # TODO: fix numbering after merging develop into master
+    E941 = ("Can't find model '{name}'. It looks like you're trying to load a "
+            "model from a shortcut, which is deprecated as of spaCy v3.0. To "
+            "load the model, use its full name instead. For example:\n\n"
+            "nlp = spacy.load(\"{full}\")\n\nFor more details on the available "
+            "models, see the models directory: https://spacy.io/models")
     E942 = ("Executing after_{name} callback failed. Expected the function to "
             "return an initialized nlp object but got: {value}. Maybe "
             "you forgot to return the modified object in your function?")
@@ -633,6 +638,15 @@ class TempErrors:
     T003 = ("Resizing pretrained Tagger models is not currently supported.")
     T007 = ("Can't yet set {attr} from Span. Vote for this feature on the "
             "issue tracker: http://github.com/explosion/spaCy/issues")
+
+
+# Deprecated model shortcuts, only used in errors and warnings
+OLD_MODEL_SHORTCUTS = {
+    "en": "en_core_web_sm", "de": "de_core_news_sm", "es": "es_core_news_sm",
+    "pt": "pt_core_news_sm", "fr": "fr_core_news_sm", "it": "it_core_news_sm",
+    "nl": "nl_core_news_sm", "el": "el_core_news_sm", "nb": "nb_core_news_sm",
+    "lt": "lt_core_news_sm", "xx": "xx_ent_wiki_sm"
+}
 
 
 # fmt: on

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -484,9 +484,11 @@ class Errors:
     # TODO: fix numbering after merging develop into master
     E941 = ("Can't find model '{name}'. It looks like you're trying to load a "
             "model from a shortcut, which is deprecated as of spaCy v3.0. To "
-            "load the model, use its full name instead. For example:\n\n"
+            "load the model, use its full name instead:\n\n"
             "nlp = spacy.load(\"{full}\")\n\nFor more details on the available "
-            "models, see the models directory: https://spacy.io/models")
+            "models, see the models directory: https://spacy.io/models. If you "
+            "want to create a blank model, use spacy.blank: "
+            "nlp = spacy.blank(\"{name}\")")
     E942 = ("Executing after_{name} callback failed. Expected the function to "
             "return an initialized nlp object but got: {value}. Maybe "
             "you forgot to return the modified object in your function?")

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -44,7 +44,7 @@ from thinc.api import fix_random_seed, compounding, decaying  # noqa: F401
 
 from .symbols import ORTH
 from .compat import cupy, CudaStream, is_windows
-from .errors import Errors, Warnings
+from .errors import Errors, Warnings, OLD_MODEL_SHORTCUTS
 from . import about
 
 if TYPE_CHECKING:
@@ -232,6 +232,8 @@ def load_model(
             return load_model_from_path(Path(name), **kwargs)
     elif hasattr(name, "exists"):  # Path or Path-like to model data
         return load_model_from_path(name, **kwargs)
+    if name in OLD_MODEL_SHORTCUTS:
+        raise IOError(Errors.E941.format(name=name, full=OLD_MODEL_SHORTCUTS[name]))
     raise IOError(Errors.E050.format(name=name))
 
 


### PR DESCRIPTION
## Description

If loading a model fails, we might as well raise a more helpful error if the loaded string is a former shortcut. Or if the user typos and writes `.load` instead of `.blank` (which is what I did).

(Wasn't sure where to put the old model shortcuts that are only used for errors and warnings and shared across modules. So I put them in `spacy.errors` for now.)

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
