### PR TITLE
Fix skipped documents in entity scorer

### DIFF
--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -28,6 +28,7 @@ class PRFScore:
         self.tp += other.tp
         self.fp += other.fp
         self.fn += other.fn
+        return self
 
     def __add__(self, other):
         return PRFScore(
@@ -642,15 +643,15 @@ def get_ner_prf(examples: Iterable[Example]) -> Dict[str, PRFScore]:
                 scores[pred_ent.label_] = PRFScore()
             indices = align_x2y[pred_ent.start : pred_ent.end].dataXd.ravel()
             if len(indices):
-                g_span = eg.y[indices[0] : indices[-1]]
+                g_span = eg.y[indices[0] : indices[-1] + 1]
                 # Check we aren't missing annotation on this span. If so,
                 # our prediction is neither right nor wrong, we just
                 # ignore it.
                 if all(token.ent_iob != 0 for token in g_span):
-                    key = (pred_ent.label_, indices[0], indices[-1])
+                    key = (pred_ent.label_, indices[0], indices[-1] + 1)
                     if key in golds:
                         scores[pred_ent.label_].tp += 1
-                        golds.pop(span)
+                        golds.remove(key)
                     else:
                         scores[pred_ent.label_].fp += 1
         for label, start, end in golds:

--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -308,7 +308,7 @@ class Scorer:
                     # Check we aren't missing annotation on this span. If so,
                     # our prediction is neither right nor wrong, we just
                     # ignore it.
-                    if any(token.ent_iob == 0 for token in g_span):
+                    if all(token.ent_iob != 0 for token in g_span):
                         span = (pred_span.label_, indices[0], indices[-1])
                         pred_spans.add(span)
                         pred_per_type[pred_span.label_].add(span)

--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -1,5 +1,6 @@
 from typing import Optional, Iterable, Dict, Any, Callable, TYPE_CHECKING
 import numpy as np
+from collections import defaultdict
 
 from .training import Example
 from .tokens import Token, Doc, Span

--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -630,15 +630,15 @@ def get_ner_prf(examples: Iterable[Example]) -> Dict[str, PRFScore]:
     for eg in examples:
         if not eg.y.has_annotation("ENT_IOB"):
             continue
-        golds = {(e.label_, e.start, e.end) for e in example.y.ents}
-        align_x2y = example.alignment.x2y
+        golds = {(e.label_, e.start, e.end) for e in eg.y.ents}
+        align_x2y = eg.alignment.x2y
         preds = set()
-        for pred_ent in example.x.ents:
+        for pred_ent in eg.x.ents:
             if pred_ent.label_ not in scores:
                 scores[pred_ent.label_] = PRFScore()
             indices = align_x2y[pred_ent.start : pred_ent.end].dataXd.ravel()
             if len(indices):
-                g_span = example.y[indices[0] : indices[-1]]
+                g_span = eg.y[indices[0] : indices[-1]]
                 # Check we aren't missing annotation on this span. If so,
                 # our prediction is neither right nor wrong, we just
                 # ignore it.

--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -626,6 +626,10 @@ class Scorer:
 
 
 def get_ner_prf(examples: Iterable[Example]) -> Dict[str, PRFScore]:
+    """Compute per-entity PRFScore objects for a sequence of examples. The
+    results are returned as a dictionary keyed by the entity type. You can
+    add the PRFScore objects to get micro-averaged total.
+    """
     scores = defaultdict(PRFScore)
     for eg in examples:
         if not eg.y.has_annotation("ENT_IOB"):

--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -304,9 +304,14 @@ class Scorer:
             for pred_span in getter(pred_doc, attr):
                 indices = align_x2y[pred_span.start : pred_span.end].dataXd.ravel()
                 if len(indices):
-                    span = (pred_span.label_, indices[0], indices[-1])
-                    pred_spans.add(span)
-                    pred_per_type[pred_span.label_].add(span)
+                    g_span = gold_doc[indices[0] : indices[-1]]
+                    # Check we aren't missing annotation on this span. If so,
+                    # our prediction is neither right nor wrong, we just
+                    # ignore it.
+                    if any(token.ent_iob == 0 for token in g_span):
+                        span = (pred_span.label_, indices[0], indices[-1])
+                        pred_spans.add(span)
+                        pred_per_type[pred_span.label_].add(span)
             # Scores per label
             for k, v in score_per_type.items():
                 if k in pred_per_type:


### PR DESCRIPTION
In our OntoNotes evaluation, we're working off documents that have some sentences that don't have NER annotations, because we've merged the annotations from the parse and name sections of the corpus onto one doc, so that we can train them together. The missing annotations are tricky to deal with during scoring.

Previously we were skipping documents that had missing data for the NER. This is fine when comparing spaCy models to other spaCy models, as they're all running over the same test set, but it means our test was slightly different from what other people were running, which makes it a bit harder to directly compare against other people's OntoNotes numbers. Our comparison is already a bit indirect anyway, because we do the task "whole document" without the sentence boundaries. But still, it's good to get this fixed, especially now that our alignment API is easier to work with.

After the fix, our NER scores for the CNN go down by about 0.5 on the OntoNotes 5 evaluation.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
