### PR TITLE
Make sure sys.argv exists

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -193,7 +193,7 @@ def setup_package():
 
     root = os.path.abspath(os.path.dirname(__file__))
 
-    if len(sys.argv) > 1 and sys.argv[1] == "clean":
+    if hasattr(sys, "arg") and len(sys.argv) > 1 and sys.argv[1] == "clean":
         return clean(root)
 
     with chdir(root):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Make sure that the setup runs as expected, even if a user's Python implementation doesn't have `sys.argv` (e.g Rust bindings). It's only used in the `setup.py` and not relevant at runtime (and obviously the CLI via `typer` via `click`, but we can't really avoid that).

Resolves #5610.

### Types of change
compat

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
