### PR TITLE
Make a pre-check to speed up alignment cache

### DIFF
--- a/spacy/training/example.pxd
+++ b/spacy/training/example.pxd
@@ -1,5 +1,5 @@
 from ..tokens.doc cimport Doc
-from murmurhash.mrmr cimport hash_t
+from libc.stdint cimport uint64_t
 
 
 cdef class Example:
@@ -8,5 +8,5 @@ cdef class Example:
     cdef readonly object _cached_alignment
     cdef readonly object _cached_words_x
     cdef readonly object _cached_words_y
-    cdef readonly hash_t _x_sig
-    cdef readonly hash_t _y_sig
+    cdef readonly uint64_t _x_sig
+    cdef readonly uint64_t _y_sig

--- a/spacy/training/example.pxd
+++ b/spacy/training/example.pxd
@@ -7,3 +7,5 @@ cdef class Example:
     cdef readonly object _cached_alignment
     cdef readonly object _cached_words_x
     cdef readonly object _cached_words_y
+    cdef readonly int _cached_mem_size_x
+    cdef readonly int _cached_mem_size_y

--- a/spacy/training/example.pxd
+++ b/spacy/training/example.pxd
@@ -1,4 +1,5 @@
 from ..tokens.doc cimport Doc
+from murmurhash.mrmr cimport hash_t
 
 
 cdef class Example:
@@ -7,5 +8,5 @@ cdef class Example:
     cdef readonly object _cached_alignment
     cdef readonly object _cached_words_x
     cdef readonly object _cached_words_y
-    cdef readonly int _cached_mem_size_x
-    cdef readonly int _cached_mem_size_y
+    cdef readonly hash_t _x_sig
+    cdef readonly hash_t _y_sig

--- a/spacy/training/example.pyx
+++ b/spacy/training/example.pyx
@@ -98,8 +98,8 @@ cdef class Example:
 
     @property
     def alignment(self):
-        x_sig = hash64(doc.c, sizeof(self.x.c[0]) * self.x.length, 0)
-        y_sig = hash64(doc.c, sizeof(self.y.c[0]) * self.y.length, 0)
+        x_sig = hash64(self.x.c, sizeof(self.x.c[0]) * self.x.length, 0)
+        y_sig = hash64(self.y.c, sizeof(self.y.c[0]) * self.y.length, 0)
         if (
             self._cached_alignment is not None
             and self._x_sig == x_sig

--- a/spacy/training/example.pyx
+++ b/spacy/training/example.pyx
@@ -100,11 +100,16 @@ cdef class Example:
     def alignment(self):
         x_sig = hash64(self.x.c, sizeof(self.x.c[0]) * self.x.length, 0)
         y_sig = hash64(self.y.c, sizeof(self.y.c[0]) * self.y.length, 0)
-        if (
-            self._cached_alignment is not None
-            and self._x_sig == x_sig
-            and self._y_sig == y_sig
-        ):
+        if self._cached_alignment is None:
+            words_x = [token.text for token in self.x]
+            words_y = [token.text for token in self.y]
+            self._x_sig = x_sig
+            self._y_sig = y_sig
+            self._cached_words_x = words_x
+            self._cached_words_y = words_y
+            self._cached_alignment = Alignment.from_strings(words_x, words_y)
+            return self._cached_alignment
+        elif self._x_sig == x_sig and self._y_sig == y_sig:
             # If we have a cached alignment, check whether the cache is invalid
             # due to retokenization. To make this check fast in loops, we first
             # check a hash of the TokenC arrays.


### PR DESCRIPTION
The `Example.alignment` property has grown an extra check to make sure the cached alignment is still valid. However, this check means that using the `alignment` property in a loop is now problematic.

I've added a preliminary check that hashes the `TokenC` contents. There shouldn't be a way this check could match falsely, but it could fail to match at times when the alignment hasn't changed. We therefore fall back to the text check, and update the hashes if necessary.

- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
