### PR TITLE
prevent overwriting score_weights

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -243,7 +243,8 @@ class Language:
         self._config["nlp"]["pipeline"] = list(self.component_names)
         self._config["nlp"]["disabled"] = list(self.disabled)
         self._config["components"] = pipeline
-        self._config["training"]["score_weights"] = combine_score_weights(score_weights)
+        if not self._config["training"].get("score_weights"):
+            self._config["training"]["score_weights"] = combine_score_weights(score_weights)
         if not srsly.is_json_serializable(self._config):
             raise ValueError(Errors.E961.format(config=self._config))
         return self._config


### PR DESCRIPTION

## Description
The `score_weights` in the training's config was getting overwritten bij the `Language` class. Suppose your config would have 
```
[training.score_weights]
cats_macro_p = 0.0 
cats_macro_r = 0.0
cats_macro_f = 1.0
```
then this would get overwritten (due to the defaults) by `cats_score = 1.0`, and the console logger would only show the `cat_score` instead of the scores from the config.

I think adding this conditional is sufficient?

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
