### PR TITLE
Improve CLI config validation with latest Thinc 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     "cymem>=2.0.2,<2.1.0",
     "preshed>=3.0.2,<3.1.0",
     "murmurhash>=0.28.0,<1.1.0",
-    "thinc>=8.0.0a35,<8.0.0a40",
+    "thinc>=8.0.0a36,<8.0.0a40",
     "blis>=0.4.0,<0.5.0",
     "pytokenizations",
     "pathy"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Our libraries
 cymem>=2.0.2,<2.1.0
 preshed>=3.0.2,<3.1.0
-thinc>=8.0.0a35,<8.0.0a40
+thinc>=8.0.0a36,<8.0.0a40
 blis>=0.4.0,<0.5.0
 ml_datasets==0.2.0a0
 murmurhash>=0.28.0,<1.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,13 +34,13 @@ setup_requires =
     cymem>=2.0.2,<2.1.0
     preshed>=3.0.2,<3.1.0
     murmurhash>=0.28.0,<1.1.0
-    thinc>=8.0.0a35,<8.0.0a40
+    thinc>=8.0.0a36,<8.0.0a40
 install_requires =
     # Our libraries
     murmurhash>=0.28.0,<1.1.0
     cymem>=2.0.2,<2.1.0
     preshed>=3.0.2,<3.1.0
-    thinc>=8.0.0a35,<8.0.0a40
+    thinc>=8.0.0a36,<8.0.0a40
     blis>=0.4.0,<0.5.0
     wasabi>=0.8.0,<1.1.0
     srsly>=2.1.0,<3.0.0

--- a/spacy/cli/debug_config.py
+++ b/spacy/cli/debug_config.py
@@ -1,8 +1,8 @@
 from typing import Optional, Dict, Any, Union, List
 from pathlib import Path
 from wasabi import msg, table
-from thinc.api import Config
-from thinc.config import VARIABLE_RE, ConfigValidationError
+from thinc.api import Config, ConfigValidationError
+from thinc.config import VARIABLE_RE
 import typer
 
 from ._util import Arg, Opt, show_validation_error, parse_config_overrides
@@ -115,4 +115,4 @@ def check_section_refs(config: Config, fields: List[str]) -> None:
             msg = f"not a valid section reference: {value}"
             errors.append({"loc": field.split("."), "msg": msg})
     if errors:
-        raise ConfigValidationError(config, errors)
+        raise ConfigValidationError(config=config, errors=errors)

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -89,7 +89,7 @@ def train(
         nlp, config = util.load_model_from_config(config)
     util.load_vocab_data_into_model(nlp, lookups=config["training"]["lookups"])
     if config["training"]["vectors"] is not None:
-        util.load_vectors_into_model(nlp, config["training"]["vectors"])
+        add_vectors(nlp, config["training"]["vectors"])
     raw_text, tag_map, morph_rules, weights_data = load_from_paths(config)
     T_cfg = config["training"]
     optimizer = T_cfg["optimizer"]
@@ -193,6 +193,19 @@ def train(
             else:
                 nlp.to_disk(final_model_path)
             msg.good(f"Saved pipeline to output directory {final_model_path}")
+
+
+def add_vectors(nlp: Language, vectors: str) -> None:
+    title = f"Config validation error for vectors {vectors}"
+    desc = (
+        "This typically means that there's a problem in the config.cfg included "
+        "with the packaged vectors. Make sure that the vectors package you're "
+        "loading is compatible with the current version of spaCy."
+    )
+    with show_validation_error(
+        title=title, desc=desc, hint_fill=False, show_config=False
+    ):
+        util.load_vectors_into_model(nlp, vectors)
 
 
 def create_train_batches(iterator, batcher, max_epochs: int):

--- a/spacy/tests/lang/zh/test_tokenizer.py
+++ b/spacy/tests/lang/zh/test_tokenizer.py
@@ -1,6 +1,6 @@
 import pytest
 from spacy.lang.zh import Chinese, _get_pkuseg_trie_data
-from thinc.config import ConfigValidationError
+from thinc.api import ConfigValidationError
 
 
 # fmt: off

--- a/spacy/tests/pipeline/test_pipe_factories.py
+++ b/spacy/tests/pipeline/test_pipe_factories.py
@@ -4,8 +4,7 @@ from spacy.lang.en import English
 from spacy.lang.de import German
 from spacy.tokens import Doc
 from spacy.util import registry, SimpleFrozenDict, combine_score_weights
-from thinc.api import Model, Linear
-from thinc.config import ConfigValidationError
+from thinc.api import Model, Linear, ConfigValidationError
 from pydantic import StrictInt, StrictStr
 
 from ..util import make_tempdir

--- a/spacy/tests/serialize/test_serialize_config.py
+++ b/spacy/tests/serialize/test_serialize_config.py
@@ -1,5 +1,5 @@
 import pytest
-from thinc.config import Config, ConfigValidationError
+from thinc.api import Config, ConfigValidationError
 import spacy
 from spacy.lang.en import English
 from spacy.lang.de import German

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -8,7 +8,7 @@ from spacy.cli._util import validate_project_commands, parse_config_overrides
 from spacy.cli._util import load_project_config, substitute_project_variables
 from spacy.cli._util import string_to_list, OVERRIDES_ENV_VAR
 from spacy.cli.debug_config import check_section_refs
-from thinc.config import ConfigValidationError, Config
+from thinc.api import ConfigValidationError, Config
 import srsly
 import os
 


### PR DESCRIPTION
## Description

- update to latest Thinc
- clean up CLI config validation formatting helper and use new `ConfigValidationError`
- add custom validation error if loading vectors package fails due to conifg

### Types of change
enhancement, ux, cli

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
