### PR TITLE
Add quick hack to allow CLI extensions

### DIFF
--- a/spacy/cli/_util.py
+++ b/spacy/cli/_util.py
@@ -13,7 +13,7 @@ from thinc.config import Config, ConfigValidationError
 from configparser import InterpolationError
 
 from ..schemas import ProjectConfigSchema, validate
-from ..util import import_file, run_command, make_tempdir
+from ..util import import_file, run_command, make_tempdir, registry
 
 if TYPE_CHECKING:
     from pathy import Pathy  # noqa: F401
@@ -54,6 +54,8 @@ app.add_typer(init_cli)
 
 
 def setup_cli() -> None:
+    # Make sure the entry-point for CLI runs, so that they get imported.
+    registry.cli.get_all()
     # Ensure that the help messages always display the correct prompt
     command = get_command(app)
     command(prog_name=COMMAND)

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -93,6 +93,7 @@ class registry(thinc.registry):
     # environment. spaCy models packaged with `spacy package` will "advertise"
     # themselves via entry points.
     models = catalogue.create("spacy", "models", entry_points=True)
+    cli = catalogue.create("spacy", "cli", entry_points=True)
 
 
 class SimpleFrozenDict(dict):


### PR DESCRIPTION
I'm not sure whether this will be the long-term plan, but I need a quick way to extend the CLI from an external package, in order to keep developing the `spacy-ray` integration.

What I've done is added a dummy registry called "cli", that just serves as a way to import modules that are trying to hook into the CLI. Within those modules, they'll be importing spaCy's CLI `app` object to extend it.

@ines is it okay to merge this until a better solution is developed, probably within typer?


## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
