### PR TITLE
upgrade pydantic pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pathy
 numpy>=1.15.0
 requests>=2.13.0,<3.0.0
 tqdm>=4.38.0,<5.0.0
-pydantic>=1.3.0,<2.0.0
+pydantic>=1.5.0,<2.0.0
 pytokenizations
 # Official Python utilities
 setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     tqdm>=4.38.0,<5.0.0
     numpy>=1.15.0
     requests>=2.13.0,<3.0.0
-    pydantic>=1.3.0,<2.0.0
+    pydantic>=1.5.0,<2.0.0
     pytokenizations
     # Official Python utilities
     setuptools


### PR DESCRIPTION

## Description
Need to have `pydantic>=1.5` to use `field.default_factory` in Thinc
cf https://pydantic-docs.helpmanual.io/changelog/#v15-2020-04-18

### Types of change
fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
