### PR TITLE
Fix equivalance of unset and empty MorphAnalysis

### DIFF
--- a/spacy/morphology.pyx
+++ b/spacy/morphology.pyx
@@ -29,8 +29,8 @@ cdef class Morphology:
     FEATURE_SEP = "|"
     FIELD_SEP = "="
     VALUE_SEP = ","
-    # not an empty string so that the PreshMap key is not 0
-    EMPTY_MORPH = symbols.NAMES[symbols._]
+    EMPTY_MORPH = "_" # should be defined as a symbol so it's not missing from
+                      # an empty stringstore
 
     def __init__(self, StringStore strings):
         self.mem = Pool()

--- a/spacy/tests/doc/test_morphanalysis.py
+++ b/spacy/tests/doc/test_morphanalysis.py
@@ -94,3 +94,25 @@ def test_morph_property(tokenizer):
     tokenizer.vocab.strings.add("Feat=Val")
     doc[0].morph = tokenizer.vocab.strings.add("Feat=Val")
     assert doc[0].morph_ == "Feat=Val"
+
+
+def test_unset_equals_empty(en_tokenizer):
+    # one unset, one set to empty
+    doc1 = en_tokenizer("a b")
+    doc1[1].morph_ = ""
+
+    # both set to empty
+    doc2 = en_tokenizer("a b")
+    doc2[1].morph_ = ""
+    doc2[1].morph_ = ""
+
+    assert [t.morph for t in doc1] == [t.morph for t in doc2]
+    assert [t.morph_ for t in doc1] == [t.morph_ for t in doc2]
+
+    # both set to empty in different versions
+    doc2 = en_tokenizer("a b")
+    doc2[1].morph_ = "_"
+    doc2[1].morph_ = {}
+
+    assert [t.morph for t in doc1] == [t.morph for t in doc2]
+    assert [t.morph_ for t in doc1] == [t.morph_ for t in doc2]

--- a/spacy/tokens/morphanalysis.pyx
+++ b/spacy/tokens/morphanalysis.pyx
@@ -24,6 +24,8 @@ cdef class MorphAnalysis:
         """Create a morphological analysis from a given ID."""
         cdef MorphAnalysis morph = MorphAnalysis.__new__(MorphAnalysis, vocab)
         morph.vocab = vocab
+        if key == 0:
+            key = vocab.strings[Morphology.EMPTY_MORPH]
         morph.key = key
         analysis = <const MorphAnalysisC*>vocab.morphology.tags.get(key)
         if analysis is not NULL:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Make `token.morph` `MorphAnalysis` equivalent for `token.c.morph == 0` and `token.morph_ == Morphology.EMPTY_MORPH`.

Additional minor change:

* Revert change to `Morphology.EMPTY_MORPH` as a symbol, just use the string with a note.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
