### PR TITLE
Allow config overrides from environment variables

### DIFF
--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -6,7 +6,7 @@ from spacy.schemas import ProjectConfigSchema, RecommendationSchema, validate
 from spacy.cli.init_config import init_config, RECOMMENDATIONS
 from spacy.cli._util import validate_project_commands, parse_config_overrides
 from spacy.cli._util import load_project_config, substitute_project_variables
-from spacy.cli._util import string_to_list, parse_config_env_overrides
+from spacy.cli._util import string_to_list, OVERRIDES_ENV_VAR
 from thinc.config import ConfigValidationError
 import srsly
 import os
@@ -342,15 +342,21 @@ def test_parse_config_overrides_invalid_2(args):
 
 
 def test_parse_cli_overrides():
-    prefix = "SPACY_CONFIG_"
-    dot = "__"
-    os.environ[f"{prefix}TRAINING{dot}BATCH_SIZE"] = "123"
-    os.environ[f"{prefix}FOO{dot}BAR{dot}BAZ"] = "hello"
-    os.environ[prefix] = "bad"
-    result = parse_config_env_overrides(prefix=prefix, dot=dot)
-    assert len(result) == 2
-    assert result["training.batch_size"] == 123
-    assert result["foo.bar.baz"] == "hello"
+    os.environ[OVERRIDES_ENV_VAR] = "--x.foo bar --x.bar=12 --x.baz false --y.foo=hello"
+    result = parse_config_overrides([])
+    assert len(result) == 4
+    assert result["x.foo"] == "bar"
+    assert result["x.bar"] == 12
+    assert result["x.baz"] is False
+    assert result["y.foo"] == "hello"
+    os.environ[OVERRIDES_ENV_VAR] = "--x"
+    assert parse_config_overrides([], env_var=None) == {}
+    with pytest.raises(SystemExit):
+        parse_config_overrides([])
+    os.environ[OVERRIDES_ENV_VAR] = "hello world"
+    with pytest.raises(SystemExit):
+        parse_config_overrides([])
+    del os.environ[OVERRIDES_ENV_VAR]
 
 
 @pytest.mark.parametrize("lang", ["en", "nl"])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- Env variables take precedence over CLI overrides (and values defined in the config).
- Allows overriding config from the `project` CLI.
- Will hopefully make it easier for us to set up automated CI tests for the project templates because we can force-override the number of epochs/steps and actually train.

The `SPACY_CONFIG_OVERRIDES` env variable can be set to a string and currently support the same format as the CLI, e.g.: `SPACY_CONFIG_OVERRIDES="--training.batch_size 128 --paths.train=/some_path"`. This way, we can re-use a lot of the parsing logic we already have (and you'll be able to easily copy-paste your overrides around without having to modify them).


### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
