### PR TITLE
Fix handling of optional [pretraining] block

### DIFF
--- a/spacy/cli/debug_model.py
+++ b/spacy/cli/debug_model.py
@@ -51,7 +51,7 @@ def debug_model_cli(
     with show_validation_error(config_path):
         config = util.load_config(config_path, overrides=config_overrides)
         nlp, config = util.load_model_from_config(config_path)
-    seed = config["pretraining"]["seed"]
+    seed = config["training"]["seed"]
     if seed is not None:
         msg.info(f"Fixing random seed: {seed}")
         fix_random_seed(seed)

--- a/spacy/cli/init_config.py
+++ b/spacy/cli/init_config.py
@@ -137,7 +137,7 @@ def init_config(
         config = util.load_config_from_str(base_template)
         nlp, _ = util.load_model_from_config(config, auto_fill=True)
     if use_transformer:
-        nlp.config.pop("pretraining", {})  # TODO: solve this better
+        nlp.config["pretraining"] = {}  # TODO: solve this better?
     msg.good("Auto-filled config with all values")
     save_config(nlp.config, output_file, is_stdout=is_stdout)
 

--- a/spacy/cli/pretrain.py
+++ b/spacy/cli/pretrain.py
@@ -90,19 +90,20 @@ def pretrain(
     with show_validation_error(config_path):
         config = util.load_config(config_path, overrides=config_overrides)
         nlp, config = util.load_model_from_config(config)
-    # TODO: validate that [pretraining] block exists
+    pretrain_config = config["pretraining"]
+    if not pretrain_config:
+        # TODO: What's the solution here? How do we handle optional blocks?
+        msg.fail("The [pretraining] block in your config is empty", exits=1)
     if not output_dir.exists():
         output_dir.mkdir()
         msg.good(f"Created output directory: {output_dir}")
-    seed = config["pretraining"]["seed"]
+    seed = pretrain_config["seed"]
     if seed is not None:
         fix_random_seed(seed)
-    if use_gpu >= 0 and config["pretraining"]["use_pytorch_for_gpu_memory"]:
+    if use_gpu >= 0 and pretrain_config["use_pytorch_for_gpu_memory"]:
         use_pytorch_for_gpu_memory()
     config.to_disk(output_dir / "config.cfg")
     msg.good("Saved config file in the output directory")
-    pretrain_config = config["pretraining"]
-
     if texts_loc != "-":  # reading from a file
         with msg.loading("Loading input texts..."):
             texts = list(srsly.read_jsonl(texts_loc))

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -75,7 +75,9 @@ def train(
         msg.info("Using CPU")
     msg.info(f"Loading config and nlp from: {config_path}")
     with show_validation_error(config_path):
-        config = util.load_config(config_path, overrides=config_overrides, interpolate=True)
+        config = util.load_config(
+            config_path, overrides=config_overrides, interpolate=True
+        )
     if config.get("training", {}).get("seed") is not None:
         fix_random_seed(config["training"]["seed"])
     # Use original config here before it's resolved to functions
@@ -115,7 +117,7 @@ def train(
 
     # Load a pretrained tok2vec model - cf. CLI command 'pretrain'
     if weights_data is not None:
-        tok2vec_path = config.get("pretraining", {}).get("tok2vec_model", None)
+        tok2vec_path = config["pretraining"].get("tok2vec_model", None)
         if tok2vec_path is None:
             msg.fail(
                 f"To use a pretrained tok2vec model, the config needs to specify which "

--- a/spacy/default_config.cfg
+++ b/spacy/default_config.cfg
@@ -90,29 +90,3 @@ eps = 1e-8
 warmup_steps = 250
 total_steps = 20000
 initial_rate = 0.001
-
-[pretraining]
-max_epochs = 1000
-min_length = 5
-max_length = 500
-dropout = 0.2
-n_save_every = null
-batch_size = 3000
-seed = ${system.seed}
-use_pytorch_for_gpu_memory = ${system.use_pytorch_for_gpu_memory}
-tok2vec_model = "components.tok2vec.model"
-
-[pretraining.objective]
-type = "characters"
-n_characters = 4
-
-[pretraining.optimizer]
-@optimizers = "Adam.v1"
-beta1 = 0.9
-beta2 = 0.999
-L2_is_weight_decay = true
-L2 = 0.01
-grad_clip = 1.0
-use_averages = true
-eps = 1e-8
-learn_rate = 0.001

--- a/spacy/default_config_pretraining.cfg
+++ b/spacy/default_config_pretraining.cfg
@@ -1,0 +1,25 @@
+[pretraining]
+max_epochs = 1000
+min_length = 5
+max_length = 500
+dropout = 0.2
+n_save_every = null
+batch_size = 3000
+seed = ${system.seed}
+use_pytorch_for_gpu_memory = ${system.use_pytorch_for_gpu_memory}
+tok2vec_model = "components.tok2vec.model"
+
+[pretraining.objective]
+type = "characters"
+n_characters = 4
+
+[pretraining.optimizer]
+@optimizers = "Adam.v1"
+beta1 = 0.9
+beta2 = 0.999
+L2_is_weight_decay = true
+L2 = 0.01
+grad_clip = 1.0
+use_averages = true
+eps = 1e-8
+learn_rate = 0.001

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -37,6 +37,9 @@ from . import about
 # This is the base config will all settings (training etc.)
 DEFAULT_CONFIG_PATH = Path(__file__).parent / "default_config.cfg"
 DEFAULT_CONFIG = util.load_config(DEFAULT_CONFIG_PATH)
+# This is the base config for the [pretraining] block and currently not included
+# in the main config and only added via the 'init fill-config' command
+DEFAULT_CONFIG_PRETRAIN_PATH = Path(__file__).parent / "default_config_pretraining.cfg"
 
 
 class BaseDefaults:

--- a/spacy/schemas.py
+++ b/spacy/schemas.py
@@ -257,7 +257,7 @@ class ConfigSchemaPretrain(BaseModel):
 class ConfigSchema(BaseModel):
     training: ConfigSchemaTraining
     nlp: ConfigSchemaNlp
-    pretraining: Optional[ConfigSchemaPretrain]
+    pretraining: ConfigSchemaPretrain = {}
     components: Dict[str, Dict[str, Any]]
 
     @root_validator

--- a/spacy/tests/serialize/test_serialize_config.py
+++ b/spacy/tests/serialize/test_serialize_config.py
@@ -305,7 +305,7 @@ def test_config_interpolation():
 def test_config_optional_sections():
     config = Config().from_str(nlp_config_string)
     config = DEFAULT_CONFIG.merge(config)
-    del config["pretraining"]
+    assert "pretraining" not in config
     filled = registry.fill_config(config, schema=ConfigSchema, validate=False)
     # Make sure that optional "pretraining" block doesn't default to None,
     # which would (rightly) cause error because it'd result in a top-level


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

* The `[pretraining]` block now doesn't default to `null` anymore, which would cause Thinc to (correctly) raise an error because it's a top-level key that's not a section.
* Make `[pretraining]` default to `{}` (empty block) and adjust checks accordingly.
* Read `training.seed` in `debug-model`, not `pretraining.seed` (possibly copy-paste mistake?)

### Open questions / todos

- [x] How should we manage the presence / absence of the `[pretraining]` block? We currently reset it in `init config` for transformer-based models, so some `nlp.config`s may have it, and some don't. What should be the recommended path if you want to pretrain using a config and your config doesn't have a `[pretraining]` block?

### Types of change
bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
