### PR TITLE
Don't interpolate config on Language deserialization

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1542,7 +1542,9 @@ class Language:
         path = util.ensure_path(path)
         deserializers = {}
         if Path(path / "config.cfg").exists():
-            deserializers["config.cfg"] = lambda p: self.config.from_disk(p)
+            deserializers["config.cfg"] = lambda p: self.config.from_disk(
+                p, interpolate=False
+            )
         deserializers["meta.json"] = deserialize_meta
         deserializers["vocab"] = deserialize_vocab
         deserializers["tokenizer"] = lambda p: self.tokenizer.from_disk(
@@ -1605,7 +1607,9 @@ class Language:
             self.vocab.vectors.name = data.get("vectors", {}).get("name")
 
         deserializers = {}
-        deserializers["config.cfg"] = lambda b: self.config.from_bytes(b)
+        deserializers["config.cfg"] = lambda b: self.config.from_bytes(
+            b, interpolate=False
+        )
         deserializers["meta.json"] = deserialize_meta
         deserializers["vocab"] = self.vocab.from_bytes
         deserializers["tokenizer"] = lambda b: self.tokenizer.from_bytes(

--- a/spacy/tests/serialize/test_serialize_config.py
+++ b/spacy/tests/serialize/test_serialize_config.py
@@ -209,6 +209,20 @@ def test_config_nlp_roundtrip():
     assert new_nlp._factory_meta == nlp._factory_meta
 
 
+def test_config_nlp_roundtrip_bytes_disk():
+    """Test that the config is serialized correctly and not interpolated
+    by mistake."""
+    nlp = English()
+    nlp_bytes = nlp.to_bytes()
+    new_nlp = English().from_bytes(nlp_bytes)
+    assert new_nlp.config == nlp.config
+    nlp = English()
+    with make_tempdir() as d:
+        nlp.to_disk(d)
+        new_nlp = spacy.load(d)
+    assert new_nlp.config == nlp.config
+
+
 def test_serialize_config_language_specific():
     """Test that config serialization works as expected with language-specific
     factories."""


### PR DESCRIPTION
## Description

`Language.from_bytes` and `Language.from_disk` didn't correctly set `interpolate=False` when loading the config back from bytes/disk. This caused variables to be replaced, so the loaded config didn't match the original config and variable references were destroyed.

### Types of change
bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
