### PR TITLE
Fix significant performance bug in parser training

### DIFF
--- a/spacy/pipeline/_parser_internals/_state.pxd
+++ b/spacy/pipeline/_parser_internals/_state.pxd
@@ -42,6 +42,7 @@ cdef cppclass StateC:
     RingBufferC _hist
     int length
     int offset
+    int n_pushes
     int _s_i
     int _b_i
     int _e_i
@@ -49,6 +50,7 @@ cdef cppclass StateC:
 
     __init__(const TokenC* sent, int length) nogil:
         cdef int PADDING = 5
+        this.n_pushes = 0
         this._buffer = <int*>calloc(length + (PADDING * 2), sizeof(int))
         this._stack = <int*>calloc(length + (PADDING * 2), sizeof(int))
         this.shifted = <bint*>calloc(length + (PADDING * 2), sizeof(bint))
@@ -335,6 +337,7 @@ cdef cppclass StateC:
             this.set_break(this.B_(0).l_edge)
         if this._b_i > this._break:
             this._break = -1
+        this.n_pushes += 1
 
     void pop() nogil:
         if this._s_i >= 1:
@@ -351,6 +354,7 @@ cdef cppclass StateC:
         this._buffer[this._b_i] = this.S(0)
         this._s_i -= 1
         this.shifted[this.B(0)] = True
+        this.n_pushes -= 1
 
     void add_arc(int head, int child, attr_t label) nogil:
         if this.has_head(child):
@@ -431,6 +435,7 @@ cdef cppclass StateC:
         this._break = src._break
         this.offset = src.offset
         this._empty_token = src._empty_token
+        this.n_pushes = src.n_pushes
 
     void fast_forward() nogil:
         # space token attachement policy:

--- a/spacy/pipeline/_parser_internals/stateclass.pyx
+++ b/spacy/pipeline/_parser_internals/stateclass.pyx
@@ -36,6 +36,10 @@ cdef class StateClass:
             hist[i] = self.c.get_hist(i+1)
         return hist
 
+    @property
+    def n_pushes(self):
+        return self.c.n_pushes
+
     def is_final(self):
         return self.c.is_final()
 


### PR DESCRIPTION
The parser training makes use of a trick for long documents, where we
use the oracle to cut up the document into sections, so that we can have
batch items in the middle of a document. For instance, if we have one
document of 600 words, we might make 6 states, starting at words 0, 100,
200, 300, 400 and 500.

The problem is for v3, I screwed this up and didn't stop parsing! So
instead of a batch of `[100, 100, 100, 100, 100, 100]`, we'd have a batch
of `[600, 500, 400, 300, 200, 100]`. Oops.

The implementation here could probably be improved, it's annoying to
have this extra variable in the state. But this'll do.

This makes the v3 parser training 5-10 times faster, depending on document
lengths. This problem wasn't in v2.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
