### PR TITLE
updates to NEL functionality

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -507,8 +507,8 @@ class Errors:
             "instead.")
     E927 = ("Can't write to frozen list Maybe you're trying to modify a computed "
             "property or default function argument?")
-    E928 = ("A 'KnowledgeBase' should be written to / read from a file, but the "
-            "provided argument {loc} is an existing directory.")
+    E928 = ("A 'KnowledgeBase' can only be serialized to/from from a directory, "
+            "but the provided argument {loc} points to a file.")
     E929 = ("A 'KnowledgeBase' could not be read from {loc} - the path does "
             "not seem to exist.")
     E930 = ("Received invalid get_examples callback in {name}.begin_training. "

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -209,12 +209,11 @@ class EntityLinker(Pipe):
             # it does run the model twice :(
             predictions = self.model.predict(docs)
         for eg in examples:
-            sentences = [s for s in eg.predicted.sents]
+            sentences = [s for s in eg.reference.sents]
             kb_ids = eg.get_aligned("ENT_KB_ID", as_string=True)
-            for ent in eg.predicted.ents:
-                kb_id = kb_ids[
-                    ent.start
-                ]  # KB ID of the first token is the same as the whole span
+            for ent in eg.reference.ents:
+                # KB ID of the first token is the same as the whole span
+                kb_id = kb_ids[ent.start]
                 if kb_id:
                     try:
                         # find the sentence in the list of sentences.
@@ -253,7 +252,7 @@ class EntityLinker(Pipe):
         entity_encodings = []
         for eg in examples:
             kb_ids = eg.get_aligned("ENT_KB_ID", as_string=True)
-            for ent in eg.predicted.ents:
+            for ent in eg.reference.ents:
                 kb_id = kb_ids[ent.start]
                 if kb_id:
                     entity_encoding = self.kb.get_vector(kb_id)

--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -1,4 +1,4 @@
-from typing import Optional, Iterable, Dict, Any, Callable, TYPE_CHECKING, List
+from typing import Optional, Iterable, Dict, Any, Callable, TYPE_CHECKING
 import numpy as np
 
 from .training import Example
@@ -453,17 +453,15 @@ class Scorer:
 
     @staticmethod
     def score_links(
-        examples: Iterable[Example],
-        *,
-        negative_labels: List[str],
+        examples: Iterable[Example], *, negative_labels: Iterable[str]
     ) -> Dict[str, Any]:
-        """Returns PRF and ROC AUC scores for a span-level attribute with a
-        string value like Span.kb_id_. The reported overall
-        score depends on the scorer settings.
+        """Returns PRF for predicted links on the entity level.
+        To disentangle the performance of the NEL from the NER,
+        this method only evaluates NEL links for entities that overlap
+        between the gold reference and the predictions.
 
         examples (Iterable[Example]): Examples to score
-        attr (str): The label attribute to score.
-        labels (Iterable[str]): The set of span labels to evaluate on.
+        negative_labels (Iterable[str]): The string values that refer to no annotation (e.g. "NIL")
         RETURNS (Dict[str, Any]): A dictionary containing the scores.
 
         DOCS (TODO): https://nightly.spacy.io/api/scorer#score_links

--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -1,4 +1,4 @@
-from typing import Optional, Iterable, Dict, Any, Callable, TYPE_CHECKING
+from typing import Optional, Iterable, Dict, Any, Callable, TYPE_CHECKING, List
 import numpy as np
 
 from .training import Example
@@ -240,7 +240,7 @@ class Scorer:
                             pred_per_feat[field].add((gold_i, feat))
             for field in per_feat:
                 per_feat[field].score_set(
-                    pred_per_feat.get(field, set()), gold_per_feat.get(field, set()),
+                    pred_per_feat.get(field, set()), gold_per_feat.get(field, set())
                 )
         result = {k: v.to_dict() for k, v in per_feat.items()}
         return {f"{attr}_per_feat": result}
@@ -449,6 +449,76 @@ class Scorer:
         else:
             results[f"{attr}_score"] = results[f"{attr}_macro_auc"]
             results[f"{attr}_score_desc"] = "macro AUC"
+        return results
+
+    @staticmethod
+    def score_links(
+        examples: Iterable[Example],
+        *,
+        negative_labels: List[str],
+    ) -> Dict[str, Any]:
+        """Returns PRF and ROC AUC scores for a span-level attribute with a
+        string value like Span.kb_id_. The reported overall
+        score depends on the scorer settings.
+
+        examples (Iterable[Example]): Examples to score
+        attr (str): The label attribute to score.
+        labels (Iterable[str]): The set of span labels to evaluate on.
+        RETURNS (Dict[str, Any]): A dictionary containing the scores.
+
+        DOCS (TODO): https://nightly.spacy.io/api/scorer#score_links
+        """
+        f_per_type = {}
+        for example in examples:
+            gold_ent_by_offset = {}
+            for gold_ent in example.reference.ents:
+                gold_ent_by_offset[(gold_ent.start_char, gold_ent.end_char)] = gold_ent
+
+            for pred_ent in example.predicted.ents:
+                gold_span = gold_ent_by_offset.get(
+                    (pred_ent.start_char, pred_ent.end_char), None
+                )
+                label = gold_span.label_
+                if not label in f_per_type:
+                    f_per_type[label] = PRFScore()
+                gold = gold_span.kb_id_
+                # only evaluating entities that overlap between gold and pred,
+                # to disentangle the performance of the NEL from the NER
+                if gold is not None:
+                    pred = pred_ent.kb_id_
+                    if gold in negative_labels and pred in negative_labels:
+                        # ignore true negatives
+                        pass
+                    elif gold == pred:
+                        f_per_type[label].tp += 1
+                    elif gold in negative_labels:
+                        f_per_type[label].fp += 1
+                    elif pred in negative_labels:
+                        f_per_type[label].fn += 1
+                    else:
+                        # a wrong prediction (e.g. Q42 != Q3) counts as both a FP as well as a FN
+                        f_per_type[label].fp += 1
+                        f_per_type[label].fn += 1
+        micro_prf = PRFScore()
+        for label_prf in f_per_type.values():
+            micro_prf.tp += label_prf.tp
+            micro_prf.fn += label_prf.fn
+            micro_prf.fp += label_prf.fp
+        n_labels = len(f_per_type) + 1e-100
+        macro_p = sum(prf.precision for prf in f_per_type.values()) / n_labels
+        macro_r = sum(prf.recall for prf in f_per_type.values()) / n_labels
+        macro_f = sum(prf.fscore for prf in f_per_type.values()) / n_labels
+        results = {
+            f"nel_score": micro_prf.fscore,
+            f"nel_score_desc": "micro F",
+            f"nel_micro_p": micro_prf.precision,
+            f"nel_micro_r": micro_prf.recall,
+            f"nel_micro_f": micro_prf.fscore,
+            f"nel_macro_p": macro_p,
+            f"nel_macro_r": macro_r,
+            f"nel_macro_f": macro_f,
+            f"nel_f_per_type": {k: v.to_dict() for k, v in f_per_type.items()},
+        }
         return results
 
     @staticmethod

--- a/spacy/tests/pipeline/test_entity_linker.py
+++ b/spacy/tests/pipeline/test_entity_linker.py
@@ -161,6 +161,7 @@ def test_kb_serialize(nlp):
             # can not read from an unknown file
             mykb.from_disk(d / "unknown" / "kb")
 
+
 def test_candidate_generation(nlp):
     """Test correct candidate generation"""
     mykb = KnowledgeBase(nlp.vocab, entity_vector_length=1)
@@ -258,7 +259,9 @@ def test_vocab_serialization(nlp):
     q3_hash = mykb.add_entity(entity="Q3", freq=5, entity_vector=[3])
 
     # adding aliases
-    douglas_hash = mykb.add_alias(alias="douglas", entities=["Q2", "Q3"], probabilities=[0.4, 0.1])
+    douglas_hash = mykb.add_alias(
+        alias="douglas", entities=["Q2", "Q3"], probabilities=[0.4, 0.1]
+    )
     adam_hash = mykb.add_alias(alias="adam", entities=["Q2"], probabilities=[0.9])
 
     candidates = mykb.get_alias_candidates("adam")
@@ -499,19 +502,32 @@ def test_overfitting_IO():
                 predictions.append(ent.kb_id_)
         assert predictions == GOLD_entities
 
+
 def test_scorer_links():
     train_examples = []
     nlp = English()
     ref1 = nlp("Julia lives in London happily.")
-    ref1.ents = [Span(ref1, 0, 1, label="PERSON", kb_id="Q2"), Span(ref1, 3, 4, label="LOC", kb_id="Q3")]
+    ref1.ents = [
+        Span(ref1, 0, 1, label="PERSON", kb_id="Q2"),
+        Span(ref1, 3, 4, label="LOC", kb_id="Q3"),
+    ]
     pred1 = nlp("Julia lives in London happily.")
-    pred1.ents = [Span(pred1, 0, 1, label="PERSON", kb_id="Q70"), Span(pred1, 3, 4, label="LOC", kb_id="Q3")]
+    pred1.ents = [
+        Span(pred1, 0, 1, label="PERSON", kb_id="Q70"),
+        Span(pred1, 3, 4, label="LOC", kb_id="Q3"),
+    ]
     train_examples.append(Example(pred1, ref1))
 
     ref2 = nlp("She loves London.")
-    ref2.ents = [Span(ref2, 0, 1, label="PERSON", kb_id="Q2"), Span(ref2, 2, 3, label="LOC", kb_id="Q13")]
+    ref2.ents = [
+        Span(ref2, 0, 1, label="PERSON", kb_id="Q2"),
+        Span(ref2, 2, 3, label="LOC", kb_id="Q13"),
+    ]
     pred2 = nlp("She loves London.")
-    pred2.ents = [Span(pred2, 0, 1, label="PERSON", kb_id="Q2"), Span(pred2, 2, 3, label="LOC", kb_id="NIL")]
+    pred2.ents = [
+        Span(pred2, 0, 1, label="PERSON", kb_id="Q2"),
+        Span(pred2, 2, 3, label="LOC", kb_id="NIL"),
+    ]
     train_examples.append(Example(pred2, ref2))
 
     ref3 = nlp("London is great.")
@@ -521,10 +537,10 @@ def test_scorer_links():
     train_examples.append(Example(pred3, ref3))
 
     scores = Scorer().score_links(train_examples, negative_labels=["NIL"])
-    assert scores["nel_f_per_type"]["PERSON"]["p"] == 1/2
-    assert scores["nel_f_per_type"]["PERSON"]["r"] == 1/2
-    assert scores["nel_f_per_type"]["LOC"]["p"] == 1/1
-    assert scores["nel_f_per_type"]["LOC"]["r"] == 1/2
+    assert scores["nel_f_per_type"]["PERSON"]["p"] == 1 / 2
+    assert scores["nel_f_per_type"]["PERSON"]["r"] == 1 / 2
+    assert scores["nel_f_per_type"]["LOC"]["p"] == 1 / 1
+    assert scores["nel_f_per_type"]["LOC"]["r"] == 1 / 2
 
-    assert scores["nel_micro_p"] == 2/3
-    assert scores["nel_micro_r"] == 2/4
+    assert scores["nel_micro_p"] == 2 / 3
+    assert scores["nel_micro_r"] == 2 / 4

--- a/spacy/tests/pipeline/test_entity_linker.py
+++ b/spacy/tests/pipeline/test_entity_linker.py
@@ -152,18 +152,10 @@ def test_kb_serialize(nlp):
         # normal read-write behaviour
         mykb.to_disk(d / "kb")
         mykb.from_disk(d / "kb")
-        mykb.to_disk(d / "kb.file")
-        mykb.from_disk(d / "kb.file")
         mykb.to_disk(d / "new" / "kb")
         mykb.from_disk(d / "new" / "kb")
         # allow overwriting an existing file
-        mykb.to_disk(d / "kb.file")
-        with pytest.raises(ValueError):
-            # can not write to a directory
-            mykb.to_disk(d)
-        with pytest.raises(ValueError):
-            # can not read from a directory
-            mykb.from_disk(d)
+        mykb.to_disk(d / "kb")
         with pytest.raises(ValueError):
             # can not read from an unknown file
             mykb.from_disk(d / "unknown" / "kb")
@@ -283,8 +275,9 @@ def test_vocab_serialization(nlp):
         candidates = kb_new_vocab.get_alias_candidates("adam")
         assert len(candidates) == 1
         assert candidates[0].entity == q2_hash
-        with pytest.raises(KeyError):
-            assert candidates[0].entity_ == "Q2"
+        assert candidates[0].entity_ == "Q2"
+        assert candidates[0].alias == adam_hash
+        assert candidates[0].alias_ == "adam"
 
 
 def test_append_alias(nlp):

--- a/spacy/tests/pipeline/test_entity_linker.py
+++ b/spacy/tests/pipeline/test_entity_linker.py
@@ -5,6 +5,7 @@ from spacy.kb import KnowledgeBase, get_candidates, Candidate
 from spacy.vocab import Vocab
 
 from spacy import util, registry
+from spacy.scorer import Scorer
 from spacy.training import Example
 from spacy.lang.en import English
 from spacy.tests.util import make_tempdir
@@ -497,3 +498,33 @@ def test_overfitting_IO():
             for ent in doc2.ents:
                 predictions.append(ent.kb_id_)
         assert predictions == GOLD_entities
+
+def test_scorer_links():
+    train_examples = []
+    nlp = English()
+    ref1 = nlp("Julia lives in London happily.")
+    ref1.ents = [Span(ref1, 0, 1, label="PERSON", kb_id="Q2"), Span(ref1, 3, 4, label="LOC", kb_id="Q3")]
+    pred1 = nlp("Julia lives in London happily.")
+    pred1.ents = [Span(pred1, 0, 1, label="PERSON", kb_id="Q70"), Span(pred1, 3, 4, label="LOC", kb_id="Q3")]
+    train_examples.append(Example(pred1, ref1))
+
+    ref2 = nlp("She loves London.")
+    ref2.ents = [Span(ref2, 0, 1, label="PERSON", kb_id="Q2"), Span(ref2, 2, 3, label="LOC", kb_id="Q13")]
+    pred2 = nlp("She loves London.")
+    pred2.ents = [Span(pred2, 0, 1, label="PERSON", kb_id="Q2"), Span(pred2, 2, 3, label="LOC", kb_id="NIL")]
+    train_examples.append(Example(pred2, ref2))
+
+    ref3 = nlp("London is great.")
+    ref3.ents = [Span(ref3, 0, 1, label="LOC", kb_id="NIL")]
+    pred3 = nlp("London is great.")
+    pred3.ents = [Span(pred3, 0, 1, label="LOC", kb_id="NIL")]
+    train_examples.append(Example(pred3, ref3))
+
+    scores = Scorer().score_links(train_examples, negative_labels=["NIL"])
+    assert scores["nel_f_per_type"]["PERSON"]["p"] == 1/2
+    assert scores["nel_f_per_type"]["PERSON"]["r"] == 1/2
+    assert scores["nel_f_per_type"]["LOC"]["p"] == 1/1
+    assert scores["nel_f_per_type"]["LOC"]["r"] == 1/2
+
+    assert scores["nel_micro_p"] == 2/3
+    assert scores["nel_micro_r"] == 2/4

--- a/spacy/tests/training/test_new_example.py
+++ b/spacy/tests/training/test_new_example.py
@@ -244,3 +244,22 @@ def test_Example_from_dict_with_links_invalid(annots):
     predicted = Doc(vocab, words=annots["words"])
     with pytest.raises(ValueError):
         Example.from_dict(predicted, annots)
+
+
+def test_Example_from_dict_sentences():
+    vocab = Vocab()
+    predicted = Doc(vocab, words=["One", "sentence", ".", "one", "more"])
+    annots = {"sent_starts": [1, 0, 0, 1, 0]}
+    ex = Example.from_dict(predicted, annots)
+    assert len(list(ex.reference.sents)) == 2
+
+    # this currently throws an error - bug or feature?
+    # predicted = Doc(vocab, words=["One", "sentence", "not", "one", "more"])
+    # annots = {"sent_starts": [1, 0, 0, 0, 0]}
+    # ex = Example.from_dict(predicted, annots)
+    # assert len(list(ex.reference.sents)) == 1
+
+    predicted = Doc(vocab, words=["One", "sentence", "not", "one", "more"])
+    annots = {"sent_starts": [1, -1, 0, 0, 0]}
+    ex = Example.from_dict(predicted, annots)
+    assert len(list(ex.reference.sents)) == 1

--- a/website/docs/api/entitylinker.md
+++ b/website/docs/api/entitylinker.md
@@ -225,6 +225,21 @@ pipe's entity linking model and context encoder. Delegates to
 | `losses`          | Optional record of the loss during training. Updated using the component name as the key. ~~Optional[Dict[str, float]]~~           |
 | **RETURNS**       | The updated `losses` dictionary. ~~Dict[str, float]~~                                                                              |
 
+## EntityLinker.score {#score tag="method" new="3"}
+
+Score a batch of examples.
+
+> #### Example
+>
+> ```python
+> scores = entity_linker.score(examples)
+> ```
+
+| Name        | Description                                                                                    |
+| ----------- | ---------------------------------------------------------------------------------------------- |
+| `examples`  | The examples to score. ~~Iterable[Example]~~                                                   |
+| **RETURNS** | The scores, produced by [`Scorer.score_links`](/api/scorer#score_links) . ~~Dict[str, float]~~ |
+
 ## EntityLinker.create_optimizer {#create_optimizer tag="method"}
 
 Create an optimizer for the pipeline component.

--- a/website/docs/api/scorer.md
+++ b/website/docs/api/scorer.md
@@ -206,3 +206,26 @@ depends on the scorer settings:
 | `multi_label`    | Whether the attribute allows multiple labels. Defaults to `True`. ~~bool~~                                                                         |
 | `positive_label` | The positive label for a binary task with exclusive classes. Defaults to `None`. ~~Optional[str]~~                                                 |
 | **RETURNS**      | A dictionary containing the scores, with inapplicable scores as `None`. ~~Dict[str, Optional[float]]~~                                             |
+
+## Scorer.score_links {#score_links tag="staticmethod" new="3"}
+
+Returns PRF for predicted links on the entity level. To disentangle the
+performance of the NEL from the NER, this method only evaluates NEL links for
+entities that overlap between the gold reference and the predictions.
+
+> #### Example
+>
+> ```python
+> scores = Scorer.score_links(
+>     examples,
+>     negative_labels=["NIL", ""]
+> )
+> print(scores["nel_micro_f"])
+> ```
+
+| Name              | Description                                                                                                         |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `examples`        | The `Example` objects holding both the predictions and the correct gold-standard annotations. ~~Iterable[Example]~~ |
+| _keyword-only_    |                                                                                                                     |
+| `negative_labels` | The string values that refer to no annotation (e.g. "NIL"). ~~Iterable[str]~~                                       |
+| **RETURNS**       | A dictionary containing the scores. ~~Dict[str, Optional[float]]~~                                                  |


### PR DESCRIPTION
## Description
Updates & bug fixes to NEL functionality:
- `entity_linker.update` now relies on gold sentences and entities, to allow training an NEL in isolation
- implemented scoring for NEL that works together with the train CLI
- write KB to directory instead of file, and include `strings.json` that will be added to the new `vocab` when the KB is loaded back in. 

### Types of change
bug fix & enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
