### PR TITLE
Support "list" pipeline argument

### DIFF
--- a/spacy/cli/_util.py
+++ b/spacy/cli/_util.py
@@ -336,10 +336,12 @@ def git_sparse_checkout(repo: str, subpath: str, dest: Path, *, branch: str = "m
         # Now pass those missings into another bit of git internals
         missings = " ".join([x[1:] for x in ret.stdout.split() if x.startswith("?")])
         if not missings:
-           err = f"Could not find any relevant files for '{subpath}'. " \
-                 f"Did you specify a correct and complete path within repo '{repo}' " \
-                 f"and branch {branch}?"
-           msg.fail(err, exits=1)
+            err = (
+                f"Could not find any relevant files for '{subpath}'. "
+                f"Did you specify a correct and complete path within repo '{repo}' "
+                f"and branch {branch}?"
+            )
+            msg.fail(err, exits=1)
         cmd = f"git -C {tmp_dir} fetch-pack {git_repo} {missings}"
         _attempt_run_command(cmd)
         # And finally, we can checkout our subpath
@@ -348,12 +350,14 @@ def git_sparse_checkout(repo: str, subpath: str, dest: Path, *, branch: str = "m
         # We need Path(name) to make sure we also support subdirectories
         shutil.move(str(tmp_dir / Path(subpath)), str(dest))
 
+
 def _attempt_run_command(cmd):
     try:
         return run_command(cmd, capture=True)
     except subprocess.CalledProcessError as e:
         err = f"Could not run command: {cmd}."
         msg.fail(err, exits=1)
+
 
 def _from_http_to_git(repo):
     if repo.startswith("http://"):
@@ -364,3 +368,23 @@ def _from_http_to_git(repo):
             repo = repo[:-1]
         repo = f"{repo}.git"
     return repo
+
+
+def string_to_list(value, intify=False):
+    """Parse a comma-separated string to a list"""
+    if not value:
+        return []
+    if value.startswith("[") and value.endswith("]"):
+        value = value[1:-1]
+    result = []
+    for p in value.split(","):
+        p = p.strip()
+        if p.startswith("'") and p.endswith("'"):
+            p = p[1:-1]
+        if p.startswith('"') and p.endswith('"'):
+            p = p[1:-1]
+        p = p.strip()
+        if intify:
+            p = int(p)
+        result.append(p)
+    return result

--- a/spacy/cli/debug_model.py
+++ b/spacy/cli/debug_model.py
@@ -5,7 +5,7 @@ from thinc.api import require_gpu, fix_random_seed, set_dropout_rate, Adam
 from thinc.api import Model, data_validation
 import typer
 
-from ._util import Arg, Opt, debug_cli, show_validation_error, parse_config_overrides
+from ._util import Arg, Opt, debug_cli, show_validation_error, parse_config_overrides, string_to_list
 from .. import util
 
 
@@ -38,12 +38,13 @@ def debug_model_cli(
         require_gpu(use_gpu)
     else:
         msg.info("Using CPU")
+    layers = string_to_list(layers, intify=True)
     print_settings = {
         "dimensions": dimensions,
         "parameters": parameters,
         "gradients": gradients,
         "attributes": attributes,
-        "layers": [int(x.strip()) for x in layers.split(",")] if layers else [],
+        "layers": layers,
         "print_before_training": P0,
         "print_after_init": P1,
         "print_after_training": P2,

--- a/spacy/cli/init_config.py
+++ b/spacy/cli/init_config.py
@@ -42,6 +42,8 @@ def init_config_cli(
     """
     if isinstance(optimize, Optimizations):  # instance of enum from the CLI
         optimize = optimize.value
+    if pipeline.startswith("[") and pipeline.endswith("]"):
+        pipeline = pipeline[1:-1]
     pipeline = [p.strip() for p in pipeline.split(",")]
     init_config(output_file, lang=lang, pipeline=pipeline, optimize=optimize, cpu=cpu)
 

--- a/spacy/cli/init_config.py
+++ b/spacy/cli/init_config.py
@@ -9,7 +9,7 @@ import re
 from .. import util
 from ..language import DEFAULT_CONFIG_PRETRAIN_PATH
 from ..schemas import RecommendationSchema
-from ._util import init_cli, Arg, Opt, show_validation_error, COMMAND
+from ._util import init_cli, Arg, Opt, show_validation_error, COMMAND, string_to_list
 
 
 ROOT = Path(__file__).parent / "templates"
@@ -42,9 +42,7 @@ def init_config_cli(
     """
     if isinstance(optimize, Optimizations):  # instance of enum from the CLI
         optimize = optimize.value
-    if pipeline.startswith("[") and pipeline.endswith("]"):
-        pipeline = pipeline[1:-1]
-    pipeline = [p.strip() for p in pipeline.split(",")]
+    pipeline = string_to_list(pipeline)
     init_config(output_file, lang=lang, pipeline=pipeline, optimize=optimize, cpu=cpu)
 
 


### PR DESCRIPTION
## Description
The `pipeline` argument for `init config` should be a comma-seperated list like `-p "tagger, textcat"`. However, I think it is likely for people to try to write `-p "[textcat]"` (as in the config). So we may as well support this, because it gives an ugly error downstream otherwise. With this edit, we even support people writing something like `-p "["tagger", "textcat"]"`

### Types of change
enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
