### PR TITLE
Update to latest spacy-lookups-data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ console_scripts =
 
 [options.extras_require]
 lookups =
-    spacy_lookups_data>=0.3.2,<0.4.0
+    spacy_lookups_data==0.4.0.dev0
 cuda =
     cupy>=5.0.0b4,<9.0.0
 cuda80 =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Just released a new dev version for the `spacy-lookups-data` package exposing the simpler entry points used in v3. Not sure if we need to specify this anywhere else (internally etc.)? This is mostly relevant for the lexeme tables, which are otherwise not available (because they were previously exposed via the `lookups_extra`).

### Types of change
dependencies?

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
