### PR TITLE
reorder so tagmap is replaced only if a custom file is provided.

### DIFF
--- a/spacy/cli/debug_data.py
+++ b/spacy/cli/debug_data.py
@@ -59,10 +59,6 @@ def debug_data(
     if not dev_path.exists():
         msg.fail("Development data not found", dev_path, exits=1)
 
-    tag_map = {}
-    if tag_map_path is not None:
-        tag_map = srsly.read_json(tag_map_path)
-
     # Initialize the model and pipeline
     pipeline = [p.strip() for p in pipeline.split(",")]
     if base_model:
@@ -70,8 +66,12 @@ def debug_data(
     else:
         lang_cls = get_lang_class(lang)
         nlp = lang_cls()
-    # Replace tag map with provided mapping
-    nlp.vocab.morphology.load_tag_map(tag_map)
+
+    tag_map = {}
+    if tag_map_path is not None:
+        tag_map = srsly.read_json(tag_map_path)
+        # Replace tag map with provided mapping
+        nlp.vocab.morphology.load_tag_map(tag_map)
 
     msg.divider("Data format validation")
 

--- a/spacy/cli/debug_data.py
+++ b/spacy/cli/debug_data.py
@@ -67,7 +67,6 @@ def debug_data(
         lang_cls = get_lang_class(lang)
         nlp = lang_cls()
 
-    tag_map = {}
     if tag_map_path is not None:
         tag_map = srsly.read_json(tag_map_path)
         # Replace tag map with provided mapping


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Fixed an issue whereby a tagmap is replaced by an empty mapping if a custom tagmap is not provided. See #6129 

### Types of change

Bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
