### PR TITLE
Make project pull order insensitive

### DIFF
--- a/spacy/cli/project/pull.py
+++ b/spacy/cli/project/pull.py
@@ -27,19 +27,32 @@ def project_pull_cli(
 
 
 def project_pull(project_dir: Path, remote: str, *, verbose: bool = False):
+    # TODO: We don't have tests for this :(. It would take a bit of mockery to
+    # set up. I guess see if it breaks first?
     config = load_project_config(project_dir)
     if remote in config.get("remotes", {}):
         remote = config["remotes"][remote]
     storage = RemoteStorage(project_dir, remote)
-    for cmd in config.get("commands", []):
-        deps = [project_dir / dep for dep in cmd.get("deps", [])]
-        if any(not dep.exists() for dep in deps):
-            continue
-        cmd_hash = get_command_hash("", "", deps, cmd["script"])
-        for output_path in cmd.get("outputs", []):
-            url = storage.pull(output_path, command_hash=cmd_hash)
-            yield url, output_path
+    commands = list(config.get("commands", []))
+    # We use a while loop here because we don't know how the commands
+    # will be ordered. A command might need dependencies from one that's later
+    # in the list.
+    while commands:
+        for i, cmd in enumerate(list(commands)):
+            deps = [project_dir / dep for dep in cmd.get("deps", [])]
+            if all(dep.exists() for dep in deps):
+                cmd_hash = get_command_hash("", "", deps, cmd["script"])
+                for output_path in cmd.get("outputs", []):
+                    url = storage.pull(output_path, command_hash=cmd_hash)
+                    yield url, output_path
 
-        out_locs = [project_dir / out for out in cmd.get("outputs", [])]
-        if all(loc.exists() for loc in out_locs):
-            update_lockfile(project_dir, cmd)
+                out_locs = [project_dir / out for out in cmd.get("outputs", [])]
+                if all(loc.exists() for loc in out_locs):
+                    update_lockfile(project_dir, cmd)
+                # We remove the command from the list here, and break, so that
+                # we iterate over the loop again.
+                commands.remove(i)
+                break
+        else:
+            # If we didn't break the for loop, break the while loop.
+            break


### PR DESCRIPTION
`spacy project pull` was simply going through the commands in the order they're defined in the file, which means if you put an earlier-running command lower down, your pulls wouldn't work. In short examples it feels natural that of course, the earlier thing is earlier in the file. But when you add stuff over time, or have a template, you can easily just not have them in order. This already bit me when training the models, so I figured I'd better fix it.

The "fancy" approach to this sort of thing is to define the input/output dependencies as a graph, and then do a topological sort. I'm using a while loop because it gets the same result and the code is much clearer (imo). What I'm doing would even work if we wanted to download the things in parallel...In that case we would just use a thread or an async library to do the work, the outer loop would be the same. Maybe worth remembering if we want to support parallelism in `spacy project run`.

- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
