### PR TITLE
Pipe API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     "cymem>=2.0.2,<2.1.0",
     "preshed>=3.0.2,<3.1.0",
     "murmurhash>=0.28.0,<1.1.0",
-    "thinc>=8.0.0a30,<8.0.0a40",
+    "thinc>=8.0.0a31,<8.0.0a40",
     "blis>=0.4.0,<0.5.0",
     "pytokenizations",
     "pathy"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Our libraries
 cymem>=2.0.2,<2.1.0
 preshed>=3.0.2,<3.1.0
-thinc>=8.0.0a30,<8.0.0a40
+thinc>=8.0.0a31,<8.0.0a40
 blis>=0.4.0,<0.5.0
 ml_datasets>=0.1.1
 murmurhash>=0.28.0,<1.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,13 +34,13 @@ setup_requires =
     cymem>=2.0.2,<2.1.0
     preshed>=3.0.2,<3.1.0
     murmurhash>=0.28.0,<1.1.0
-    thinc>=8.0.0a30,<8.0.0a40
+    thinc>=8.0.0a31,<8.0.0a40
 install_requires =
     # Our libraries
     murmurhash>=0.28.0,<1.1.0
     cymem>=2.0.2,<2.1.0
     preshed>=3.0.2,<3.1.0
-    thinc>=8.0.0a30,<8.0.0a40
+    thinc>=8.0.0a31,<8.0.0a40
     blis>=0.4.0,<0.5.0
     wasabi>=0.8.0,<1.1.0
     srsly>=2.1.0,<3.0.0

--- a/spacy/cli/debug_model.py
+++ b/spacy/cli/debug_model.py
@@ -84,11 +84,11 @@ def debug_model(model: Model, *, print_settings: Optional[Dict[str, Any]] = None
         _print_model(model, print_settings)
 
     # STEP 1: Initializing the model and printing again
+    X = _get_docs()
     Y = _get_output(model.ops.xp)
-    _set_output_dim(nO=Y.shape[-1], model=model)
     # The output vector might differ from the official type of the output layer
     with data_validation(False):
-        model.initialize(X=_get_docs(), Y=Y)
+        model.initialize(X=X, Y=Y)
     if print_settings.get("print_after_init"):
         msg.divider(f"STEP 1 - after initialization")
         _print_model(model, print_settings)
@@ -133,15 +133,6 @@ def _get_docs(lang: str = "en"):
 
 def _get_output(xp):
     return xp.asarray([i + 10 for i, _ in enumerate(_get_docs())], dtype="float32")
-
-
-def _set_output_dim(model, nO):
-    # the dim inference doesn't always work 100%, we need this hack like we have it in pipe.pyx
-    if model.has_dim("nO") is None:
-        model.set_dim("nO", nO)
-    if model.has_ref("output_layer"):
-        if model.get_ref("output_layer").has_dim("nO") is None:
-            model.get_ref("output_layer").set_dim("nO", nO)
 
 
 def _print_model(model, print_settings):

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -476,6 +476,8 @@ class Errors:
     E199 = ("Unable to merge 0-length span at doc[{start}:{end}].")
 
     # TODO: fix numbering after merging develop into master
+    E925 = ("Encountered an unknown label '{label}' in {component}. Did you call "
+            "{component}.add_label('{label}')?")
     E926 = ("It looks like you're trying to modify nlp.{attr} directly. This "
             "doesn't work because it's an immutable computed property. If you "
             "need to modify the pipeline, use the built-in methods like "

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -479,6 +479,11 @@ class Errors:
             "layer can not be dynamically changed.")
     E922 = ("Component '{name}' has been initialized with an output dimension of "
             "{nO} - cannot add any more labels.")
+    E923 = ("It looks like there is no proper sample data to initialize the "
+            "Model of component '{name}'. "
+            "This is likely a bug in spaCy, so feel free to open an issue.")
+    E924 = ("The '{name}' component does not seem to be initialized properly. "
+            "This is likely a bug in spaCy, so feel free to open an issue.")
     E925 = ("Invalid color values for displaCy visualizer: expected dictionary "
             "mapping label names to colors but got: {obj}")
     E926 = ("It looks like you're trying to modify nlp.{attr} directly. This "

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -316,10 +316,6 @@ class Errors:
             "So instead of pickling the span, pickle the Doc it belongs to or "
             "use Span.as_doc to convert the span to a standalone Doc object.")
     E115 = ("All subtokens must have associated heads.")
-    E116 = ("Cannot currently add labels to pretrained text classifier. Add "
-            "labels before training begins. This functionality was available "
-            "in previous versions, but had significant bugs that led to poor "
-            "performance.")
     E117 = ("The newly split tokens must match the text of the original token. "
             "New orths: {new}. Old text: {old}.")
     E118 = ("The custom extension attribute '{attr}' is not registered on the "
@@ -478,6 +474,11 @@ class Errors:
     # TODO: fix numbering after merging develop into master
     E920 = ("Encountered an unknown label '{label}' in {component}. Did you call "
             "{component}.add_label('{label}')?")
+    E921 = ("The method 'set_output' can only be called on components that have "
+            "a Model with a 'resize_output' attribute. Otherwise, the output "
+            "layer can not be dynamically changed.")
+    E922 = ("Component '{name}' has been initialized with an output dimension of "
+            "{nO} - cannot add any more labels.")
     E925 = ("Invalid color values for displaCy visualizer: expected dictionary "
             "mapping label names to colors but got: {obj}")
     E926 = ("It looks like you're trying to modify nlp.{attr} directly. This "

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -243,8 +243,8 @@ class Errors:
             "Query string: {string}\nOrth cached: {orth}\nOrth ID: {orth_id}")
     E065 = ("Only one of the vector table's width and shape can be specified. "
             "Got width {width} and shape {shape}.")
-    E067 = ("Invalid BILUO tag sequence: Got a tag starting with 'I' (inside "
-            "an entity) without a preceding 'B' (beginning of an entity). "
+    E067 = ("Invalid BILUO tag sequence: Got a tag starting with {start} "
+            "without a preceding 'B' (beginning of an entity). "
             "Tag sequence:\n{tags}")
     E068 = ("Invalid BILUO tag: '{tag}'.")
     E071 = ("Error creating lexeme: specified orth ID ({orth}) does not "

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -370,8 +370,9 @@ class Errors:
             "should be of equal length.")
     E141 = ("Entity vectors should be of length {required} instead of the "
             "provided {found}.")
-    E143 = ("Labels for component '{name}' not initialized. Did you forget to "
-            "call add_label()?")
+    E143 = ("Labels for component '{name}' not initialized. This can be fixed "
+            "by calling add_label, or by providing a representative batch of "
+            "examples to the component's begin_training method.")
     E145 = ("Error reading `{param}` from input file.")
     E146 = ("Could not access `{path}`.")
     E147 = ("Unexpected error in the {method} functionality of the "
@@ -472,8 +473,6 @@ class Errors:
     E199 = ("Unable to merge 0-length span at doc[{start}:{end}].")
 
     # TODO: fix numbering after merging develop into master
-    E920 = ("Encountered an unknown label '{label}' in {component}. Did you call "
-            "{component}.add_label('{label}')?")
     E921 = ("The method 'set_output' can only be called on components that have "
             "a Model with a 'resize_output' attribute. Otherwise, the output "
             "layer can not be dynamically changed.")

--- a/spacy/gold/iob_utils.py
+++ b/spacy/gold/iob_utils.py
@@ -195,13 +195,15 @@ def tags_to_entities(tags):
             continue
         elif tag.startswith("I"):
             if start is None:
-                raise ValueError(Errors.E067.format(tags=tags[: i + 1]))
+                raise ValueError(Errors.E067.format(start="I", tags=tags[: i + 1]))
             continue
         if tag.startswith("U"):
             entities.append((tag[2:], i, i))
         elif tag.startswith("B"):
             start = i
         elif tag.startswith("L"):
+            if start is None:
+                raise ValueError(Errors.E067.format(start="L", tags=tags[: i + 1]))
             entities.append((tag[2:], start, i))
             start = None
         else:

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1155,21 +1155,21 @@ class Language:
 
         DOCS: https://spacy.io/api/language#begin_training
         """
-        # TODO: throw warning when get_gold_tuples is provided instead of get_examples
         if get_examples is None:
-            get_examples = lambda: []
-        else:  # Populate vocab
-            if not hasattr(get_examples, "__call__"):
-                err = Errors.E930.format(name="Language", obj=type(get_examples))
+            doc = Doc(self.vocab, words=["This is an example sentence."])
+            get_examples = lambda: [Example.from_dict(doc, {})]
+        # Populate vocab
+        if not hasattr(get_examples, "__call__"):
+            err = Errors.E930.format(name="Language", obj=type(get_examples))
+            raise ValueError(err)
+        for example in get_examples():
+            if not isinstance(example, Example):
+                err = Errors.E978.format(
+                    name="Language.begin_training", types=type(example)
+                )
                 raise ValueError(err)
-            for example in get_examples():
-                if not isinstance(example, Example):
-                    err = Errors.E978.format(
-                        name="Language.begin_training", types=type(example)
-                    )
-                    raise ValueError(err)
-                for word in [t.text for t in example.reference]:
-                    _ = self.vocab[word]  # noqa: F841
+            for word in [t.text for t in example.reference]:
+                _ = self.vocab[word]  # noqa: F841
         if device >= 0:  # TODO: do we need this here?
             require_gpu(device)
             if self.vocab.vectors.data.shape[1] >= 1:

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -656,7 +656,7 @@ class Language:
         return resolved[factory_name]
 
     def create_pipe_from_source(
-        self, source_name: str, source: "Language", *, name: str,
+        self, source_name: str, source: "Language", *, name: str
     ) -> Tuple[Callable[[Doc], Doc], str]:
         """Create a pipeline component by copying it from an existing model.
 
@@ -1156,7 +1156,10 @@ class Language:
         DOCS: https://nightly.spacy.io/api/language#begin_training
         """
         if get_examples is None:
-            doc = Doc(self.vocab, words=["This is an example sentence."])
+            util.logger.debug(
+                "No 'get_examples' callback provided to 'Language.begin_training', creating dummy examples"
+            )
+            doc = Doc(self.vocab, words=["x", "y", "z"])
             get_examples = lambda: [Example.from_dict(doc, {})]
         # Populate vocab
         if not hasattr(get_examples, "__call__"):
@@ -1187,7 +1190,7 @@ class Language:
         return self._optimizer
 
     def resume_training(
-        self, *, sgd: Optional[Optimizer] = None, device: int = -1,
+        self, *, sgd: Optional[Optimizer] = None, device: int = -1
     ) -> Optimizer:
         """Continue training a pretrained model.
 

--- a/spacy/ml/_iob.py
+++ b/spacy/ml/_iob.py
@@ -62,8 +62,6 @@ def forward(model: Model[Padded, Padded], Xp: Padded, is_train: bool):
 def get_num_actions(n_labels: int) -> int:
     # One BEGIN action per label
     # One IN action per label
-    # One LAST action per label
-    # One UNIT action per label
     # One OUT action
     return n_labels * 2 + 1
 

--- a/spacy/ml/models/simple_ner.py
+++ b/spacy/ml/models/simple_ner.py
@@ -21,7 +21,7 @@ def BiluoTagger(
     A BILUO tag sequence encodes a sequence of non-overlapping labelled spans
     into tags assigned to each token. The first token of a span is given the
     tag B-LABEL, the last token of the span is given the tag L-LABEL, and tokens
-    within the span are given the tag U-LABEL. Single-token spans are given
+    within the span are given the tag I-LABEL. Single-token spans are given
     the tag U-LABEL. All other tokens are assigned the tag O.
 
     The BILUO tag scheme generally results in better linear separation between
@@ -86,7 +86,7 @@ def IOBTagger(
 
 
 def init(model: Model[List[Doc], List[Floats2d]], X=None, Y=None) -> None:
-    if model.get_dim("nO") is None and Y:
+    if model.has_dim("nO") is None and Y:
         model.set_dim("nO", Y[0].shape[1])
     nO = model.get_dim("nO")
     biluo = model.get_ref("biluo")

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -162,8 +162,8 @@ class EntityLinker(Pipe):
         for example in islice(get_examples(), 10):
             doc_sample.append(example.x)
             vector_sample.append(self.model.ops.alloc1f(nO))
-        assert doc_sample
-        assert vector_sample
+        assert len(doc_sample) > 0, Errors.E923.format(name=self.name)
+        assert len(vector_sample) > 0, Errors.E923.format(name=self.name)
         self.model.initialize(X=doc_sample, Y=self.model.ops.asarray(vector_sample, dtype="float32"))
         if sgd is None:
             sgd = self.create_optimizer()

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -156,8 +156,15 @@ class EntityLinker(Pipe):
         self._ensure_examples(get_examples)
         self._require_kb()
         nO = self.kb.entity_vector_length
-        self.set_output(nO)
-        self.model.initialize()
+        doc_sample = []
+        vector_sample = []
+        for example in get_examples():
+            if len(doc_sample) < 10:
+                doc_sample.append(example.x)
+                vector_sample.append(self.model.ops.alloc1f(nO))
+        assert doc_sample
+        assert vector_sample
+        self.model.initialize(X=doc_sample, Y=self.model.ops.asarray(vector_sample, dtype="float32"))
         if sgd is None:
             sgd = self.create_optimizer()
         return sgd

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -142,8 +142,8 @@ class EntityLinker(Pipe):
     ) -> Optimizer:
         """Initialize the pipe for training, using data examples if available.
 
-        get_examples (Callable[[], Iterable[Example]]): Optional function that
-            returns gold-standard Example objects.
+        get_examples (Callable[[], Iterable[Example]]): Function that
+            returns a sample of gold-standard Example objects.
         pipeline (List[Tuple[str, Callable]]): Optional list of pipeline
             components that this component is part of. Corresponds to
             nlp.pipeline.
@@ -153,6 +153,9 @@ class EntityLinker(Pipe):
 
         DOCS: https://nightly.spacy.io/api/entitylinker#begin_training
         """
+        if get_examples is None or not hasattr(get_examples, "__call__"):
+            err = Errors.E930.format(name="EntityLinker", obj=type(get_examples))
+            raise ValueError(err)
         self.require_kb()
         nO = self.kb.entity_vector_length
         self.set_output(nO)

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -141,10 +141,11 @@ class EntityLinker(Pipe):
         pipeline: Optional[List[Tuple[str, Callable[[Doc], Doc]]]] = None,
         sgd: Optional[Optimizer] = None,
     ) -> Optimizer:
-        """Initialize the pipe for training, using data examples if available.
+        """Initialize the pipe for training, using a representative set
+        of data examples.
 
         get_examples (Callable[[], Iterable[Example]]): Function that
-            returns a sample of gold-standard Example objects.
+            returns a representative sample of gold-standard Example objects.
         pipeline (List[Tuple[str, Callable]]): Optional list of pipeline
             components that this component is part of. Corresponds to
             nlp.pipeline.
@@ -164,7 +165,9 @@ class EntityLinker(Pipe):
             vector_sample.append(self.model.ops.alloc1f(nO))
         assert len(doc_sample) > 0, Errors.E923.format(name=self.name)
         assert len(vector_sample) > 0, Errors.E923.format(name=self.name)
-        self.model.initialize(X=doc_sample, Y=self.model.ops.asarray(vector_sample, dtype="float32"))
+        self.model.initialize(
+            X=doc_sample, Y=self.model.ops.asarray(vector_sample, dtype="float32")
+        )
         if sgd is None:
             sgd = self.create_optimizer()
         return sgd
@@ -413,7 +416,7 @@ class EntityLinker(Pipe):
                     token.ent_kb_id_ = kb_id
 
     def to_disk(
-        self, path: Union[str, Path], *, exclude: Iterable[str] = SimpleFrozenList(),
+        self, path: Union[str, Path], *, exclude: Iterable[str] = SimpleFrozenList()
     ) -> None:
         """Serialize the pipe to disk.
 
@@ -430,7 +433,7 @@ class EntityLinker(Pipe):
         util.to_disk(path, serialize, exclude)
 
     def from_disk(
-        self, path: Union[str, Path], *, exclude: Iterable[str] = SimpleFrozenList(),
+        self, path: Union[str, Path], *, exclude: Iterable[str] = SimpleFrozenList()
     ) -> "EntityLinker":
         """Load the pipe from disk. Modifies the object in place and returns it.
 

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -128,7 +128,7 @@ class EntityLinker(Pipe):
         # how many neightbour sentences to take into account
         self.n_sents = cfg.get("n_sents", 0)
 
-    def require_kb(self) -> None:
+    def _require_kb(self) -> None:
         # Raise an error if the knowledge base is not initialized.
         if len(self.kb) == 0:
             raise ValueError(Errors.E139.format(name=self.name))
@@ -153,10 +153,8 @@ class EntityLinker(Pipe):
 
         DOCS: https://nightly.spacy.io/api/entitylinker#begin_training
         """
-        if get_examples is None or not hasattr(get_examples, "__call__"):
-            err = Errors.E930.format(name="EntityLinker", obj=type(get_examples))
-            raise ValueError(err)
-        self.require_kb()
+        self._ensure_examples(get_examples)
+        self._require_kb()
         nO = self.kb.entity_vector_length
         self.set_output(nO)
         self.model.initialize()
@@ -187,7 +185,7 @@ class EntityLinker(Pipe):
 
         DOCS: https://nightly.spacy.io/api/entitylinker#update
         """
-        self.require_kb()
+        self._require_kb()
         if losses is None:
             losses = {}
         losses.setdefault(self.name, 0.0)
@@ -299,7 +297,7 @@ class EntityLinker(Pipe):
 
         DOCS: https://nightly.spacy.io/api/entitylinker#predict
         """
-        self.require_kb()
+        self._require_kb()
         entity_count = 0
         final_kb_ids = []
         if not docs:

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -1,3 +1,4 @@
+from itertools import islice
 from typing import Optional, Iterable, Callable, Dict, Iterator, Union, List, Tuple
 from pathlib import Path
 import srsly
@@ -158,10 +159,9 @@ class EntityLinker(Pipe):
         nO = self.kb.entity_vector_length
         doc_sample = []
         vector_sample = []
-        for example in get_examples():
-            if len(doc_sample) < 10:
-                doc_sample.append(example.x)
-                vector_sample.append(self.model.ops.alloc1f(nO))
+        for example in islice(get_examples(), 10):
+            doc_sample.append(example.x)
+            vector_sample.append(self.model.ops.alloc1f(nO))
         assert doc_sample
         assert vector_sample
         self.model.initialize(X=doc_sample, Y=self.model.ops.asarray(vector_sample, dtype="float32"))

--- a/spacy/pipeline/morphologizer.pyx
+++ b/spacy/pipeline/morphologizer.pyx
@@ -130,8 +130,8 @@ class Morphologizer(Tagger):
     def begin_training(self, get_examples, *, pipeline=None, sgd=None):
         """Initialize the pipe for training, using data examples if available.
 
-        get_examples (Callable[[], Iterable[Example]]): Optional function that
-            returns gold-standard Example objects.
+        get_examples (Callable[[], Iterable[Example]]): Function that
+            returns a sample of gold-standard Example objects.
         pipeline (List[Tuple[str, Callable]]): Optional list of pipeline
             components that this component is part of. Corresponds to
             nlp.pipeline.
@@ -141,7 +141,7 @@ class Morphologizer(Tagger):
 
         DOCS: https://nightly.spacy.io/api/morphologizer#begin_training
         """
-        if not hasattr(get_examples, "__call__"):
+        if get_examples is None or not hasattr(get_examples, "__call__"):
             err = Errors.E930.format(name="Morphologizer", obj=type(get_examples))
             raise ValueError(err)
         for example in get_examples():

--- a/spacy/pipeline/morphologizer.pyx
+++ b/spacy/pipeline/morphologizer.pyx
@@ -113,6 +113,7 @@ class Morphologizer(Tagger):
             raise ValueError(Errors.E187)
         if label in self.labels:
             return 0
+        self._allow_extra_label()
         # normalize label
         norm_label = self.vocab.morphology.normalize_features(label)
         # extract separate POS and morph tags

--- a/spacy/pipeline/morphologizer.pyx
+++ b/spacy/pipeline/morphologizer.pyx
@@ -141,12 +141,8 @@ class Morphologizer(Tagger):
 
         DOCS: https://nightly.spacy.io/api/morphologizer#begin_training
         """
-        if get_examples is None or not hasattr(get_examples, "__call__"):
-            err = Errors.E930.format(name="Morphologizer", obj=type(get_examples))
-            raise ValueError(err)
-        if len(self.labels) == 0:
-            err = Errors.E1006.format(name="Morphologizer")
-            raise ValueError(err)
+        self._ensure_examples(get_examples)
+        self._require_labels()
         doc_sample = []
         label_sample = []
         for example in get_examples():

--- a/spacy/pipeline/morphologizer.pyx
+++ b/spacy/pipeline/morphologizer.pyx
@@ -163,8 +163,8 @@ class Morphologizer(Tagger):
                 gold_array.append([1.0 if label == norm_label else 0.0 for label in self.labels])
             doc_sample.append(example.x)
             label_sample.append(self.model.ops.asarray(gold_array, dtype="float32"))
-        assert len(doc_sample) > 0
-        assert len(label_sample) > 0
+        assert len(doc_sample) > 0, Errors.E923.format(name=self.name)
+        assert len(label_sample) > 0, Errors.E923.format(name=self.name)
         self.model.initialize(X=doc_sample, Y=label_sample)
         if sgd is None:
             sgd = self.create_optimizer()

--- a/spacy/pipeline/morphologizer.pyx
+++ b/spacy/pipeline/morphologizer.pyx
@@ -162,8 +162,8 @@ class Morphologizer(Tagger):
                 gold_array.append([1.0 if label == norm_label else 0.0 for label in self.labels])
             doc_sample.append(example.x)
             label_sample.append(self.model.ops.asarray(gold_array, dtype="float32"))
-        assert doc_sample
-        assert label_sample
+        assert len(doc_sample) > 0
+        assert len(label_sample) > 0
         self.model.initialize(X=doc_sample, Y=label_sample)
         if sgd is None:
             sgd = self.create_optimizer()

--- a/spacy/pipeline/morphologizer.pyx
+++ b/spacy/pipeline/morphologizer.pyx
@@ -1,4 +1,5 @@
 # cython: infer_types=True, profile=True, binding=True
+from itertools import islice
 from typing import Optional
 import srsly
 from thinc.api import SequenceCategoricalCrossentropy, Model, Config
@@ -145,7 +146,7 @@ class Morphologizer(Tagger):
         self._require_labels()
         doc_sample = []
         label_sample = []
-        for example in get_examples():
+        for example in islice(get_examples(), 10):
             gold_array = []
             for i, token in enumerate(example.reference):
                 pos = token.pos_
@@ -159,9 +160,8 @@ class Morphologizer(Tagger):
                     err = Errors.E920.format(component="morphologizer", label=norm_label)
                     raise ValueError(err)
                 gold_array.append([1.0 if label == norm_label else 0.0 for label in self.labels])
-            if len(doc_sample) < 10:
-                doc_sample.append(example.x)
-                label_sample.append(self.model.ops.asarray(gold_array, dtype="float32"))
+            doc_sample.append(example.x)
+            label_sample.append(self.model.ops.asarray(gold_array, dtype="float32"))
         assert doc_sample
         assert label_sample
         self.model.initialize(X=doc_sample, Y=label_sample)

--- a/spacy/pipeline/multitask.pyx
+++ b/spacy/pipeline/multitask.pyx
@@ -90,7 +90,7 @@ class MultitaskObjective(Tagger):
                 label = self.make_label(token)
                 if label is not None and label not in self.labels:
                     self.labels[label] = len(self.labels)
-        self.model.initialize()
+        self.model.initialize()   # TODO: fix initialization by defining X and Y
         if sgd is None:
             sgd = self.create_optimizer()
         return sgd
@@ -178,7 +178,7 @@ class ClozeMultitask(Pipe):
         pass
 
     def begin_training(self, get_examples, pipeline=None, sgd=None):
-        self.model.initialize()
+        self.model.initialize()  # TODO: fix initialization by defining X and Y
         X = self.model.ops.alloc((5, self.model.get_ref("tok2vec").get_dim("nO")))
         self.model.output_layer.begin_training(X)
         if sgd is None:

--- a/spacy/pipeline/pipe.pyx
+++ b/spacy/pipeline/pipe.pyx
@@ -172,8 +172,8 @@ cdef class Pipe:
     def begin_training(self, get_examples, *, pipeline=None, sgd=None):
         """Initialize the pipe for training, using data examples if available.
 
-        get_examples (Callable[[], Iterable[Example]]): Optional function that
-            returns gold-standard Example objects.
+        get_examples (Callable[[], Iterable[Example]]): Function that
+            returns a sample of gold-standard Example objects.
         pipeline (List[Tuple[str, Callable]]): Optional list of pipeline
             components that this component is part of. Corresponds to
             nlp.pipeline.

--- a/spacy/pipeline/pipe.pyx
+++ b/spacy/pipeline/pipe.pyx
@@ -160,6 +160,13 @@ cdef class Pipe:
         """
         raise NotImplementedError(Errors.E931.format(method="add_label", name=self.name))
 
+
+    def _require_labels(self) -> None:
+        """Raise an error if the component's model has no labels defined."""
+        if not self.labels:
+            raise ValueError(Errors.E143.format(name=self.name))
+
+
     def create_optimizer(self):
         """Create an optimizer for the pipeline component.
 
@@ -187,6 +194,11 @@ cdef class Pipe:
         if sgd is None:
             sgd = self.create_optimizer()
         return sgd
+
+    def _ensure_examples(self, get_examples):
+        if get_examples is None or not hasattr(get_examples, "__call__"):
+            err = Errors.E930.format(name=self.name, obj=type(get_examples))
+            raise ValueError(err)
 
     def set_output(self, nO):
         if self.model.has_dim("nO") is not False:

--- a/spacy/pipeline/pipe.pyx
+++ b/spacy/pipeline/pipe.pyx
@@ -203,12 +203,8 @@ cdef class Pipe:
             err = Errors.E930.format(name=self.name, obj=get_examples())
             raise ValueError(err)
 
-
     def set_output(self, nO):
-        if self.model.has_dim("nO") is not False:
-            self.model.set_dim("nO", nO)
-        if self.model.has_ref("output_layer"):
-            self.model.get_ref("output_layer").set_dim("nO", nO)
+        raise NotImplementedError(Errors.E931.format(method="set_output", name=self.name))
 
     def use_params(self, params):
         """Modify the pipe's model, to use the given parameter values. At the

--- a/spacy/pipeline/pipe.pyx
+++ b/spacy/pipeline/pipe.pyx
@@ -178,6 +178,9 @@ cdef class Pipe:
 
     def begin_training(self, get_examples, *, pipeline=None, sgd=None):
         """Initialize the pipe for training, using data examples if available.
+        This method needs to be implemented by each Pipe component,
+        ensuring the internal model (if available) is initialized properly
+        using the provided sample of Example objects.
 
         get_examples (Callable[[], Iterable[Example]]): Function that
             returns a sample of gold-standard Example objects.
@@ -190,10 +193,7 @@ cdef class Pipe:
 
         DOCS: https://nightly.spacy.io/api/pipe#begin_training
         """
-        self.model.initialize()
-        if sgd is None:
-            sgd = self.create_optimizer()
-        return sgd
+        raise NotImplementedError(Errors.E931.format(method="add_label", name=self.name))
 
     def _ensure_examples(self, get_examples):
         if get_examples is None or not hasattr(get_examples, "__call__"):

--- a/spacy/pipeline/pipe.pyx
+++ b/spacy/pipeline/pipe.pyx
@@ -199,6 +199,10 @@ cdef class Pipe:
         if get_examples is None or not hasattr(get_examples, "__call__"):
             err = Errors.E930.format(name=self.name, obj=type(get_examples))
             raise ValueError(err)
+        if not get_examples():
+            err = Errors.E930.format(name=self.name, obj=get_examples())
+            raise ValueError(err)
+
 
     def set_output(self, nO):
         if self.model.has_dim("nO") is not False:

--- a/spacy/pipeline/pipe.pyx
+++ b/spacy/pipeline/pipe.pyx
@@ -163,7 +163,7 @@ cdef class Pipe:
 
     def _require_labels(self) -> None:
         """Raise an error if the component's model has no labels defined."""
-        if not self.labels:
+        if not self.labels or list(self.labels) == [""]:
             raise ValueError(Errors.E143.format(name=self.name))
 
 
@@ -190,7 +190,7 @@ cdef class Pipe:
         using the provided sample of Example objects.
 
         get_examples (Callable[[], Iterable[Example]]): Function that
-            returns a sample of gold-standard Example objects.
+            returns a representative sample of gold-standard Example objects.
         pipeline (List[Tuple[str, Callable]]): Optional list of pipeline
             components that this component is part of. Corresponds to
             nlp.pipeline.

--- a/spacy/pipeline/senter.pyx
+++ b/spacy/pipeline/senter.pyx
@@ -137,9 +137,7 @@ class SentenceRecognizer(Tagger):
 
         DOCS: https://nightly.spacy.io/api/sentencerecognizer#begin_training
         """
-        if get_examples is None or not hasattr(get_examples, "__call__"):
-            err = Errors.E930.format(name="SentenceRecognizer", obj=type(get_examples))
-            raise ValueError(err)
+        self._ensure_examples(get_examples)
         doc_sample = []
         label_sample = []
         assert self.labels

--- a/spacy/pipeline/senter.pyx
+++ b/spacy/pipeline/senter.pyx
@@ -126,8 +126,8 @@ class SentenceRecognizer(Tagger):
     def begin_training(self, get_examples, *, pipeline=None, sgd=None):
         """Initialize the pipe for training, using data examples if available.
 
-        get_examples (Callable[[], Iterable[Example]]): Optional function that
-            returns gold-standard Example objects.
+        get_examples (Callable[[], Iterable[Example]]): Function that
+            returns a sample of gold-standard Example objects.
         pipeline (List[Tuple[str, Callable]]): Optional list of pipeline
             components that this component is part of. Corresponds to
             nlp.pipeline.
@@ -137,6 +137,9 @@ class SentenceRecognizer(Tagger):
 
         DOCS: https://nightly.spacy.io/api/sentencerecognizer#begin_training
         """
+        if get_examples is None or not hasattr(get_examples, "__call__"):
+            err = Errors.E930.format(name="SentenceRecognizer", obj=type(get_examples))
+            raise ValueError(err)
         self.set_output(len(self.labels))
         self.model.initialize()
         if sgd is None:

--- a/spacy/pipeline/senter.pyx
+++ b/spacy/pipeline/senter.pyx
@@ -148,8 +148,8 @@ class SentenceRecognizer(Tagger):
             gold_tags = example.get_aligned("SENT_START")
             gold_array = [[1.0 if tag == gold_tag else 0.0 for tag in self.labels] for gold_tag in gold_tags]
             label_sample.append(self.model.ops.asarray(gold_array, dtype="float32"))
-        assert doc_sample
-        assert label_sample
+        assert len(doc_sample) > 0
+        assert len(label_sample) > 0
         self.model.initialize(X=doc_sample, Y=label_sample)
         if sgd is None:
             sgd = self.create_optimizer()

--- a/spacy/pipeline/senter.pyx
+++ b/spacy/pipeline/senter.pyx
@@ -142,14 +142,14 @@ class SentenceRecognizer(Tagger):
         self._ensure_examples(get_examples)
         doc_sample = []
         label_sample = []
-        assert self.labels
+        assert self.labels, Errors.E924.format(name=self.name)
         for example in islice(get_examples(), 10):
             doc_sample.append(example.x)
             gold_tags = example.get_aligned("SENT_START")
             gold_array = [[1.0 if tag == gold_tag else 0.0 for tag in self.labels] for gold_tag in gold_tags]
             label_sample.append(self.model.ops.asarray(gold_array, dtype="float32"))
-        assert len(doc_sample) > 0
-        assert len(label_sample) > 0
+        assert len(doc_sample) > 0, Errors.E923.format(name=self.name)
+        assert len(label_sample) > 0, Errors.E923.format(name=self.name)
         self.model.initialize(X=doc_sample, Y=label_sample)
         if sgd is None:
             sgd = self.create_optimizer()

--- a/spacy/pipeline/senter.pyx
+++ b/spacy/pipeline/senter.pyx
@@ -126,10 +126,11 @@ class SentenceRecognizer(Tagger):
         return float(loss), d_scores
 
     def begin_training(self, get_examples, *, pipeline=None, sgd=None):
-        """Initialize the pipe for training, using data examples if available.
+        """Initialize the pipe for training, using a representative set
+        of data examples.
 
         get_examples (Callable[[], Iterable[Example]]): Function that
-            returns a sample of gold-standard Example objects.
+            returns a representative sample of gold-standard Example objects.
         pipeline (List[Tuple[str, Callable]]): Optional list of pipeline
             components that this component is part of. Corresponds to
             nlp.pipeline.

--- a/spacy/pipeline/senter.pyx
+++ b/spacy/pipeline/senter.pyx
@@ -140,8 +140,18 @@ class SentenceRecognizer(Tagger):
         if get_examples is None or not hasattr(get_examples, "__call__"):
             err = Errors.E930.format(name="SentenceRecognizer", obj=type(get_examples))
             raise ValueError(err)
-        self.set_output(len(self.labels))
-        self.model.initialize()
+        doc_sample = []
+        label_sample = []
+        assert self.labels
+        for example in get_examples():
+            if len(doc_sample) < 10:
+                doc_sample.append(example.x)
+                gold_tags = example.get_aligned("SENT_START")
+                gold_array = [[1.0 if tag == gold_tag else 0.0 for tag in self.labels] for gold_tag in gold_tags]
+                label_sample.append(self.model.ops.asarray(gold_array, dtype="float32"))
+        assert doc_sample
+        assert label_sample
+        self.model.initialize(X=doc_sample, Y=label_sample)
         if sgd is None:
             sgd = self.create_optimizer()
         return sgd

--- a/spacy/pipeline/senter.pyx
+++ b/spacy/pipeline/senter.pyx
@@ -1,4 +1,6 @@
 # cython: infer_types=True, profile=True, binding=True
+from itertools import islice
+
 import srsly
 from thinc.api import Model, SequenceCategoricalCrossentropy, Config
 
@@ -141,12 +143,11 @@ class SentenceRecognizer(Tagger):
         doc_sample = []
         label_sample = []
         assert self.labels
-        for example in get_examples():
-            if len(doc_sample) < 10:
-                doc_sample.append(example.x)
-                gold_tags = example.get_aligned("SENT_START")
-                gold_array = [[1.0 if tag == gold_tag else 0.0 for tag in self.labels] for gold_tag in gold_tags]
-                label_sample.append(self.model.ops.asarray(gold_array, dtype="float32"))
+        for example in islice(get_examples(), 10):
+            doc_sample.append(example.x)
+            gold_tags = example.get_aligned("SENT_START")
+            gold_array = [[1.0 if tag == gold_tag else 0.0 for tag in self.labels] for gold_tag in gold_tags]
+            label_sample.append(self.model.ops.asarray(gold_array, dtype="float32"))
         assert doc_sample
         assert label_sample
         self.model.initialize(X=doc_sample, Y=label_sample)

--- a/spacy/pipeline/simple_ner.py
+++ b/spacy/pipeline/simple_ner.py
@@ -168,9 +168,8 @@ class SimpleNER(Pipe):
         pipeline: Optional[List[Tuple[str, Callable[[Doc], Doc]]]] = None,
         sgd: Optional[Optimizer] = None,
     ):
-        if get_examples is None or not hasattr(get_examples, "__call__"):
-            err = Errors.E930.format(name="SimpleNER", obj=type(get_examples))
-            raise ValueError(err)
+        self._ensure_examples(get_examples)
+        self._require_labels()
         all_labels = set()
         for example in get_examples():
             all_labels.update(_get_labels(example))

--- a/spacy/pipeline/simple_ner.py
+++ b/spacy/pipeline/simple_ner.py
@@ -168,10 +168,10 @@ class SimpleNER(Pipe):
         pipeline: Optional[List[Tuple[str, Callable[[Doc], Doc]]]] = None,
         sgd: Optional[Optimizer] = None,
     ):
-        all_labels = set()
-        if not hasattr(get_examples, "__call__"):
+        if get_examples is None or not hasattr(get_examples, "__call__"):
             err = Errors.E930.format(name="SimpleNER", obj=type(get_examples))
             raise ValueError(err)
+        all_labels = set()
         for example in get_examples():
             all_labels.update(_get_labels(example))
         for label in sorted(all_labels):

--- a/spacy/pipeline/simple_ner.py
+++ b/spacy/pipeline/simple_ner.py
@@ -1,3 +1,4 @@
+from itertools import islice
 from typing import List, Iterable, Optional, Dict, Tuple, Callable, Set
 from thinc.types import Floats2d
 from thinc.api import SequenceCategoricalCrossentropy, set_dropout_rate, Model
@@ -172,7 +173,7 @@ class SimpleNER(Pipe):
         self._require_labels()
         doc_sample = []
         label_sample = []
-        for example in get_examples():
+        for example in islice(get_examples(), 10):
             for label in _get_labels(example):
                 if label and label not in self.labels:
                     err = Errors.E920.format(component="simple_ner", label=label)
@@ -183,8 +184,8 @@ class SimpleNER(Pipe):
                 gold_tags = biluo_to_iob(gold_tags)
             gold_array = [[1.0 if tag == gold_tag else 0.0 for tag in self.get_tag_names()] for gold_tag in gold_tags]
             label_sample.append(self.model.ops.asarray(gold_array, dtype="float32"))
-        assert doc_sample
-        assert label_sample
+        assert len(doc_sample) > 0
+        assert len(label_sample) > 0
         self.model.initialize(X=doc_sample, Y=label_sample)
         if pipeline is not None:
             self.init_multitask_objectives(get_examples, pipeline, sgd=sgd, **self.cfg)

--- a/spacy/pipeline/simple_ner.py
+++ b/spacy/pipeline/simple_ner.py
@@ -184,8 +184,8 @@ class SimpleNER(Pipe):
                 gold_tags = biluo_to_iob(gold_tags)
             gold_array = [[1.0 if tag == gold_tag else 0.0 for tag in self.get_tag_names()] for gold_tag in gold_tags]
             label_sample.append(self.model.ops.asarray(gold_array, dtype="float32"))
-        assert len(doc_sample) > 0
-        assert len(label_sample) > 0
+        assert len(doc_sample) > 0, Errors.E923.format(name=self.name)
+        assert len(label_sample) > 0, Errors.E923.format(name=self.name)
         self.model.initialize(X=doc_sample, Y=label_sample)
         if pipeline is not None:
             self.init_multitask_objectives(get_examples, pipeline, sgd=sgd, **self.cfg)

--- a/spacy/pipeline/tagger.pyx
+++ b/spacy/pipeline/tagger.pyx
@@ -272,12 +272,8 @@ class Tagger(Pipe):
 
         DOCS: https://nightly.spacy.io/api/tagger#begin_training
         """
-        if get_examples is None or not hasattr(get_examples, "__call__"):
-            err = Errors.E930.format(name="Tagger", obj=type(get_examples))
-            raise ValueError(err)
-        if len(self.labels) == 0:
-            err = Errors.E1006.format(name="Tagger")
-            raise ValueError(err)
+        self._ensure_examples(get_examples)
+        self._require_labels()
         doc_sample = []
         label_sample = []
         for example in get_examples():

--- a/spacy/pipeline/tagger.pyx
+++ b/spacy/pipeline/tagger.pyx
@@ -286,8 +286,8 @@ class Tagger(Pipe):
             gold_tags = example.get_aligned("TAG", as_string=True)
             gold_array = [[1.0 if tag == gold_tag else 0.0 for tag in self.labels] for gold_tag in gold_tags]
             label_sample.append(self.model.ops.asarray(gold_array, dtype="float32"))
-        assert len(doc_sample) > 0
-        assert len(label_sample) > 0
+        assert len(doc_sample) > 0, Errors.E923.format(name=self.name)
+        assert len(label_sample) > 0, Errors.E923.format(name=self.name)
         self.model.initialize(X=doc_sample, Y=label_sample)
         if sgd is None:
             sgd = self.create_optimizer()

--- a/spacy/pipeline/tagger.pyx
+++ b/spacy/pipeline/tagger.pyx
@@ -1,11 +1,11 @@
 # cython: infer_types=True, profile=True, binding=True
-from itertools import islice
 from typing import List
 import numpy
 import srsly
 from thinc.api import Model, set_dropout_rate, SequenceCategoricalCrossentropy, Config
 from thinc.types import Floats2d
 import warnings
+from itertools import islice
 
 from ..tokens.doc cimport Doc
 from ..morphology cimport Morphology

--- a/spacy/pipeline/tagger.pyx
+++ b/spacy/pipeline/tagger.pyx
@@ -286,8 +286,8 @@ class Tagger(Pipe):
             gold_tags = example.get_aligned("TAG", as_string=True)
             gold_array = [[1.0 if tag == gold_tag else 0.0 for tag in self.labels] for gold_tag in gold_tags]
             label_sample.append(self.model.ops.asarray(gold_array, dtype="float32"))
-        assert doc_sample
-        assert label_sample
+        assert len(doc_sample) > 0
+        assert len(label_sample) > 0
         self.model.initialize(X=doc_sample, Y=label_sample)
         if sgd is None:
             sgd = self.create_optimizer()

--- a/spacy/pipeline/tagger.pyx
+++ b/spacy/pipeline/tagger.pyx
@@ -305,6 +305,7 @@ class Tagger(Pipe):
             raise ValueError(Errors.E187)
         if label in self.labels:
             return 0
+        self._allow_extra_label()
         self.cfg["labels"].append(label)
         self.vocab.strings.add(label)
         return 1

--- a/spacy/pipeline/textcat.py
+++ b/spacy/pipeline/textcat.py
@@ -343,8 +343,8 @@ class TextCategorizer(Pipe):
                     raise ValueError(err)
         doc_sample = [eg.reference for eg in subbatch]
         label_sample, _ = self._examples_to_truth(subbatch)
-        assert len(doc_sample) > 0
-        assert len(label_sample) > 0
+        assert len(doc_sample) > 0, Errors.E923.format(name=self.name)
+        assert len(label_sample) > 0, Errors.E923.format(name=self.name)
         self.model.initialize(X=doc_sample, Y=label_sample)
         if sgd is None:
             sgd = self.create_optimizer()

--- a/spacy/pipeline/textcat.py
+++ b/spacy/pipeline/textcat.py
@@ -334,8 +334,8 @@ class TextCategorizer(Pipe):
     ) -> Optimizer:
         """Initialize the pipe for training, using data examples if available.
 
-        get_examples (Callable[[], Iterable[Example]]): Optional function that
-            returns gold-standard Example objects.
+        get_examples (Callable[[], Iterable[Example]]): Function that
+            returns a sample of gold-standard Example objects.
         pipeline (List[Tuple[str, Callable]]): Optional list of pipeline
             components that this component is part of. Corresponds to
             nlp.pipeline.
@@ -345,7 +345,7 @@ class TextCategorizer(Pipe):
 
         DOCS: https://nightly.spacy.io/api/textcategorizer#begin_training
         """
-        if not hasattr(get_examples, "__call__"):
+        if get_examples is None or not hasattr(get_examples, "__call__"):
             err = Errors.E930.format(name="TextCategorizer", obj=type(get_examples))
             raise ValueError(err)
         subbatch = []  # Select a subbatch of examples to initialize the model

--- a/spacy/pipeline/textcat.py
+++ b/spacy/pipeline/textcat.py
@@ -351,11 +351,11 @@ class TextCategorizer(Pipe):
                 if cat and cat not in self.labels:
                     err = Errors.E920.format(component="textcat", label=cat)
                     raise ValueError(err)
-        docs = [eg.reference for eg in subbatch]
-        if not docs:  # need at least one doc
-            docs = [Doc(self.vocab, words=["hello"])]
-        truths, _ = self._examples_to_truth(subbatch)
-        self.model.initialize(X=docs, Y=truths)
+        doc_sample = [eg.reference for eg in subbatch]
+        label_sample, _ = self._examples_to_truth(subbatch)
+        assert len(doc_sample) > 0
+        assert len(label_sample) > 0
+        self.model.initialize(X=doc_sample, Y=label_sample)
         if sgd is None:
             sgd = self.create_optimizer()
         return sgd

--- a/spacy/pipeline/textcat.py
+++ b/spacy/pipeline/textcat.py
@@ -307,17 +307,7 @@ class TextCategorizer(Pipe):
             raise ValueError(Errors.E187)
         if label in self.labels:
             return 0
-        if self.model.has_dim("nO"):
-            # This functionality was available previously, but was broken.
-            # The problem is that we resize the last layer, but the last layer
-            # is actually just an ensemble. We're not resizing the child layers
-            # - a huge problem.
-            raise ValueError(Errors.E116)
-            # smaller = self.model._layers[-1]
-            # larger = Linear(len(self.labels)+1, smaller.nI)
-            # copy_array(larger.W[:smaller.nO], smaller.W)
-            # copy_array(larger.b[:smaller.nO], smaller.b)
-            # self.model._layers[-1] = larger
+        self._allow_extra_label()
         self.labels = tuple(list(self.labels) + [label])
         return 1
 

--- a/spacy/pipeline/tok2vec.py
+++ b/spacy/pipeline/tok2vec.py
@@ -211,8 +211,8 @@ class Tok2Vec(Pipe):
     ):
         """Initialize the pipe for training, using data examples if available.
 
-        get_examples (Callable[[], Iterable[Example]]): Optional function that
-            returns gold-standard Example objects.
+        get_examples (Callable[[], Iterable[Example]]): Function that
+            returns a sample of gold-standard Example objects.
         pipeline (List[Tuple[str, Callable]]): Optional list of pipeline
             components that this component is part of. Corresponds to
             nlp.pipeline.
@@ -222,6 +222,9 @@ class Tok2Vec(Pipe):
 
         DOCS: https://nightly.spacy.io/api/tok2vec#begin_training
         """
+        if get_examples is None or not hasattr(get_examples, "__call__"):
+            err = Errors.E930.format(name="Tok2Vec", obj=type(get_examples))
+            raise ValueError(err)
         docs = [Doc(self.vocab, words=["hello"])]
         self.model.initialize(X=docs)
 

--- a/spacy/pipeline/tok2vec.py
+++ b/spacy/pipeline/tok2vec.py
@@ -227,7 +227,7 @@ class Tok2Vec(Pipe):
         doc_sample = []
         for example in islice(get_examples(), 10):
             doc_sample.append(example.x)
-        assert doc_sample
+        assert doc_sample, Errors.E923.format(name=self.name)
         self.model.initialize(X=doc_sample)
 
     def add_label(self, label):

--- a/spacy/pipeline/tok2vec.py
+++ b/spacy/pipeline/tok2vec.py
@@ -210,10 +210,11 @@ class Tok2Vec(Pipe):
         pipeline: Optional[List[Tuple[str, Callable[[Doc], Doc]]]] = None,
         sgd: Optional[Optimizer] = None,
     ):
-        """Initialize the pipe for training, using data examples if available.
+        """Initialize the pipe for training, using a representative set
+        of data examples.
 
         get_examples (Callable[[], Iterable[Example]]): Function that
-            returns a sample of gold-standard Example objects.
+            returns a representative sample of gold-standard Example objects.
         pipeline (List[Tuple[str, Callable]]): Optional list of pipeline
             components that this component is part of. Corresponds to
             nlp.pipeline.

--- a/spacy/pipeline/tok2vec.py
+++ b/spacy/pipeline/tok2vec.py
@@ -1,6 +1,6 @@
-from itertools import islice
 from typing import Iterator, Sequence, Iterable, Optional, Dict, Callable, List, Tuple
 from thinc.api import Model, set_dropout_rate, Optimizer, Config
+from itertools import islice
 
 from .pipe import Pipe
 from ..gold import Example, validate_examples

--- a/spacy/pipeline/tok2vec.py
+++ b/spacy/pipeline/tok2vec.py
@@ -222,11 +222,13 @@ class Tok2Vec(Pipe):
 
         DOCS: https://nightly.spacy.io/api/tok2vec#begin_training
         """
-        if get_examples is None or not hasattr(get_examples, "__call__"):
-            err = Errors.E930.format(name="Tok2Vec", obj=type(get_examples))
-            raise ValueError(err)
-        docs = [Doc(self.vocab, words=["hello"])]
-        self.model.initialize(X=docs)
+        self._ensure_examples(get_examples)
+        doc_sample = []
+        for example in get_examples():
+            if len(doc_sample) < 10:
+                doc_sample.append(example.x)
+        assert doc_sample
+        self.model.initialize(X=doc_sample)
 
     def add_label(self, label):
         raise NotImplementedError

--- a/spacy/pipeline/tok2vec.py
+++ b/spacy/pipeline/tok2vec.py
@@ -1,3 +1,4 @@
+from itertools import islice
 from typing import Iterator, Sequence, Iterable, Optional, Dict, Callable, List, Tuple
 from thinc.api import Model, set_dropout_rate, Optimizer, Config
 
@@ -224,9 +225,8 @@ class Tok2Vec(Pipe):
         """
         self._ensure_examples(get_examples)
         doc_sample = []
-        for example in get_examples():
-            if len(doc_sample) < 10:
-                doc_sample.append(example.x)
+        for example in islice(get_examples(), 10):
+            doc_sample.append(example.x)
         assert doc_sample
         self.model.initialize(X=doc_sample)
 

--- a/spacy/pipeline/transition_parser.pyx
+++ b/spacy/pipeline/transition_parser.pyx
@@ -413,7 +413,7 @@ cdef class Parser(Pipe):
             langs = ", ".join(util.LEXEME_NORM_LANGS)
             util.logger.debug(Warnings.W033.format(model="parser or NER", langs=langs))
         actions = self.moves.get_actions(
-        #    examples=get_examples(),
+            examples=get_examples(),
             min_freq=self.cfg['min_action_freq'],
             learn_tokens=self.cfg["learn_tokens"]
         )

--- a/spacy/pipeline/transition_parser.pyx
+++ b/spacy/pipeline/transition_parser.pyx
@@ -244,7 +244,7 @@ cdef class Parser(Pipe):
             int nr_class, int batch_size) nogil:
         # n_moves should not be zero at this point, but make sure to avoid zero-length mem alloc
         with gil:
-            assert self.moves.n_moves > 0
+            assert self.moves.n_moves > 0, Errors.E924.format(name=self.name)
         is_valid = <int*>calloc(self.moves.n_moves, sizeof(int))
         cdef int i, guess
         cdef Transition action
@@ -378,7 +378,7 @@ cdef class Parser(Pipe):
         cdef int i
 
         # n_moves should not be zero at this point, but make sure to avoid zero-length mem alloc
-        assert self.moves.n_moves > 0
+        assert self.moves.n_moves > 0, Errors.E924.format(name=self.name)
 
         is_valid = <int*>mem.alloc(self.moves.n_moves, sizeof(int))
         costs = <float*>mem.alloc(self.moves.n_moves, sizeof(float))
@@ -439,7 +439,7 @@ cdef class Parser(Pipe):
         if not doc_sample:
             for example in islice(get_examples(), 10):
                 doc_sample.append(example.predicted)
-        assert len(doc_sample) > 0
+        assert len(doc_sample) > 0, Errors.E923.format(name=self.name)
         self.model.initialize(doc_sample)
         if pipeline is not None:
             self.init_multitask_objectives(get_examples, pipeline, sgd=sgd, **self.cfg)

--- a/spacy/pipeline/transition_parser.pyx
+++ b/spacy/pipeline/transition_parser.pyx
@@ -406,7 +406,7 @@ cdef class Parser(Pipe):
         self.model.attrs["resize_output"](self.model, nO)
 
     def begin_training(self, get_examples, pipeline=None, sgd=None, **kwargs):
-        if not hasattr(get_examples, "__call__"):
+        if get_examples is None or not hasattr(get_examples, "__call__"):
             err = Errors.E930.format(name="DependencyParser/EntityRecognizer", obj=type(get_examples))
             raise ValueError(err)
         self.cfg.update(kwargs)

--- a/spacy/pipeline/transition_parser.pyx
+++ b/spacy/pipeline/transition_parser.pyx
@@ -406,9 +406,7 @@ cdef class Parser(Pipe):
         self.model.attrs["resize_output"](self.model, nO)
 
     def begin_training(self, get_examples, pipeline=None, sgd=None, **kwargs):
-        if get_examples is None or not hasattr(get_examples, "__call__"):
-            err = Errors.E930.format(name="DependencyParser/EntityRecognizer", obj=type(get_examples))
-            raise ValueError(err)
+        self._ensure_examples(get_examples)
         self.cfg.update(kwargs)
         lexeme_norms = self.vocab.lookups.get_table("lexeme_norm", {})
         if len(lexeme_norms) == 0 and self.vocab.lang in util.LEXEME_NORM_LANGS:

--- a/spacy/tests/doc/test_add_entities.py
+++ b/spacy/tests/doc/test_add_entities.py
@@ -1,10 +1,17 @@
+from spacy.gold import Example
 from spacy.pipeline import EntityRecognizer
-from spacy.tokens import Span
+from spacy.tokens import Span, Doc
 from spacy import registry
 import pytest
 
 from ..util import get_doc
 from spacy.pipeline.ner import DEFAULT_NER_MODEL
+
+
+def _ner_example(ner):
+    doc = Doc(ner.vocab, words=["Joe", "loves", "visiting", "London", "during", "the", "weekend"])
+    gold = {"entities": [(0, 3, "PERSON"), (19, 25, "LOC")]}
+    return Example.from_dict(doc, gold)
 
 
 def test_doc_add_entities_set_ents_iob(en_vocab):
@@ -18,7 +25,7 @@ def test_doc_add_entities_set_ents_iob(en_vocab):
     cfg = {"model": DEFAULT_NER_MODEL}
     model = registry.make_from_config(cfg, validate=True)["model"]
     ner = EntityRecognizer(en_vocab, model, **config)
-    ner.begin_training(lambda: [])
+    ner.begin_training(lambda: [_ner_example(ner)])
     ner(doc)
     assert len(list(doc.ents)) == 0
     assert [w.ent_iob_ for w in doc] == (["O"] * len(doc))
@@ -41,7 +48,7 @@ def test_ents_reset(en_vocab):
     cfg = {"model": DEFAULT_NER_MODEL}
     model = registry.make_from_config(cfg, validate=True)["model"]
     ner = EntityRecognizer(en_vocab, model, **config)
-    ner.begin_training(lambda: [])
+    ner.begin_training(lambda: [_ner_example(ner)])
     ner(doc)
     assert [t.ent_iob_ for t in doc] == (["O"] * len(doc))
     doc.ents = list(doc.ents)

--- a/spacy/tests/doc/test_add_entities.py
+++ b/spacy/tests/doc/test_add_entities.py
@@ -27,32 +27,12 @@ def test_doc_add_entities_set_ents_iob(en_vocab):
     ner = EntityRecognizer(en_vocab, model, **config)
     ner.begin_training(lambda: [_ner_example(ner)])
     ner(doc)
-    assert len(list(doc.ents)) == 0
-    assert [w.ent_iob_ for w in doc] == (["O"] * len(doc))
 
     doc.ents = [(doc.vocab.strings["ANIMAL"], 3, 4)]
     assert [w.ent_iob_ for w in doc] == ["O", "O", "O", "B"]
 
     doc.ents = [(doc.vocab.strings["WORD"], 0, 2)]
     assert [w.ent_iob_ for w in doc] == ["B", "I", "O", "O"]
-
-
-def test_ents_reset(en_vocab):
-    text = ["This", "is", "a", "lion"]
-    doc = get_doc(en_vocab, text)
-    config = {
-        "learn_tokens": False,
-        "min_action_freq": 30,
-        "update_with_oracle_cut_size": 100,
-    }
-    cfg = {"model": DEFAULT_NER_MODEL}
-    model = registry.make_from_config(cfg, validate=True)["model"]
-    ner = EntityRecognizer(en_vocab, model, **config)
-    ner.begin_training(lambda: [_ner_example(ner)])
-    ner(doc)
-    assert [t.ent_iob_ for t in doc] == (["O"] * len(doc))
-    doc.ents = list(doc.ents)
-    assert [t.ent_iob_ for t in doc] == (["O"] * len(doc))
 
 
 def test_add_overlapping_entities(en_vocab):

--- a/spacy/tests/doc/test_add_entities.py
+++ b/spacy/tests/doc/test_add_entities.py
@@ -35,6 +35,25 @@ def test_doc_add_entities_set_ents_iob(en_vocab):
     assert [w.ent_iob_ for w in doc] == ["B", "I", "O", "O"]
 
 
+def test_ents_reset(en_vocab):
+    """Ensure that resetting doc.ents does not change anything"""
+    text = ["This", "is", "a", "lion"]
+    doc = get_doc(en_vocab, text)
+    config = {
+        "learn_tokens": False,
+        "min_action_freq": 30,
+        "update_with_oracle_cut_size": 100,
+    }
+    cfg = {"model": DEFAULT_NER_MODEL}
+    model = registry.make_from_config(cfg, validate=True)["model"]
+    ner = EntityRecognizer(en_vocab, model, **config)
+    ner.begin_training(lambda: [_ner_example(ner)])
+    ner(doc)
+    orig_iobs = [t.ent_iob_ for t in doc]
+    doc.ents = list(doc.ents)
+    assert [t.ent_iob_ for t in doc] == orig_iobs
+
+
 def test_add_overlapping_entities(en_vocab):
     text = ["Louisiana", "Office", "of", "Conservation"]
     doc = get_doc(en_vocab, text)

--- a/spacy/tests/parser/test_add_label.py
+++ b/spacy/tests/parser/test_add_label.py
@@ -35,7 +35,7 @@ def test_init_parser(parser):
 def _train_parser(parser):
     fix_random_seed(1)
     parser.add_label("left")
-    parser.begin_training(lambda: [], **parser.cfg)
+    parser.begin_training(lambda: [_parser_example(parser)], **parser.cfg)
     sgd = Adam(0.001)
 
     for i in range(5):
@@ -47,16 +47,25 @@ def _train_parser(parser):
     return parser
 
 
+def _parser_example(parser):
+    doc = Doc(parser.vocab, words=["a", "b", "c", "d"])
+    gold = {"heads": [1, 1, 3, 3], "deps": ["right", "ROOT", "left", "ROOT"]}
+    return Example.from_dict(doc, gold)
+
+
+def _ner_example(ner):
+    doc = Doc(ner.vocab, words=["Joe", "loves", "visiting", "London", "during", "the", "weekend"])
+    gold = {"entities": [(0, 3, "PERSON"), (19, 25, "LOC")]}
+    return Example.from_dict(doc, gold)
+
+
 def test_add_label(parser):
     parser = _train_parser(parser)
     parser.add_label("right")
     sgd = Adam(0.001)
     for i in range(100):
         losses = {}
-        doc = Doc(parser.vocab, words=["a", "b", "c", "d"])
-        gold = {"heads": [1, 1, 3, 3], "deps": ["right", "ROOT", "left", "ROOT"]}
-        example = Example.from_dict(doc, gold)
-        parser.update([example], sgd=sgd, losses=losses)
+        parser.update([_parser_example(parser)], sgd=sgd, losses=losses)
     doc = Doc(parser.vocab, words=["a", "b", "c", "d"])
     doc = parser(doc)
     assert doc[0].dep_ == "right"
@@ -75,7 +84,7 @@ def test_add_label_deserializes_correctly():
     ner1.add_label("C")
     ner1.add_label("B")
     ner1.add_label("A")
-    ner1.begin_training(lambda: [])
+    ner1.begin_training(lambda: [_ner_example(ner1)])
     ner2 = EntityRecognizer(Vocab(), model, **config)
 
     # the second model needs to be resized before we can call from_bytes

--- a/spacy/tests/parser/test_parse.py
+++ b/spacy/tests/parser/test_parse.py
@@ -85,7 +85,7 @@ def test_parser_merge_pp(en_tokenizer):
     pos = ["DET", "NOUN", "ADP", "DET", "NOUN", "VERB"]
     tokens = en_tokenizer(text)
     doc = get_doc(
-        tokens.vocab, words=[t.text for t in tokens], deps=deps, heads=heads, pos=pos,
+        tokens.vocab, words=[t.text for t in tokens], deps=deps, heads=heads, pos=pos
     )
     with doc.retokenize() as retokenizer:
         for np in doc.noun_chunks:

--- a/spacy/tests/parser/test_preset_sbd.py
+++ b/spacy/tests/parser/test_preset_sbd.py
@@ -14,6 +14,12 @@ def vocab():
     return Vocab(lex_attr_getters={NORM: lambda s: s})
 
 
+def _parser_example(parser):
+    doc = Doc(parser.vocab, words=["a", "b", "c", "d"])
+    gold = {"heads": [1, 1, 3, 3], "deps": ["right", "ROOT", "left", "ROOT"]}
+    return Example.from_dict(doc, gold)
+
+
 @pytest.fixture
 def parser(vocab):
     config = {
@@ -28,7 +34,7 @@ def parser(vocab):
     parser.cfg["hidden_width"] = 32
     # parser.add_label('right')
     parser.add_label("left")
-    parser.begin_training(lambda: [], **parser.cfg)
+    parser.begin_training(lambda: [_parser_example(parser)], **parser.cfg)
     sgd = Adam(0.001)
 
     for i in range(10):

--- a/spacy/tests/pipeline/test_morphologizer.py
+++ b/spacy/tests/pipeline/test_morphologizer.py
@@ -39,6 +39,17 @@ def test_invalid_label():
         nlp.begin_training(get_examples=lambda: train_examples)
 
 
+def test_no_resize():
+    nlp = Language()
+    morphologizer = nlp.add_pipe("morphologizer")
+    morphologizer.add_label("POS" + Morphology.FIELD_SEP + "NOUN")
+    morphologizer.add_label("POS" + Morphology.FIELD_SEP + "VERB")
+    nlp.begin_training()
+    # this throws an error because the morphologizer can't be resized after initialization
+    with pytest.raises(ValueError):
+        morphologizer.add_label("POS" + Morphology.FIELD_SEP + "ADJ")
+
+
 def test_begin_training_examples():
     nlp = Language()
     morphologizer = nlp.add_pipe("morphologizer")

--- a/spacy/tests/pipeline/test_senter.py
+++ b/spacy/tests/pipeline/test_senter.py
@@ -30,7 +30,7 @@ TRAIN_DATA = [
     ),
 ]
 
-def test_senter_begin_training_examples():
+def test_begin_training_examples():
     nlp = Language()
     senter = nlp.add_pipe("senter")
     train_examples = []

--- a/spacy/tests/pipeline/test_senter.py
+++ b/spacy/tests/pipeline/test_senter.py
@@ -30,6 +30,20 @@ TRAIN_DATA = [
     ),
 ]
 
+def test_senter_begin_training_examples():
+    nlp = Language()
+    senter = nlp.add_pipe("senter")
+    train_examples = []
+    for t in TRAIN_DATA:
+        train_examples.append(Example.from_dict(nlp.make_doc(t[0]), t[1]))
+    # you shouldn't really call this more than once, but for testing it should be fine
+    nlp.begin_training()
+    nlp.begin_training(get_examples=lambda: train_examples)
+    with pytest.raises(TypeError):
+        nlp.begin_training(get_examples=lambda: None)
+    with pytest.raises(ValueError):
+        nlp.begin_training(get_examples=train_examples)
+
 
 def test_overfitting_IO():
     # Simple test to try and quickly overfit the senter - ensuring the ML models work correctly

--- a/spacy/tests/pipeline/test_simple_ner.py
+++ b/spacy/tests/pipeline/test_simple_ner.py
@@ -11,7 +11,6 @@ TRAIN_DATA = [
 ]
 
 
-
 def test_no_label():
     nlp = English()
     nlp.add_pipe("simple_ner")
@@ -19,15 +18,14 @@ def test_no_label():
         nlp.begin_training()
 
 
-def test_invalid_tag():
+def test_implicit_label():
     nlp = English()
     ner = nlp.add_pipe("simple_ner")
     train_examples = []
     ner.add_label("ORG")
     for t in TRAIN_DATA:
         train_examples.append(Example.from_dict(nlp.make_doc(t[0]), t[1]))
-    with pytest.raises(ValueError):
-        nlp.begin_training(get_examples=lambda: train_examples)
+    nlp.begin_training(get_examples=lambda: train_examples)
 
 
 @pytest.mark.skip(reason="Should be fixed")
@@ -82,9 +80,7 @@ def test_overfitting_IO():
     train_examples = []
     for text, annotations in TRAIN_DATA:
         train_examples.append(Example.from_dict(nlp.make_doc(text), annotations))
-        for ent in annotations.get("entities"):
-            ner.add_label(ent[2])
-    optimizer = nlp.begin_training()
+    optimizer = nlp.begin_training(get_examples=lambda: train_examples)
 
     for i in range(50):
         losses = {}

--- a/spacy/tests/pipeline/test_simple_ner.py
+++ b/spacy/tests/pipeline/test_simple_ner.py
@@ -1,3 +1,4 @@
+import pytest
 from spacy.lang.en import English
 from spacy.gold import Example
 from spacy import util
@@ -5,9 +6,49 @@ from ..util import make_tempdir
 
 
 TRAIN_DATA = [
-    ("Who is Shaka Khan?", {"entities": [(7, 17, "PERSON")]}),
+    ("Who is Shaka S Khan?", {"entities": [(7, 19, "PERSON")]}),
     ("I like London and Berlin.", {"entities": [(7, 13, "LOC"), (18, 24, "LOC")]}),
 ]
+
+
+
+def test_no_label():
+    nlp = English()
+    nlp.add_pipe("simple_ner")
+    with pytest.raises(ValueError):
+        nlp.begin_training()
+
+
+def test_invalid_tag():
+    nlp = English()
+    ner = nlp.add_pipe("simple_ner")
+    train_examples = []
+    ner.add_label("ORG")
+    for t in TRAIN_DATA:
+        train_examples.append(Example.from_dict(nlp.make_doc(t[0]), t[1]))
+    with pytest.raises(ValueError):
+        nlp.begin_training(get_examples=lambda: train_examples)
+
+
+def test_begin_training_examples():
+    nlp = English()
+    ner = nlp.add_pipe("simple_ner")
+    train_examples = []
+    for text, annotations in TRAIN_DATA:
+        train_examples.append(Example.from_dict(nlp.make_doc(text), annotations))
+        for ent in annotations.get("entities"):
+            ner.add_label(ent[2])
+    # you shouldn't really call this more than once, but for testing it should be fine
+    nlp.begin_training()
+    nlp.begin_training(get_examples=lambda: train_examples)
+    with pytest.raises(TypeError):
+        nlp.begin_training(get_examples=lambda: None)
+    with pytest.raises(TypeError):
+        nlp.begin_training(get_examples=lambda: train_examples[0])
+    with pytest.raises(ValueError):
+        nlp.begin_training(get_examples=lambda: [])
+    with pytest.raises(ValueError):
+        nlp.begin_training(get_examples=train_examples)
 
 
 def test_overfitting_IO():

--- a/spacy/tests/pipeline/test_simple_ner.py
+++ b/spacy/tests/pipeline/test_simple_ner.py
@@ -41,6 +41,7 @@ def test_resize():
     nlp.begin_training()
     assert len(ner.labels) == 2
     ner.add_label("ORG")
+    nlp.begin_training()
     assert len(ner.labels) == 3
     nlp("Example sentence")
 

--- a/spacy/tests/pipeline/test_simple_ner.py
+++ b/spacy/tests/pipeline/test_simple_ner.py
@@ -30,20 +30,28 @@ def test_invalid_tag():
         nlp.begin_training(get_examples=lambda: train_examples)
 
 
+@pytest.mark.skip(reason="Should be fixed")
+def test_untrained():
+    # This shouldn't crash, but it does when the simple_ner produces an invalid sequence like ['L-PERSON', 'L-ORG']
+    nlp = English()
+    ner = nlp.add_pipe("simple_ner")
+    ner.add_label("PERSON")
+    ner.add_label("LOC")
+    ner.add_label("ORG")
+    nlp.begin_training()
+    nlp("Example sentence")
+
+
 def test_resize():
     nlp = English()
     ner = nlp.add_pipe("simple_ner")
-    train_examples = []
-    for text, annotations in TRAIN_DATA:
-        train_examples.append(Example.from_dict(nlp.make_doc(text), annotations))
-        for ent in annotations.get("entities"):
-            ner.add_label(ent[2])
+    ner.add_label("PERSON")
+    ner.add_label("LOC")
     nlp.begin_training()
     assert len(ner.labels) == 2
     ner.add_label("ORG")
     nlp.begin_training()
     assert len(ner.labels) == 3
-    nlp("Example sentence")
 
 
 def test_begin_training_examples():

--- a/spacy/tests/pipeline/test_simple_ner.py
+++ b/spacy/tests/pipeline/test_simple_ner.py
@@ -30,6 +30,21 @@ def test_invalid_tag():
         nlp.begin_training(get_examples=lambda: train_examples)
 
 
+def test_resize():
+    nlp = English()
+    ner = nlp.add_pipe("simple_ner")
+    train_examples = []
+    for text, annotations in TRAIN_DATA:
+        train_examples.append(Example.from_dict(nlp.make_doc(text), annotations))
+        for ent in annotations.get("entities"):
+            ner.add_label(ent[2])
+    nlp.begin_training()
+    assert len(ner.labels) == 2
+    ner.add_label("ORG")
+    assert len(ner.labels) == 3
+    nlp("Example sentence")
+
+
 def test_begin_training_examples():
     nlp = English()
     ner = nlp.add_pipe("simple_ner")

--- a/spacy/tests/pipeline/test_tagger.py
+++ b/spacy/tests/pipeline/test_tagger.py
@@ -65,6 +65,10 @@ def test_begin_training_examples():
     nlp.begin_training(get_examples=lambda: train_examples)
     with pytest.raises(TypeError):
         nlp.begin_training(get_examples=lambda: None)
+    with pytest.raises(TypeError):
+        nlp.begin_training(get_examples=lambda: train_examples[0])
+    with pytest.raises(ValueError):
+        nlp.begin_training(get_examples=lambda: [])
     with pytest.raises(ValueError):
         nlp.begin_training(get_examples=train_examples)
 

--- a/spacy/tests/pipeline/test_tagger.py
+++ b/spacy/tests/pipeline/test_tagger.py
@@ -34,6 +34,36 @@ TRAIN_DATA = [
 ]
 
 
+def test_tagger_invalid_tag():
+    nlp = Language()
+    tagger = nlp.add_pipe("tagger")
+    train_examples = []
+    tagger.add_label("N")
+    train_examples = []
+    for t in TRAIN_DATA:
+        train_examples.append(Example.from_dict(nlp.make_doc(t[0]), t[1]))
+    with pytest.raises(ValueError):
+        nlp.begin_training(get_examples=lambda: train_examples)
+
+
+def test_tagger_begin_training_examples():
+    nlp = Language()
+    tagger = nlp.add_pipe("tagger")
+    train_examples = []
+    for tag in TAGS:
+        tagger.add_label(tag)
+    train_examples = []
+    for t in TRAIN_DATA:
+        train_examples.append(Example.from_dict(nlp.make_doc(t[0]), t[1]))
+    # you shouldn't really call this more than once, but for testing it should be fine
+    nlp.begin_training()
+    nlp.begin_training(get_examples=lambda: train_examples)
+    with pytest.raises(TypeError):
+        nlp.begin_training(get_examples=lambda: None)
+    with pytest.raises(ValueError):
+        nlp.begin_training(get_examples=train_examples)
+
+
 def test_overfitting_IO():
     # Simple test to try and quickly overfit the tagger - ensuring the ML models work correctly
     nlp = English()

--- a/spacy/tests/pipeline/test_tagger.py
+++ b/spacy/tests/pipeline/test_tagger.py
@@ -41,7 +41,20 @@ def test_no_label():
         nlp.begin_training()
 
 
-def test_invalid_tag():
+def test_no_resize():
+    nlp = Language()
+    tagger = nlp.add_pipe("tagger")
+    tagger.add_label("N")
+    tagger.add_label("V")
+    assert tagger.labels == ("N", "V")
+    nlp.begin_training()
+    assert tagger.model.get_dim("nO") == 2
+    # this throws an error because the tagger can't be resized after initialization
+    with pytest.raises(ValueError):
+        tagger.add_label("J")
+
+
+def test_invalid_label():
     nlp = Language()
     tagger = nlp.add_pipe("tagger")
     train_examples = []

--- a/spacy/tests/pipeline/test_tagger.py
+++ b/spacy/tests/pipeline/test_tagger.py
@@ -54,15 +54,13 @@ def test_no_resize():
         tagger.add_label("J")
 
 
-def test_invalid_label():
+def test_implicit_label():
     nlp = Language()
-    tagger = nlp.add_pipe("tagger")
+    nlp.add_pipe("tagger")
     train_examples = []
-    tagger.add_label("N")
     for t in TRAIN_DATA:
         train_examples.append(Example.from_dict(nlp.make_doc(t[0]), t[1]))
-    with pytest.raises(ValueError):
-        nlp.begin_training(get_examples=lambda: train_examples)
+    nlp.begin_training(get_examples=lambda: train_examples)
 
 
 def test_begin_training_examples():
@@ -93,9 +91,7 @@ def test_overfitting_IO():
     train_examples = []
     for t in TRAIN_DATA:
         train_examples.append(Example.from_dict(nlp.make_doc(t[0]), t[1]))
-    for tag in TAGS:
-        tagger.add_label(tag)
-    optimizer = nlp.begin_training()
+    optimizer = nlp.begin_training(get_examples=lambda: train_examples)
     assert tagger.model.get_dim("nO") == len(TAGS)
 
     for i in range(50):

--- a/spacy/tests/pipeline/test_tagger.py
+++ b/spacy/tests/pipeline/test_tagger.py
@@ -34,7 +34,14 @@ TRAIN_DATA = [
 ]
 
 
-def test_tagger_invalid_tag():
+def test_no_label():
+    nlp = Language()
+    nlp.add_pipe("tagger")
+    with pytest.raises(ValueError):
+        nlp.begin_training()
+
+
+def test_invalid_tag():
     nlp = Language()
     tagger = nlp.add_pipe("tagger")
     train_examples = []
@@ -46,7 +53,7 @@ def test_tagger_invalid_tag():
         nlp.begin_training(get_examples=lambda: train_examples)
 
 
-def test_tagger_begin_training_examples():
+def test_begin_training_examples():
     nlp = Language()
     tagger = nlp.add_pipe("tagger")
     train_examples = []

--- a/spacy/tests/pipeline/test_tagger.py
+++ b/spacy/tests/pipeline/test_tagger.py
@@ -79,6 +79,7 @@ def test_overfitting_IO():
     for tag in TAGS:
         tagger.add_label(tag)
     optimizer = nlp.begin_training()
+    assert tagger.model.get_dim("nO") == len(TAGS)
 
     for i in range(50):
         losses = {}

--- a/spacy/tests/pipeline/test_tagger.py
+++ b/spacy/tests/pipeline/test_tagger.py
@@ -46,7 +46,6 @@ def test_invalid_tag():
     tagger = nlp.add_pipe("tagger")
     train_examples = []
     tagger.add_label("N")
-    train_examples = []
     for t in TRAIN_DATA:
         train_examples.append(Example.from_dict(nlp.make_doc(t[0]), t[1]))
     with pytest.raises(ValueError):
@@ -59,7 +58,6 @@ def test_begin_training_examples():
     train_examples = []
     for tag in TAGS:
         tagger.add_label(tag)
-    train_examples = []
     for t in TRAIN_DATA:
         train_examples.append(Example.from_dict(nlp.make_doc(t[0]), t[1]))
     # you shouldn't really call this more than once, but for testing it should be fine

--- a/spacy/tests/pipeline/test_textcat.py
+++ b/spacy/tests/pipeline/test_textcat.py
@@ -98,6 +98,18 @@ def test_invalid_label():
         nlp.begin_training(get_examples=lambda: train_examples)
 
 
+def test_no_resize():
+    nlp = Language()
+    textcat = nlp.add_pipe("textcat")
+    textcat.add_label("POSITIVE")
+    textcat.add_label("NEGATIVE")
+    nlp.begin_training()
+    assert textcat.model.get_dim("nO") == 2
+    # this throws an error because the textcat can't be resized after initialization
+    with pytest.raises(ValueError):
+        textcat.add_label("NEUTRAL")
+
+
 def test_begin_training_examples():
     nlp = Language()
     textcat = nlp.add_pipe("textcat")

--- a/spacy/tests/pipeline/test_textcat.py
+++ b/spacy/tests/pipeline/test_textcat.py
@@ -87,15 +87,13 @@ def test_no_label():
         nlp.begin_training()
 
 
-def test_invalid_label():
+def test_implicit_label():
     nlp = Language()
     textcat = nlp.add_pipe("textcat")
     train_examples = []
-    textcat.add_label("IRRELEVANT")
     for t in TRAIN_DATA:
         train_examples.append(Example.from_dict(nlp.make_doc(t[0]), t[1]))
-    with pytest.raises(ValueError):
-        nlp.begin_training(get_examples=lambda: train_examples)
+    nlp.begin_training(get_examples=lambda: train_examples)
 
 
 def test_no_resize():
@@ -136,9 +134,7 @@ def test_overfitting_IO():
     train_examples = []
     for text, annotations in TRAIN_DATA:
         train_examples.append(Example.from_dict(nlp.make_doc(text), annotations))
-        for label, value in annotations.get("cats").items():
-            textcat.add_label(label)
-    optimizer = nlp.begin_training()
+    optimizer = nlp.begin_training(get_examples=lambda: train_examples)
     assert textcat.model.get_dim("nO") == 2
 
     for i in range(50):

--- a/spacy/tests/pipeline/test_textcat.py
+++ b/spacy/tests/pipeline/test_textcat.py
@@ -127,6 +127,7 @@ def test_overfitting_IO():
         for label, value in annotations.get("cats").items():
             textcat.add_label(label)
     optimizer = nlp.begin_training()
+    assert textcat.model.get_dim("nO") == 2
 
     for i in range(50):
         losses = {}

--- a/spacy/tests/regression/test_issue2501-3000.py
+++ b/spacy/tests/regression/test_issue2501-3000.py
@@ -20,7 +20,7 @@ def test_issue2564():
     nlp = Language()
     tagger = nlp.add_pipe("tagger")
     tagger.add_label("A")
-    tagger.begin_training(lambda: [])
+    nlp.begin_training()
     doc = nlp("hello world")
     assert doc.is_tagged
     docs = nlp.pipe(["hello", "world"])

--- a/spacy/tests/regression/test_issue3501-4000.py
+++ b/spacy/tests/regression/test_issue3501-4000.py
@@ -251,6 +251,12 @@ def test_issue3803():
     assert [t.like_num for t in doc] == [True, True, True, True, True, True]
 
 
+def _parser_example(parser):
+    doc = Doc(parser.vocab, words=["a", "b", "c", "d"])
+    gold = {"heads": [1, 1, 3, 3], "deps": ["right", "ROOT", "left", "ROOT"]}
+    return Example.from_dict(doc, gold)
+
+
 def test_issue3830_no_subtok():
     """Test that the parser doesn't have subtok label if not learn_tokens"""
     config = {
@@ -264,7 +270,7 @@ def test_issue3830_no_subtok():
     parser = DependencyParser(Vocab(), model, **config)
     parser.add_label("nsubj")
     assert "subtok" not in parser.labels
-    parser.begin_training(lambda: [])
+    parser.begin_training(lambda: [_parser_example(parser)])
     assert "subtok" not in parser.labels
 
 
@@ -281,7 +287,7 @@ def test_issue3830_with_subtok():
     parser = DependencyParser(Vocab(), model, **config)
     parser.add_label("nsubj")
     assert "subtok" not in parser.labels
-    parser.begin_training(lambda: [])
+    parser.begin_training(lambda: [_parser_example(parser)])
     assert "subtok" in parser.labels
 
 

--- a/spacy/tests/regression/test_issue5230.py
+++ b/spacy/tests/regression/test_issue5230.py
@@ -64,7 +64,7 @@ def tagger():
     # 1. no model leads to error in serialization,
     # 2. the affected line is the one for model serialization
     tagger.add_label("A")
-    tagger.begin_training(lambda: [], pipeline=nlp.pipeline)
+    nlp.begin_training()
     return tagger
 
 
@@ -85,7 +85,7 @@ def entity_linker():
     # need to add model for two reasons:
     # 1. no model leads to error in serialization,
     # 2. the affected line is the one for model serialization
-    entity_linker.begin_training(lambda: [], pipeline=nlp.pipeline)
+    nlp.begin_training()
     return entity_linker
 
 

--- a/spacy/tests/test_tok2vec.py
+++ b/spacy/tests/test_tok2vec.py
@@ -89,6 +89,7 @@ def test_init_tok2vec():
     tok2vec = nlp.add_pipe("tok2vec")
     assert tok2vec.listeners == []
     nlp.begin_training()
+    assert tok2vec.model.get_dim("nO")
 
 
 cfg_string = """


### PR DESCRIPTION
## Description
Some changes to the `Pipe` API:
* Removed the `set_output` hack that would directly set the `nO` dimension
* Instead, enforce that `Pipe` components always receive a few `Example` objects to do shape inference with. This is easily achieved by calling `nlp.begin_training`. 
* Within the `begin_training` method of a component,  `self.model.initialize` should be called with relevant arguments.
   * I wasn't sure about two cases: `multitask.py` (is this currently used?) and `transition_parser.pyx` (which does resizing which I think works fine as is)
* If a component wants to be able to resize its output layer, its model should have an entry `resize_output` in `self.model.attrs`. In this case, `component.is_resizable()` will be `True`.
* ~~I think we should avoid adding labels or inferring other arbitrary properties in the `begin_training` methods, as we ran into trouble with that before, and the provided examples should really only be a small sample. They are not supposed to contain all valid labels, for instance. So instead of adding them automagically, the component now throws an error if the labels are not properly defined beforehand.~~
* Throw an error when a script calls e.g. `component.add_label` when the component's output dimension would become incompatible (e.g. when `component.begin_training` had already been called previously) with the additional label AND the component can not be resized 

I tried to be careful, but the shape inference is sometimes a bit fiddly, and the original `set_output` hack was overwriting most of it. It seems to work now though. I hope this doesn't break anything (if so - we need more tests!)

Note: I wouldn't typically work with `assert...` statements in the main code flow, but I think it's useful to have them in the `begin_training`methods so the code crashes there instead of somewhere in a recursive function in Thinc. If these asserts fail, they point to a programming error, so this really shouldn't happen.

I'll update the docs after this PR gets merged.

### Types of change
enhancement
 
## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
