### PR TITLE
Fix `Doc.from_docs` for empty string Doc

### DIFF
--- a/spacy/tests/doc/test_doc_api.py
+++ b/spacy/tests/doc/test_doc_api.py
@@ -317,7 +317,8 @@ def test_doc_from_array_morph(en_vocab):
 
 
 def test_doc_api_from_docs(en_tokenizer, de_tokenizer):
-    en_texts = ["Merging the docs is fun.", "They don't think alike."]
+    en_texts = ["Merging the docs is fun.", "", "They don't think alike."]
+    en_texts_without_empty = [t for t in en_texts if len(t)]
     de_text = "Wie war die Frage?"
     en_docs = [en_tokenizer(text) for text in en_texts]
     docs_idx = en_texts[0].index("docs")
@@ -338,14 +339,14 @@ def test_doc_api_from_docs(en_tokenizer, de_tokenizer):
         Doc.from_docs(en_docs + [de_doc])
 
     m_doc = Doc.from_docs(en_docs)
-    assert len(en_docs) == len(list(m_doc.sents))
+    assert len(en_texts_without_empty) == len(list(m_doc.sents))
     assert len(str(m_doc)) > len(en_texts[0]) + len(en_texts[1])
-    assert str(m_doc) == " ".join(en_texts)
+    assert str(m_doc) == " ".join(en_texts_without_empty)
     p_token = m_doc[len(en_docs[0]) - 1]
     assert p_token.text == "." and bool(p_token.whitespace_)
     en_docs_tokens = [t for doc in en_docs for t in doc]
     assert len(m_doc) == len(en_docs_tokens)
-    think_idx = len(en_texts[0]) + 1 + en_texts[1].index("think")
+    think_idx = len(en_texts[0]) + 1 + en_texts[2].index("think")
     assert m_doc[9].idx == think_idx
     with pytest.raises(AttributeError):
         # not callable, because it was not set via set_extension
@@ -353,14 +354,14 @@ def test_doc_api_from_docs(en_tokenizer, de_tokenizer):
     assert len(m_doc.user_data) == len(en_docs[0].user_data)  # but it's there
 
     m_doc = Doc.from_docs(en_docs, ensure_whitespace=False)
-    assert len(en_docs) == len(list(m_doc.sents))
-    assert len(str(m_doc)) == len(en_texts[0]) + len(en_texts[1])
+    assert len(en_texts_without_empty) == len(list(m_doc.sents))
+    assert len(str(m_doc)) == sum(len(t) for t in en_texts)
     assert str(m_doc) == "".join(en_texts)
     p_token = m_doc[len(en_docs[0]) - 1]
     assert p_token.text == "." and not bool(p_token.whitespace_)
     en_docs_tokens = [t for doc in en_docs for t in doc]
     assert len(m_doc) == len(en_docs_tokens)
-    think_idx = len(en_texts[0]) + 0 + en_texts[1].index("think")
+    think_idx = len(en_texts[0]) + 0 + en_texts[2].index("think")
     assert m_doc[9].idx == think_idx
 
     m_doc = Doc.from_docs(en_docs, attrs=["lemma", "length", "pos"])
@@ -369,12 +370,12 @@ def test_doc_api_from_docs(en_tokenizer, de_tokenizer):
         assert list(m_doc.sents)
     assert len(str(m_doc)) > len(en_texts[0]) + len(en_texts[1])
     # space delimiter considered, although spacy attribute was missing
-    assert str(m_doc) == " ".join(en_texts)
+    assert str(m_doc) == " ".join(en_texts_without_empty)
     p_token = m_doc[len(en_docs[0]) - 1]
     assert p_token.text == "." and bool(p_token.whitespace_)
     en_docs_tokens = [t for doc in en_docs for t in doc]
     assert len(m_doc) == len(en_docs_tokens)
-    think_idx = len(en_texts[0]) + 1 + en_texts[1].index("think")
+    think_idx = len(en_texts[0]) + 1 + en_texts[2].index("think")
     assert m_doc[9].idx == think_idx
 
 

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -920,7 +920,9 @@ cdef class Doc:
                         warnings.warn(Warnings.W101.format(name=name))
                 else:
                     warnings.warn(Warnings.W102.format(key=key, value=value))
-            char_offset += len(doc.text) if not ensure_whitespace or doc[-1].is_space else len(doc.text) + 1
+            char_offset += len(doc.text)
+            if ensure_whitespace and not (len(doc) > 0 and doc[-1].is_space):
+                char_offset += 1
 
         arrays = [doc.to_array(attrs) for doc in docs]
 
@@ -932,7 +934,7 @@ cdef class Doc:
             token_offset = -1
             for doc in docs[:-1]:
                 token_offset += len(doc)
-                if not doc[-1].is_space:
+                if not (len(doc) > 0 and doc[-1].is_space):
                     concat_spaces[token_offset] = True
 
         concat_array = numpy.concatenate(arrays)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

`Doc.from_docs` will fail if the argument `docs` contains empty string docs, e.g. `len(doc.text) == 0` because `doc[-1]` is referenced in the method.

The new method doesn't add white space to emtpy docs, even if `ensure_space = True`. I'd like your opinion about it.


### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
