### PR TITLE
Ordinal numbers for Turkish

### DIFF
--- a/spacy/lang/tr/lex_attrs.py
+++ b/spacy/lang/tr/lex_attrs.py
@@ -35,6 +35,36 @@ _num_words = [
 ]
 
 
+_ordinal_words = [
+    "birinci",
+    "ikinci"
+    "üçüncü",
+    "dördüncü",
+    "beşinci",
+    "altıncı",
+    "yedinci",
+    "sekizinci",
+    "dokuzuncu",
+    "onuncu",
+    "yirminci",
+    "otuzuncu",
+    "kırkıncı",
+    "ellinci",
+    "altmışıncı",
+    "yetmişinci",
+    "sekseninci",
+    "doksanıncı",
+    "yüzüncü",
+    "bininci",
+    "mliyonuncu",
+    "milyarıncı",
+    "trilyonuncu",
+    "katrilyonuncu",
+    "kentilyonuncu",
+]
+
+_ordinal_endings = ("inci", "ıncı", "nci", "ncı", "uncu", "üncü")
+
 def like_num(text):
     if text.startswith(("+", "-", "±", "~")):
         text = text[1:]
@@ -45,8 +75,20 @@ def like_num(text):
         num, denom = text.split("/")
         if num.isdigit() and denom.isdigit():
             return True
-    if text.lower() in _num_words:
+
+    text_lower = text.lower()
+
+    #Check cardinal number
+    if text_lower in _num_words:
         return True
+
+    #Check ordinal number
+    if text_lower in _ordinal_words:
+        return True
+    if text_lower.endswith(_ordinal_endings):
+        if text_lower[:-3].isdigit() or text_lower[:-4].isdigit():
+            return True
+
     return False
 
 

--- a/spacy/lang/tr/lex_attrs.py
+++ b/spacy/lang/tr/lex_attrs.py
@@ -37,7 +37,7 @@ _num_words = [
 
 _ordinal_words = [
     "birinci",
-    "ikinci"
+    "ikinci",
     "üçüncü",
     "dördüncü",
     "beşinci",

--- a/spacy/tests/lang/tr/test_text.py
+++ b/spacy/tests/lang/tr/test_text.py
@@ -1,0 +1,32 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import pytest
+from spacy.lang.tr.lex_attrs import like_num
+
+
+@pytest.mark.parametrize(
+    "word",
+    [
+        "bir",
+        "iki",
+        "dört",
+        "altı",
+        "milyon",
+        "100",
+        "birinci",
+        "üçüncü",
+        "beşinci",
+        "100üncü",
+        "8inci"
+    ]
+)
+def test_tr_lex_attrs_like_number_cardinal_ordinal(word):
+    assert like_num(word)
+
+
+@pytest.mark.parametrize("word", ["beş", "yedi", "yedinci", "birinci"])
+def test_tr_lex_attrs_capitals(word):
+    assert like_num(word)
+    assert like_num(word.upper())
+


### PR DESCRIPTION
## Minor Addition to ordinal Numbers 
Minor addition to `is_num`  lexical attributes, I added ordinal words and ordinal endings. 

### Types of change

- Minor addition to `lex_attrs`
- corresponding unittest
- doc not needed, minor change.

## Checklist
- [ x] I have submitted the spaCy Contributor Agreement.
- [ x] I ran the tests, and all new and existing tests passed.
- [x ] My changes don't require a change to the documentation, or if they do, I've added all required information.
