### PR TITLE
Fix tagger training when some tags are missing

### DIFF
--- a/spacy/pipeline/senter.pyx
+++ b/spacy/pipeline/senter.pyx
@@ -3,6 +3,7 @@ from itertools import islice
 
 import srsly
 from thinc.api import Model, SequenceCategoricalCrossentropy, Config
+from thinc.api import set_dropout_rate
 
 from ..tokens.doc cimport Doc
 

--- a/spacy/pipeline/tagger.pyx
+++ b/spacy/pipeline/tagger.pyx
@@ -255,7 +255,7 @@ class Tagger(Pipe):
         """
         validate_examples(examples, "Tagger.get_loss")
         loss_func = SequenceCategoricalCrossentropy(
-            names=self.label,
+            names=self.labels,
             normalize=False,
             missing_value=""
         )


### PR DESCRIPTION
Needed to specify that the missing value is `""`, or the loss function raises an error (it expects `None` by default).

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
