### PR TITLE
Allow component decorators to re-run with same function

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -128,7 +128,8 @@ class Errors:
             "got {component} (name: '{name}'). If you're using a custom "
             "component factory, double-check that it correctly returns your "
             "initialized component.")
-    E004 = ("Can't set up pipeline component: a factory for '{name}' already exists.")
+    E004 = ("Can't set up pipeline component: a factory for '{name}' already "
+            "exists. Existing factory: {func}. New factory: {new_func}")
     E005 = ("Pipeline component '{name}' returned None. If you're using a "
             "custom component, maybe you forgot to return the processed Doc?")
     E006 = ("Invalid constraints for adding pipeline component. You can only "

--- a/spacy/tests/pipeline/test_pipe_factories.py
+++ b/spacy/tests/pipeline/test_pipe_factories.py
@@ -438,3 +438,26 @@ def test_pipe_factories_from_source_config():
     config = nlp.config["components"]["custom"]
     assert config["factory"] == name
     assert config["arg"] == "world"
+
+
+def test_pipe_factories_decorator_idempotent():
+    """Check that decorator can be run multiple times if the function is the
+    same. This is especially relevant for live reloading because we don't
+    want spaCy to raise an error if a module registering components is reloaded.
+    """
+    name = "test_pipe_factories_decorator_idempotent"
+    func = lambda nlp, name: lambda doc: doc
+    for i in range(5):
+        Language.factory(name, func=func)
+    nlp = Language()
+    nlp.add_pipe(name)
+    Language.factory(name, func=func)
+    # Make sure it also works for component decorator, which creates the
+    # factory function
+    name2 = f"{name}2"
+    func2 = lambda doc: doc
+    for i in range(5):
+        Language.component(name2, func=func2)
+    nlp = Language()
+    nlp.add_pipe(name)
+    Language.component(name2, func=func2)

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -689,7 +689,7 @@ def is_same_func(func1: Callable, func2: Callable) -> bool:
     same_name = func1.__qualname__ == func2.__qualname__
     same_file = inspect.getfile(func1) == inspect.getfile(func2)
     same_code = inspect.getsourcelines(func1) == inspect.getsourcelines(func2)
-    return all([same_name, same_file, same_code])
+    return same_name and same_file and same_code
 
 
 def get_cuda_stream(

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -673,6 +673,25 @@ def get_object_name(obj: Any) -> str:
     return repr(obj)
 
 
+def is_same_func(func1: Callable, func2: Callable) -> bool:
+    """Approximately decide whether two functions are the same, even if their
+    identity is different (e.g. after they have been live reloaded). Mostly
+    used in the @Language.component and @Language.factory decorators to decide
+    whether to raise if a factory already exists. Allows decorator to run
+    multiple times with the same function.
+
+    func1 (Callable): The first function.
+    func2 (Callable): The second function.
+    RETURNS (bool): Whether it's the same function (most likely).
+    """
+    if not callable(func1) or not callable(func2):
+        return False
+    same_name = func1.__qualname__ == func2.__qualname__
+    same_file = inspect.getfile(func1) == inspect.getfile(func2)
+    same_code = inspect.getsourcelines(func1) == inspect.getsourcelines(func2)
+    return all([same_name, same_file, same_code])
+
+
 def get_cuda_stream(
     require: bool = False, non_blocking: bool = True
 ) -> Optional[CudaStream]:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

This is especially relevant for environments where spaCy is live-reloaded (notebooks, Streamlit). The `@Language.factory` and `@Language.component` decorators should be allowed to re-run with the same function. This is a bit trickier for `@Language.component` where the decorator itself creates the factory function (and once that's done, it's harder to check whether the original stateless callable is the one we're using in the created factory).

(We can probably solve the `is_same_func` check more elegantly?)

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
