### PR TITLE
Fix sparse checkout for 'spacy project'

### DIFF
--- a/spacy/cli/_util.py
+++ b/spacy/cli/_util.py
@@ -297,9 +297,7 @@ def ensure_pathy(path):
     return Pathy(path)
 
 
-def git_sparse_checkout(
-    repo: str, subpath: str, dest: Path, *, branch: str = "master"
-):
+def git_sparse_checkout(repo: str, subpath: str, dest: Path, *, branch: str = "master"):
     if dest.exists():
         msg.fail("Destination of checkout must not exist", exits=1)
     if not dest.parent.exists():
@@ -341,6 +339,7 @@ def git_sparse_checkout(
         run_command(cmd)
         # We need Path(name) to make sure we also support subdirectories
         shutil.move(str(tmp_dir / Path(subpath)), str(dest))
+
 
 def _from_http_to_git(repo):
     if repo.startswith("http://"):

--- a/spacy/cli/project/clone.py
+++ b/spacy/cli/project/clone.py
@@ -43,7 +43,7 @@ def project_clone(name: str, dest: Path, *, repo: str = about.__projects__) -> N
         git_sparse_checkout(repo, name, dest)
     except subprocess.CalledProcessError:
         err = f"Could not clone '{name}' from repo '{repo_name}'"
-        msg.fail(err)
+        msg.fail(err, exits=1)
     msg.good(f"Cloned '{name}' from {repo_name}", project_dir)
     if not (project_dir / PROJECT_FILE).exists():
         msg.warn(f"No {PROJECT_FILE} found in directory")

--- a/spacy/cli/project/clone.py
+++ b/spacy/cli/project/clone.py
@@ -78,6 +78,7 @@ def check_clone(name: str, dest: Path, repo: str) -> None:
     if not dest.parent.exists():
         # We're not creating parents, parent dir should exist
         msg.fail(
-            f"Can't clone project, parent directory doesn't exist: {dest.parent}",
+            f"Can't clone project, parent directory doesn't exist: {dest.parent}. "
+            f"Create the necessary folder(s) first before continuing.",
             exits=1,
         )


### PR DESCRIPTION

## Description
- Rewrite `https` repo to `git` protocol
- Don't use `stdin` but pass arguments directly (seems less error prone?)
- I think the final `checkout` command needs a branch? So let's assume `master` by default?
- Few UX updates

### Types of changes
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
