### PR TITLE
Clarify how to choose pretrained weights files (closes #6027)

### DIFF
--- a/website/docs/api/cli.md
+++ b/website/docs/api/cli.md
@@ -445,7 +445,8 @@ an approximate language-modeling objective. Specifically, we load pretrained
 vectors, and train a component like a CNN, BiLSTM, etc to predict vectors which
 match the pretrained ones. The weights are saved to a directory after each
 epoch. You can then pass a path to one of these pretrained weights files to the
-`spacy train` command.
+`spacy train` command. You can try to use a few with low `Loss` values reported
+in the output.
 
 This technique may be especially helpful if you have little labelled data.
 However, it's still quite experimental, so your mileage may vary. To load the


### PR DESCRIPTION
Small addition to the `pretrain` documentation (https://spacy.io/api/cli#pretrain) to explain how one should pick the pretrained weights files for further training.

## Description

Closes issue #6027 

### Types of change

Change to the documentation

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
