### PR TITLE
Support data augmentation in Corpus

### DIFF
--- a/spacy/cli/templates/quickstart_training.jinja
+++ b/spacy/cli/templates/quickstart_training.jinja
@@ -270,6 +270,7 @@ factory = "{{ pipe }}"
 @readers = "spacy.Corpus.v1"
 path = ${paths.train}
 max_length = {{ 500 if hardware == "gpu" else 2000 }}
+augmenter = {"@augmenters": "spacy.orth_variants.v1", "level": 0.1}
 
 [corpora.dev]
 @readers = "spacy.Corpus.v1"

--- a/spacy/cli/templates/quickstart_training.jinja
+++ b/spacy/cli/templates/quickstart_training.jinja
@@ -270,7 +270,7 @@ factory = "{{ pipe }}"
 @readers = "spacy.Corpus.v1"
 path = ${paths.train}
 max_length = {{ 500 if hardware == "gpu" else 2000 }}
-augmenter = {"@augmenters": "spacy.orth_variants.v1", "level": 0.1}
+augmenter = {"@augmenters": "spacy.orth_variants.v1", "level": 0.1, "lower": 0.5}
 
 [corpora.dev]
 @readers = "spacy.Corpus.v1"

--- a/spacy/default_config.cfg
+++ b/spacy/default_config.cfg
@@ -35,6 +35,11 @@ gold_preproc = false
 max_length = 0
 # Limitation on number of training examples
 limit = 0
+# Apply some simply data augmentation, where we replace tokens with variations.
+# This is especially useful for punctuation and case replacement, to help
+# generalize beyond corpora that don't have smart-quotes, or only have smart
+# quotes, etc.
+augmenter = {"@augmenters": "spacy.orth_variants.v1", "level": 0.1}
 
 [corpora.dev]
 @readers = "spacy.Corpus.v1"

--- a/spacy/default_config.cfg
+++ b/spacy/default_config.cfg
@@ -39,7 +39,7 @@ limit = 0
 # This is especially useful for punctuation and case replacement, to help
 # generalize beyond corpora that don't have smart-quotes, or only have smart
 # quotes, etc.
-augmenter = {"@augmenters": "spacy.orth_variants.v1", "level": 0.1}
+augmenter = {"@augmenters": "spacy.orth_variants.v1", "level": 0.1, "lower": 0.5}
 
 [corpora.dev]
 @readers = "spacy.Corpus.v1"

--- a/spacy/tests/training/test_training.py
+++ b/spacy/tests/training/test_training.py
@@ -496,7 +496,7 @@ def test_make_orth_variants(doc):
         output_file = tmpdir / "roundtrip.spacy"
         DocBin(docs=[doc]).to_disk(output_file)
         # due to randomness, test only that this runs with no errors for now
-        reader = Corpus(output_file, augmenter=create_orth_variants_augmenter(leve=0.2))
+        reader = Corpus(output_file, augmenter=create_orth_variants_augmenter(level=0.2))
         train_examples = list(next(reader(nlp)))
 
 

--- a/spacy/tests/training/test_training.py
+++ b/spacy/tests/training/test_training.py
@@ -4,7 +4,7 @@ from spacy.training import biluo_tags_to_spans, iob_to_biluo
 from spacy.training import Corpus, docs_to_json
 from spacy.training.example import Example
 from spacy.training.converters import json_to_docs
-from spacy.training.augment import make_orth_variants_example
+from spacy.training.augment import orth_variants_augmenter
 from spacy.lang.en import English
 from spacy.tokens import Doc, DocBin
 from spacy.util import get_words_and_spaces, minibatch
@@ -496,9 +496,11 @@ def test_make_orth_variants(doc):
         output_file = tmpdir / "roundtrip.spacy"
         DocBin(docs=[doc]).to_disk(output_file)
         # due to randomness, test only that this runs with no errors for now
-        reader = Corpus(output_file)
-        train_example = next(reader(nlp))
-    make_orth_variants_example(nlp, train_example, orth_variant_level=0.2)
+        reader = Corpus(
+            output_file,
+            augmenter=create_orth_variants_augmenter(leve=0.2)
+        )
+        train_examples = list(next(reader(nlp)))
 
 
 @pytest.mark.skip("Outdated")

--- a/spacy/tests/training/test_training.py
+++ b/spacy/tests/training/test_training.py
@@ -497,7 +497,7 @@ def test_make_orth_variants(doc):
         DocBin(docs=[doc]).to_disk(output_file)
         # due to randomness, test only that this runs with no errors for now
         reader = Corpus(output_file, augmenter=create_orth_variants_augmenter(level=0.2, lower=0.5))
-        train_examples = list(next(reader(nlp)))
+        train_examples = list(reader(nlp))
 
 
 @pytest.mark.skip("Outdated")

--- a/spacy/tests/training/test_training.py
+++ b/spacy/tests/training/test_training.py
@@ -496,10 +496,7 @@ def test_make_orth_variants(doc):
         output_file = tmpdir / "roundtrip.spacy"
         DocBin(docs=[doc]).to_disk(output_file)
         # due to randomness, test only that this runs with no errors for now
-        reader = Corpus(
-            output_file,
-            augmenter=create_orth_variants_augmenter(leve=0.2)
-        )
+        reader = Corpus(output_file, augmenter=create_orth_variants_augmenter(leve=0.2))
         train_examples = list(next(reader(nlp)))
 
 

--- a/spacy/tests/training/test_training.py
+++ b/spacy/tests/training/test_training.py
@@ -496,7 +496,7 @@ def test_make_orth_variants(doc):
         output_file = tmpdir / "roundtrip.spacy"
         DocBin(docs=[doc]).to_disk(output_file)
         # due to randomness, test only that this runs with no errors for now
-        reader = Corpus(output_file, augmenter=create_orth_variants_augmenter(level=0.2))
+        reader = Corpus(output_file, augmenter=create_orth_variants_augmenter(level=0.2, lower=0.5))
         train_examples = list(next(reader(nlp)))
 
 

--- a/spacy/tests/training/test_training.py
+++ b/spacy/tests/training/test_training.py
@@ -4,7 +4,7 @@ from spacy.training import biluo_tags_to_spans, iob_to_biluo
 from spacy.training import Corpus, docs_to_json
 from spacy.training.example import Example
 from spacy.training.converters import json_to_docs
-from spacy.training.augment import orth_variants_augmenter
+from spacy.training.augment import create_orth_variants_augmenter
 from spacy.lang.en import English
 from spacy.tokens import Doc, DocBin
 from spacy.util import get_words_and_spaces, minibatch

--- a/spacy/training/__init__.py
+++ b/spacy/training/__init__.py
@@ -1,6 +1,7 @@
 from .corpus import Corpus  # noqa: F401
 from .example import Example, validate_examples  # noqa: F401
 from .align import Alignment  # noqa: F401
+from .augment import dont_augment, orth_variants_augmenter  # noqa: F401
 from .iob_utils import iob_to_biluo, biluo_to_iob  # noqa: F401
 from .iob_utils import offsets_to_biluo_tags, biluo_tags_to_offsets  # noqa: F401
 from .iob_utils import biluo_tags_to_spans, tags_to_entities  # noqa: F401

--- a/spacy/training/augment.py
+++ b/spacy/training/augment.py
@@ -12,7 +12,7 @@ def create_null_augmenter():
 
 
 @registry.augmenters("spacy.orth_variants.v1")
-def create_orth_variants_augmenter(level: float = 0.0) -> Callable:
+def create_orth_variants_augmenter(level: float, lower: float) -> Callable:
     """Create a data augmentation callback that uses orth-variant replacement.
     The callback can be added to a corpus or other data iterator during training.
     """

--- a/spacy/training/augment.py
+++ b/spacy/training/augment.py
@@ -10,8 +10,9 @@ from ..util import registry
 def create_null_augmenter():
     return dont_augment
 
+
 @registry.augmenters("spacy.orth_variants.v1")
-def create_orth_variants_augmenter(level: float=0.0) -> Callable:
+def create_orth_variants_augmenter(level: float = 0.0) -> Callable:
     """Create a data augmentation callback that uses orth-variant replacement.
     The callback can be added to a corpus or other data iterator during training.
     """
@@ -22,7 +23,7 @@ def dont_augment(nlp, example):
     yield example
 
 
-def orth_variants_augmenter(nlp, example, *, level: float=0.0):
+def orth_variants_augmenter(nlp, example, *, level: float = 0.0):
     if random.random() >= level:
         yield example
     else:

--- a/spacy/training/augment.py
+++ b/spacy/training/augment.py
@@ -23,7 +23,7 @@ def dont_augment(nlp, example):
     yield example
 
 
-def orth_variants_augmenter(nlp, example, *, level: float = 0.0):
+def orth_variants_augmenter(nlp, example, *, level: float = 0.0, lower: float=0.0):
     if random.random() >= level:
         yield example
     else:
@@ -33,20 +33,20 @@ def orth_variants_augmenter(nlp, example, *, level: float = 0.0):
             yield example
         else:
             variant_text, variant_token_annot = make_orth_variants(
-                nlp, raw_text, orig_dict["token_annotation"], level
+                nlp, raw_text, orig_dict["token_annotation"], lower_prob=lower
             )
             doc = nlp.make_doc(variant_text)
             orig_dict["token_annotation"] = variant_token_annot
             yield example.from_dict(doc, orig_dict)
 
 
-def make_orth_variants(nlp, raw, token_dict, orth_variant_level=0.0):
+def make_orth_variants(nlp, raw, token_dict, *, lower_prob: float=0.0):
     orig_token_dict = copy.deepcopy(token_dict)
-    lower = False
-    if random.random() >= 0.5:
+    if raw is not None and random.random() < lower_prob:
         lower = True
-        if raw is not None:
-            raw = raw.lower()
+        raw = raw.lower()
+    else:
+        lower = False
     orth_variants = nlp.vocab.lookups.get_table("orth_variants", {})
     ndsv = orth_variants.get("single", [])
     ndpv = orth_variants.get("paired", [])

--- a/spacy/training/augment.py
+++ b/spacy/training/augment.py
@@ -40,7 +40,7 @@ def orth_variants_augmenter(nlp, example, *, level: float=0.0):
 
 
 def make_orth_variants(nlp, raw, token_dict, orth_variant_level=0.0):
-    orig_token_dict = copy.deepcopy(orig_token_dict)
+    orig_token_dict = copy.deepcopy(token_dict)
     lower = False
     if random.random() >= 0.5:
         lower = True

--- a/spacy/training/augment.py
+++ b/spacy/training/augment.py
@@ -16,7 +16,7 @@ def create_orth_variants_augmenter(level: float, lower: float) -> Callable:
     """Create a data augmentation callback that uses orth-variant replacement.
     The callback can be added to a corpus or other data iterator during training.
     """
-    return partial(orth_variants_augmenter, level=level)
+    return partial(orth_variants_augmenter, level=level, lower=lower)
 
 
 def dont_augment(nlp, example):

--- a/spacy/training/augment.py
+++ b/spacy/training/augment.py
@@ -32,12 +32,11 @@ def orth_variants_augmenter(nlp, example, *, level: float = 0.0, lower: float=0.
         if not orig_dict["token_annotation"]:
             yield example
         else:
-            if raw_text is not None and random.random() < lower_prob:
-                lower = True
-            else:
-                lower = False
             variant_text, variant_token_annot = make_orth_variants(
-                nlp, raw_text, orig_dict["token_annotation"], lower=lower
+                nlp,
+                raw_text,
+                orig_dict["token_annotation"],
+                lower=raw_text is not None and random.random() < lower
             )
             doc = nlp.make_doc(variant_text)
             orig_dict["token_annotation"] = variant_token_annot

--- a/spacy/training/augment.py
+++ b/spacy/training/augment.py
@@ -1,25 +1,46 @@
+from typing import Callable
 import random
 import itertools
+import copy
+from functools import partial
+from ..util import registry
 
 
-def make_orth_variants_example(nlp, example, orth_variant_level=0.0):  # TODO: naming
-    raw_text = example.text
-    orig_dict = example.to_dict()
-    variant_text, variant_token_annot = make_orth_variants(
-        nlp, raw_text, orig_dict["token_annotation"], orth_variant_level
-    )
-    doc = nlp.make_doc(variant_text)
-    orig_dict["token_annotation"] = variant_token_annot
-    return example.from_dict(doc, orig_dict)
+@registry.augmenters("spacy.dont_augment.v1")
+def create_null_augmenter():
+    return dont_augment
+
+@registry.augmenters("spacy.orth_variants.v1")
+def create_orth_variants_augmenter(level: float=0.0) -> Callable:
+    """Create a data augmentation callback that uses orth-variant replacement.
+    The callback can be added to a corpus or other data iterator during training.
+    """
+    return partial(orth_variants_augmenter, level=level)
 
 
-def make_orth_variants(nlp, raw_text, orig_token_dict, orth_variant_level=0.0):
-    if random.random() >= orth_variant_level:
-        return raw_text, orig_token_dict
-    if not orig_token_dict:
-        return raw_text, orig_token_dict
-    raw = raw_text
-    token_dict = orig_token_dict
+def dont_augment(nlp, example):
+    yield example
+
+
+def orth_variants_augmenter(nlp, example, *, level: float=0.0):
+    if random.random() >= level:
+        yield example
+    else:
+        raw_text = example.text
+        orig_dict = example.to_dict()
+        if not orig_dict["token_annotation"]:
+            yield example
+        else:
+            variant_text, variant_token_annot = make_orth_variants(
+                nlp, raw_text, orig_dict["token_annotation"], level
+            )
+            doc = nlp.make_doc(variant_text)
+            orig_dict["token_annotation"] = variant_token_annot
+            yield example.from_dict(doc, orig_dict)
+
+
+def make_orth_variants(nlp, raw, token_dict, orth_variant_level=0.0):
+    orig_token_dict = copy.deepcopy(orig_token_dict)
     lower = False
     if random.random() >= 0.5:
         lower = True
@@ -103,7 +124,7 @@ def make_orth_variants(nlp, raw_text, orig_token_dict, orth_variant_level=0.0):
             # something went wrong, abort
             # (add a warning message?)
             if not match_found:
-                return raw_text, orig_token_dict
+                return raw, orig_token_dict
             # add following whitespace
             while raw_idx < len(raw) and raw[raw_idx].isspace():
                 variant_raw += raw[raw_idx]

--- a/spacy/training/augment.py
+++ b/spacy/training/augment.py
@@ -32,21 +32,20 @@ def orth_variants_augmenter(nlp, example, *, level: float = 0.0, lower: float=0.
         if not orig_dict["token_annotation"]:
             yield example
         else:
+            if raw_text is not None and random.random() < lower_prob:
+                lower = True
+            else:
+                lower = False
             variant_text, variant_token_annot = make_orth_variants(
-                nlp, raw_text, orig_dict["token_annotation"], lower_prob=lower
+                nlp, raw_text, orig_dict["token_annotation"], lower=lower
             )
             doc = nlp.make_doc(variant_text)
             orig_dict["token_annotation"] = variant_token_annot
             yield example.from_dict(doc, orig_dict)
 
 
-def make_orth_variants(nlp, raw, token_dict, *, lower_prob: float=0.0):
+def make_orth_variants(nlp, raw, token_dict, *, lower: bool=False):
     orig_token_dict = copy.deepcopy(token_dict)
-    if raw is not None and random.random() < lower_prob:
-        lower = True
-        raw = raw.lower()
-    else:
-        lower = False
     orth_variants = nlp.vocab.lookups.get_table("orth_variants", {})
     ndsv = orth_variants.get("single", [])
     ndpv = orth_variants.get("paired", [])

--- a/spacy/training/corpus.py
+++ b/spacy/training/corpus.py
@@ -1,9 +1,11 @@
 import warnings
 from typing import Union, List, Iterable, Iterator, TYPE_CHECKING, Callable
+from typing import Optional
 from pathlib import Path
 import srsly
 
 from .. import util
+from .augment import dont_augment
 from .example import Example
 from ..errors import Warnings
 from ..tokens import DocBin, Doc
@@ -18,9 +20,15 @@ FILE_TYPE = ".spacy"
 
 @util.registry.readers("spacy.Corpus.v1")
 def create_docbin_reader(
-    path: Path, gold_preproc: bool, max_length: int = 0, limit: int = 0
+    path: Path, gold_preproc: bool, max_length: int = 0, limit: int = 0, augmenter: Optional[Callable]=None
 ) -> Callable[["Language"], Iterable[Example]]:
-    return Corpus(path, gold_preproc=gold_preproc, max_length=max_length, limit=limit)
+    return Corpus(
+        path,
+        gold_preproc=gold_preproc,
+        max_length=max_length,
+        limit=limit,
+        augmenter=augmenter
+    )
 
 
 @util.registry.readers("spacy.JsonlReader.v1")
@@ -70,6 +78,8 @@ class Corpus:
         0, which indicates no limit.
     limit (int): Limit corpus to a subset of examples, e.g. for debugging.
         Defaults to 0, which indicates no limit.
+    augment (Callable[Example, Iterable[Example]]): Optional data augmentation
+        function, to extrapolate additional examples from your annotations.
 
     DOCS: https://nightly.spacy.io/api/corpus
     """
@@ -81,11 +91,13 @@ class Corpus:
         limit: int = 0,
         gold_preproc: bool = False,
         max_length: int = 0,
+        augmenter: Optional[Callable]=None
     ) -> None:
         self.path = util.ensure_path(path)
         self.gold_preproc = gold_preproc
         self.max_length = max_length
         self.limit = limit
+        self.augmenter = augmenter if augmenter is not None else dont_augment
 
     def __call__(self, nlp: "Language") -> Iterator[Example]:
         """Yield examples from the data.
@@ -100,7 +112,9 @@ class Corpus:
             examples = self.make_examples_gold_preproc(nlp, ref_docs)
         else:
             examples = self.make_examples(nlp, ref_docs)
-        yield from examples
+        for real_eg in examples:
+            for augmented_eg in self.augmenter(nlp, real_eg):
+                yield augmented_eg
 
     def _make_example(
         self, nlp: "Language", reference: Doc, gold_preproc: bool

--- a/spacy/training/corpus.py
+++ b/spacy/training/corpus.py
@@ -20,14 +20,18 @@ FILE_TYPE = ".spacy"
 
 @util.registry.readers("spacy.Corpus.v1")
 def create_docbin_reader(
-    path: Path, gold_preproc: bool, max_length: int = 0, limit: int = 0, augmenter: Optional[Callable]=None
+    path: Path,
+    gold_preproc: bool,
+    max_length: int = 0,
+    limit: int = 0,
+    augmenter: Optional[Callable] = None,
 ) -> Callable[["Language"], Iterable[Example]]:
     return Corpus(
         path,
         gold_preproc=gold_preproc,
         max_length=max_length,
         limit=limit,
-        augmenter=augmenter
+        augmenter=augmenter,
     )
 
 
@@ -91,7 +95,7 @@ class Corpus:
         limit: int = 0,
         gold_preproc: bool = False,
         max_length: int = 0,
-        augmenter: Optional[Callable]=None
+        augmenter: Optional[Callable] = None,
     ) -> None:
         self.path = util.ensure_path(path)
         self.gold_preproc = gold_preproc

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -81,6 +81,7 @@ class registry(thinc.registry):
     callbacks = catalogue.create("spacy", "callbacks")
     batchers = catalogue.create("spacy", "batchers", entry_points=True)
     readers = catalogue.create("spacy", "readers", entry_points=True)
+    augmenters = catalogue.create("spacy", "augmenters", entry_points=True)
     loggers = catalogue.create("spacy", "loggers", entry_points=True)
     # These are factories registered via third-party packages and the
     # spacy_factories entry point. This registry only exists so we can easily

--- a/website/docs/api/corpus.md
+++ b/website/docs/api/corpus.md
@@ -74,6 +74,7 @@ train/test skew.
 |  `gold_preproc` | Whether to set up the Example object with gold-standard sentences and tokens for the predictions. Defaults to `False`. ~~bool~~                     |
 | `max_length`    | Maximum document length. Longer documents will be split into sentences, if sentence boundaries are available. Defaults to `0` for no limit. ~~int~~ |
 | `limit`         | Limit corpus to a subset of examples, e.g. for debugging. Defaults to `0` for no limit. ~~int~~                                                     |
+| `augmenter`     | Optional data augmentation callback. ~~Callable[[Language, Example], Iterable[Example]]~~
 
 ## Corpus.\_\_call\_\_ {#call tag="method"}
 

--- a/website/docs/usage/training.md
+++ b/website/docs/usage/training.md
@@ -6,6 +6,7 @@ menu:
   - ['Introduction', 'basics']
   - ['Quickstart', 'quickstart']
   - ['Config System', 'config']
+  <!-- - ['Data Utilities', 'data'] -->
   - ['Custom Functions', 'custom-functions']
   - ['Parallel Training', 'parallel-training']
   - ['Internal API', 'api']
@@ -504,6 +505,16 @@ impossible for the model to predict 50% of your entities, your NER F-score might
 still look good.
 
 </Accordion>
+
+<!--
+## Data Utilities {#data-utilities}
+
+* spacy convert
+* The [corpora] block
+* Custom corpus class
+* Minibatching
+* Data augmentation
+-->
 
 ## Custom Functions {#custom-functions}
 


### PR DESCRIPTION
Allow an optional `augmenter` argument on the Corpus class, which can be built from the registry. A data augmenter is a callable that takes the `nlp` object and an `Example`, and yields zero or more `Example` objects, which may be copies or the original.

I've stubbed out a TODO section of the training docs as well, I think we're missing a bit about how to work with data? It would cover stuff like conversion, batching and the data augmentation.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
