### PR TITLE
Fix off-by-one error for best iteration calculation (closes #6014)

### DIFF
--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -554,9 +554,10 @@ def train(
                         iter_since_best = 0
                         best_score = current_score
                     if iter_since_best >= n_early_stopping:
+                        iter_current = i + 1
                         msg.text(
                             "Early stopping, best iteration "
-                            "is: {}".format(i - iter_since_best)
+                            "is: {}".format(iter_current - iter_since_best)
                         )
                         msg.text(
                             "Best score = {}; Final iteration "


### PR DESCRIPTION
Bugfix for #6014 

Index `i` starts from **0** and iterations in column `Itn` are numbered from **1**, so `iter_current = i + 1` was added to adjust the numbering.

## Checklist

- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
