### PR TITLE
Fix unit test with ExceptionInfo

### DIFF
--- a/spacy/tests/test_language.py
+++ b/spacy/tests/test_language.py
@@ -298,4 +298,4 @@ def test_language_init_invalid_vocab(value):
     err_fragment = "invalid value"
     with pytest.raises(ValueError) as e:
         Language(value)
-    assert err_fragment in str(e)
+    assert err_fragment in str(e.value)


### PR DESCRIPTION


## Description
The new `test_language_init_invalid_vocab` fails for me locally (in Pycharm) as `str(e)` would be `<ExceptionInfo ValueError tblen=2>` instead of the expected string `"ValueError: [E918] Received invalid value for vocab..."`.
Rewriting it to explicitely check `e.value`, which is the original `ValueError`.

I have no clue why this fails locally and not on the CI, but I think this fix should be universal.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
