### PR TITLE
Temporary work-around for scoring a subset of components

### DIFF
--- a/spacy/about.py
+++ b/spacy/about.py
@@ -1,6 +1,6 @@
 # fmt: off
 __title__ = "spacy-nightly"
-__version__ = "3.0.0a19.dev0"
+__version__ = "3.0.0a19"
 __release__ = True
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"

--- a/spacy/about.py
+++ b/spacy/about.py
@@ -1,6 +1,6 @@
 # fmt: off
 __title__ = "spacy-nightly"
-__version__ = "3.0.0a19"
+__version__ = "3.0.0a19.dev0"
 __release__ = True
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"

--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -276,6 +276,7 @@ class Scorer:
             # really need this getter system?
             try:
                 getter(gold_doc, attr)
+                getter(pred_doc, attr)
             except ValueError:
                 continue
             # Find all labels in gold and doc

--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -275,8 +275,8 @@ class Scorer:
             # ValueError here. Or we need to make this less abstract. Do we
             # really need this getter system?
             try:
-                getter(gold_doc, attr)
-                getter(pred_doc, attr)
+                list(getter(gold_doc, attr))
+                list(getter(pred_doc, attr))
             except ValueError:
                 continue
             # Find all labels in gold and doc

--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -270,6 +270,14 @@ class Scorer:
         for example in examples:
             pred_doc = example.predicted
             gold_doc = example.reference
+            # This isn't great but we need to somehow check whether the gold
+            # doc doesn't have the annotation? We need a more precise error than
+            # ValueError here. Or we need to make this less abstract. Do we
+            # really need this getter system?
+            try:
+                getter(gold_doc, attr)
+            except ValueError:
+                continue
             # Find all labels in gold and doc
             labels = set(
                 [k.label_ for k in getter(gold_doc, attr)]

--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -270,13 +270,16 @@ class Scorer:
         for example in examples:
             pred_doc = example.predicted
             gold_doc = example.reference
-            # This isn't great but we need to somehow check whether the gold
-            # doc doesn't have the annotation? We need a more precise error than
-            # ValueError here. Or we need to make this less abstract. Do we
-            # really need this getter system?
+            # TODO
+            # This is a temporary hack to work around the problem that the scorer
+            # fails if you have examples that are not fully annotated for all
+            # the tasks in your pipeline. For instance, you might have a corpus
+            # of NER annotations that does not set sentence boundaries, but the
+            # pipeline includes a parser or senter, and then the score_weights
+            # are used to evaluate that component. When the scorer attempts
+            # to read the sentences from the gold document, it fails.
             try:
                 list(getter(gold_doc, attr))
-                list(getter(pred_doc, attr))
             except ValueError:
                 continue
             # Find all labels in gold and doc


### PR DESCRIPTION
A single document with reference annotations won't always have annotations for every component in the pipeline. For instance, you might have a senter or a parser in the pipeline, but the reference doc only has NER annotations. Or you might have a document that only has reference categories, but the pipeline includes a tagger.

Currently the `Language.evaluate()` method will fail in these situations, because it will attempt to evaluate every component in the pipeline. The scorer will then raise an error when it tries to access the missing value from the reference doc.

The temporary hack here is a `try/except`. It's not the right solution, but we need it to move forward with the nightly.