### PR TITLE
project bug fixes

### DIFF
--- a/spacy/cli/_util.py
+++ b/spacy/cli/_util.py
@@ -203,10 +203,6 @@ def get_checksum(path: Union[Path, str]) -> str:
     msg.fail(f"Can't get checksum for {path}: not a file or directory", exits=1)
 
 
-def _brol(path):
-    return str.encode(Path(path).read_text().replace("\r\n", "\n"))
-
-
 @contextmanager
 def show_validation_error(
     file_path: Optional[Union[str, Path]] = None,

--- a/spacy/cli/_util.py
+++ b/spacy/cli/_util.py
@@ -203,6 +203,10 @@ def get_checksum(path: Union[Path, str]) -> str:
     msg.fail(f"Can't get checksum for {path}: not a file or directory", exits=1)
 
 
+def _brol(path):
+    return str.encode(Path(path).read_text().replace("\r\n", "\n"))
+
+
 @contextmanager
 def show_validation_error(
     file_path: Optional[Union[str, Path]] = None,
@@ -360,5 +364,7 @@ def _from_http_to_git(repo):
         repo = repo.replace(r"http://", r"https://")
     if repo.startswith(r"https://"):
         repo = repo.replace("https://", "git@").replace("/", ":", 1)
+        if repo.endswith("/"):
+            repo = repo[:-1]
         repo = f"{repo}.git"
     return repo

--- a/spacy/cli/project/assets.py
+++ b/spacy/cli/project/assets.py
@@ -44,7 +44,9 @@ def project_assets(project_dir: Path) -> None:
             if dest.exists():
                 # If there's already a file, check for checksum
                 if checksum and checksum == get_checksum(dest):
-                    msg.good(f"Skipping download with matching checksum: {dest}")
+                    msg.good(
+                        f"Skipping download with matching checksum: {asset['dest']}"
+                    )
                     continue
                 else:
                     if dest.is_dir():

--- a/spacy/cli/project/assets.py
+++ b/spacy/cli/project/assets.py
@@ -38,7 +38,7 @@ def project_assets(project_dir: Path) -> None:
         msg.warn(f"No assets specified in {PROJECT_FILE}", exits=0)
     msg.info(f"Fetching {len(assets)} asset(s)")
     for asset in assets:
-        dest = project_dir / asset["dest"]
+        dest = (project_dir / asset["dest"]).resolve()
         checksum = asset.get("checksum")
         if "git" in asset:
             if dest.exists():

--- a/spacy/cli/project/assets.py
+++ b/spacy/cli/project/assets.py
@@ -38,38 +38,45 @@ def project_assets(project_dir: Path) -> None:
         msg.warn(f"No assets specified in {PROJECT_FILE}", exits=0)
     msg.info(f"Fetching {len(assets)} asset(s)")
     for asset in assets:
-        dest = Path(asset["dest"])
+        dest = project_dir / asset["dest"]
         checksum = asset.get("checksum")
-        if "git" in asset:
-            if dest.exists():
-                # If there's already a file, check for checksum
-                if checksum and checksum == get_checksum(dest):
-                    msg.good(f"Skipping download with matching checksum: {dest}")
-                    continue
-                else:
+        if dest.exists():
+            # If there's already a file, check for checksum
+            if checksum and checksum == get_checksum(dest):
+                msg.good(f"Skipping download with matching checksum: {dest}")
+                continue
+            else:
+                msg.good(f"Removing asset with outdated checksum: {dest} ")
+                if dest.is_dir():
                     shutil.rmtree(dest)
+                else:
+                    dest.unlink()
+        if "git" in asset:
             git_sparse_checkout(
                 asset["git"]["repo"],
                 asset["git"]["path"],
                 dest,
                 branch=asset["git"].get("branch"),
             )
-        else:
+        elif "url" in asset:
             url = asset.get("url")
             if not url:
                 # project.yml defines asset without URL that the user has to place
                 check_private_asset(dest, checksum)
                 continue
             fetch_asset(project_path, url, dest, checksum)
+        else:
+            msg.warn(f"Could not fetch asset {dest} as neither a 'git' or 'url' parameter is specified.")
 
 
 def check_private_asset(dest: Path, checksum: Optional[str] = None) -> None:
     """Check and validate assets without a URL (private assets that the user
     has to provide themselves) and give feedback about the checksum.
 
-    dest (Path): Desintation path of the asset.
+    dest (Path): Destination path of the asset.
     checksum (Optional[str]): Optional checksum of the expected file.
     """
+    print("path", dest)
     if not Path(dest).exists():
         err = f"No URL provided for asset. You need to add this file yourself: {dest}"
         msg.warn(err)


### PR DESCRIPTION
3 small bugfixes to projects: 

## Description
1. the git URL can have a trailing slash which needs to be removed in `_from_http_to_git`

2. `shutil.rmtree(dest)` doesn't work if `dest` is a file

3. If you clone from your main projects dir `C:\projects`, the message says something like
```
To fetch the assets, run:
python -m spacy project assets C:\projects\tutorials\ner_fashion_brands
``` 
but if you run that exact command, it wouldn't work because the assets are fetching relatively to the (expected) working dir. So prefixing that to always work with a full path. Hope that doesn't break anything in relation to PR #6048.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
