### PR TITLE
Construct nlp from uninterpolated config before training

### DIFF
--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -78,6 +78,9 @@ def train(
         config = util.load_config(
             config_path, overrides=config_overrides, interpolate=True
         )
+        # Keep a second un-interpolated config so we can preserve variables in
+        # the final nlp object we train and serialize
+        raw_config = util.load_config(config_path, overrides=config_overrides)
     if config["training"]["seed"] is not None:
         fix_random_seed(config["training"]["seed"])
     allocator = config["training"]["gpu_allocator"]
@@ -86,7 +89,7 @@ def train(
     # Use original config here before it's resolved to functions
     sourced_components = get_sourced_components(config)
     with show_validation_error(config_path):
-        nlp, config = util.load_model_from_config(config)
+        nlp, config = util.load_model_from_config(raw_config)
     util.load_vocab_data_into_model(nlp, lookups=config["training"]["lookups"])
     if config["training"]["vectors"] is not None:
         util.load_vectors_into_model(nlp, config["training"]["vectors"])


### PR DESCRIPTION
## Description

I noticed that our trained models ended up with interpolated configs and duplicated values. That's because we interpolate the config before training so we can access all values directly (e.g. `config["training"]["seed"]`, even if it's a variable referring to the `[system]` block). This is fine, but we shouldn't use that config to create the `nlp` object. Instead, we can keep a separate non-interpolated version.

### Types of change
bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
