### PR TITLE
Update [initialize] block in languages

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -672,14 +672,22 @@ class Errors:
     E999 = ("Unable to merge the `Doc` objects because they do not all share "
             "the same `Vocab`.")
     E1000 = ("The Chinese word segmenter is pkuseg but no pkuseg model was "
-             "specified. Provide the name of a pretrained model or the path to "
-             "a model when initializing the pipeline:\n"
+             "loaded. Provide the name of a pretrained model or the path to "
+             "a model and initialize the pipeline:\n\n"
              'config = {\n'
-             '   "@tokenizers": "spacy.zh.ChineseTokenizer",\n'
-             '   "segmenter": "pkuseg",\n'
-             '   "pkuseg_model": "default", # or "/path/to/pkuseg_model" \n'
+             '    "nlp": {\n'
+             '        "tokenizer": {\n'
+             '            "@tokenizers": "spacy.zh.ChineseTokenizer",\n'
+             '            "segmenter": "pkuseg",\n'
+             '        }\n'
+             '    },\n'
+             '    "initialize": {"tokenizer": {\n'
+             '            "pkuseg_model": "default", # or /path/to/model\n'
+             '        }\n'
+             '    },\n'
              '}\n'
-             'nlp = Chinese.from_config({"nlp": {"tokenizer": config}})')
+             'nlp = Chinese.from_config(config)\n'
+             'nlp.initialize()')
     E1001 = ("Target token outside of matched span for match with tokens "
              "'{span}' and offset '{index}' matched by patterns '{patterns}'.")
     E1002 = ("Span index out of range.")

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -554,7 +554,10 @@ class Errors:
     E953 = ("Mismatched IDs received by the Tok2Vec listener: {id1} vs. {id2}")
     E954 = ("The Tok2Vec listener did not receive any valid input from an upstream "
             "component.")
-    E955 = ("Can't find table(s) '{table}' for language '{lang}' in spacy-lookups-data.")
+    E955 = ("Can't find table(s) '{table}' for language '{lang}' in "
+            "spacy-lookups-data. If you want to initialize a blank nlp object, "
+            "make sure you have the spacy-lookups-data package installed or "
+            "remove the [initialize.lookups] block from your config.")
     E956 = ("Can't find component '{name}' in [components] block in the config. "
             "Available components: {opts}")
     E957 = ("Writing directly to Language.factories isn't needed anymore in "
@@ -674,20 +677,7 @@ class Errors:
     E1000 = ("The Chinese word segmenter is pkuseg but no pkuseg model was "
              "loaded. Provide the name of a pretrained model or the path to "
              "a model and initialize the pipeline:\n\n"
-             'config = {\n'
-             '    "nlp": {\n'
-             '        "tokenizer": {\n'
-             '            "@tokenizers": "spacy.zh.ChineseTokenizer",\n'
-             '            "segmenter": "pkuseg",\n'
-             '        }\n'
-             '    },\n'
-             '    "initialize": {"tokenizer": {\n'
-             '            "pkuseg_model": "default", # or /path/to/model\n'
-             '        }\n'
-             '    },\n'
-             '}\n'
-             'nlp = Chinese.from_config(config)\n'
-             'nlp.initialize()')
+             'nlp.tokenizer.initialize(pkuseg_model="default")')
     E1001 = ("Target token outside of matched span for match with tokens "
              "'{span}' and offset '{index}' matched by patterns '{patterns}'.")
     E1002 = ("Span index out of range.")

--- a/spacy/lang/da/__init__.py
+++ b/spacy/lang/da/__init__.py
@@ -3,9 +3,21 @@ from .punctuation import TOKENIZER_INFIXES, TOKENIZER_SUFFIXES
 from .stop_words import STOP_WORDS
 from .lex_attrs import LEX_ATTRS
 from ...language import Language
+from ...util import load_config_from_str
+
+
+DEFAULT_CONFIG = """
+[initialize]
+
+[initialize.lookups]
+@misc = "spacy.LookupsDataLoader.v1"
+lang = ${nlp.lang}
+tables = ["lexeme_norm"]
+"""
 
 
 class DanishDefaults(Language.Defaults):
+    config = load_config_from_str(DEFAULT_CONFIG)
     tokenizer_exceptions = TOKENIZER_EXCEPTIONS
     infixes = TOKENIZER_INFIXES
     suffixes = TOKENIZER_SUFFIXES

--- a/spacy/lang/de/__init__.py
+++ b/spacy/lang/de/__init__.py
@@ -3,9 +3,21 @@ from .punctuation import TOKENIZER_PREFIXES, TOKENIZER_SUFFIXES, TOKENIZER_INFIX
 from .stop_words import STOP_WORDS
 from .syntax_iterators import SYNTAX_ITERATORS
 from ...language import Language
+from ...util import load_config_from_str
+
+
+DEFAULT_CONFIG = """
+[initialize]
+
+[initialize.lookups]
+@misc = "spacy.LookupsDataLoader.v1"
+lang = ${nlp.lang}
+tables = ["lexeme_norm"]
+"""
 
 
 class GermanDefaults(Language.Defaults):
+    config = load_config_from_str(DEFAULT_CONFIG)
     tokenizer_exceptions = TOKENIZER_EXCEPTIONS
     prefixes = TOKENIZER_PREFIXES
     suffixes = TOKENIZER_SUFFIXES

--- a/spacy/lang/el/__init__.py
+++ b/spacy/lang/el/__init__.py
@@ -9,9 +9,21 @@ from .punctuation import TOKENIZER_PREFIXES, TOKENIZER_SUFFIXES, TOKENIZER_INFIX
 from .lemmatizer import GreekLemmatizer
 from ...lookups import Lookups
 from ...language import Language
+from ...util import load_config_from_str
+
+
+DEFAULT_CONFIG = """
+[initialize]
+
+[initialize.lookups]
+@misc = "spacy.LookupsDataLoader.v1"
+lang = ${nlp.lang}
+tables = ["lexeme_norm"]
+"""
 
 
 class GreekDefaults(Language.Defaults):
+    config = load_config_from_str(DEFAULT_CONFIG)
     tokenizer_exceptions = TOKENIZER_EXCEPTIONS
     prefixes = TOKENIZER_PREFIXES
     suffixes = TOKENIZER_SUFFIXES

--- a/spacy/lang/en/__init__.py
+++ b/spacy/lang/en/__init__.py
@@ -1,5 +1,4 @@
 from typing import Optional
-
 from thinc.api import Model
 
 from .tokenizer_exceptions import TOKENIZER_EXCEPTIONS
@@ -10,9 +9,21 @@ from .punctuation import TOKENIZER_INFIXES
 from .lemmatizer import EnglishLemmatizer
 from ...language import Language
 from ...lookups import Lookups
+from ...util import load_config_from_str
+
+
+DEFAULT_CONFIG = """
+[initialize]
+
+[initialize.lookups]
+@misc = "spacy.LookupsDataLoader.v1"
+lang = ${nlp.lang}
+tables = ["lexeme_norm"]
+"""
 
 
 class EnglishDefaults(Language.Defaults):
+    config = load_config_from_str(DEFAULT_CONFIG)
     tokenizer_exceptions = TOKENIZER_EXCEPTIONS
     infixes = TOKENIZER_INFIXES
     lex_attr_getters = LEX_ATTRS

--- a/spacy/lang/en/__init__.py
+++ b/spacy/lang/en/__init__.py
@@ -9,21 +9,9 @@ from .punctuation import TOKENIZER_INFIXES
 from .lemmatizer import EnglishLemmatizer
 from ...language import Language
 from ...lookups import Lookups
-from ...util import load_config_from_str
-
-
-DEFAULT_CONFIG = """
-[initialize]
-
-[initialize.lookups]
-@misc = "spacy.LookupsDataLoader.v1"
-lang = ${nlp.lang}
-tables = ["lexeme_norm"]
-"""
 
 
 class EnglishDefaults(Language.Defaults):
-    config = load_config_from_str(DEFAULT_CONFIG)
     tokenizer_exceptions = TOKENIZER_EXCEPTIONS
     infixes = TOKENIZER_INFIXES
     lex_attr_getters = LEX_ATTRS

--- a/spacy/lang/id/__init__.py
+++ b/spacy/lang/id/__init__.py
@@ -4,9 +4,21 @@ from .tokenizer_exceptions import TOKENIZER_EXCEPTIONS
 from .lex_attrs import LEX_ATTRS
 from .syntax_iterators import SYNTAX_ITERATORS
 from ...language import Language
+from ...util import load_config_from_str
+
+
+DEFAULT_CONFIG = """
+[initialize]
+
+[initialize.lookups]
+@misc = "spacy.LookupsDataLoader.v1"
+lang = ${nlp.lang}
+tables = ["lexeme_norm"]
+"""
 
 
 class IndonesianDefaults(Language.Defaults):
+    config = load_config_from_str(DEFAULT_CONFIG)
     tokenizer_exceptions = TOKENIZER_EXCEPTIONS
     prefixes = TOKENIZER_PREFIXES
     suffixes = TOKENIZER_SUFFIXES

--- a/spacy/lang/ja/__init__.py
+++ b/spacy/lang/ja/__init__.py
@@ -2,7 +2,6 @@ from typing import Optional, Union, Dict, Any
 from pathlib import Path
 import srsly
 from collections import namedtuple
-from thinc.api import Config
 
 from .stop_words import STOP_WORDS
 from .syntax_iterators import SYNTAX_ITERATORS
@@ -16,7 +15,7 @@ from ...scorer import Scorer
 from ...symbols import POS
 from ...tokens import Doc
 from ...training import validate_examples
-from ...util import DummyTokenizer, registry
+from ...util import DummyTokenizer, registry, load_config_from_str
 from ... import util
 
 
@@ -166,7 +165,7 @@ class JapaneseTokenizer(DummyTokenizer):
 
 
 class JapaneseDefaults(Language.Defaults):
-    config = Config().from_str(DEFAULT_CONFIG)
+    config = load_config_from_str(DEFAULT_CONFIG)
     stop_words = STOP_WORDS
     syntax_iterators = SYNTAX_ITERATORS
     writing_system = {"direction": "ltr", "has_case": False, "has_letters": False}

--- a/spacy/lang/ko/__init__.py
+++ b/spacy/lang/ko/__init__.py
@@ -1,5 +1,4 @@
 from typing import Optional, Any, Dict
-from thinc.api import Config
 
 from .stop_words import STOP_WORDS
 from .tag_map import TAG_MAP
@@ -10,7 +9,7 @@ from ...compat import copy_reg
 from ...scorer import Scorer
 from ...symbols import POS
 from ...training import validate_examples
-from ...util import DummyTokenizer, registry
+from ...util import DummyTokenizer, registry, load_config_from_str
 
 
 DEFAULT_CONFIG = """
@@ -70,7 +69,7 @@ class KoreanTokenizer(DummyTokenizer):
 
 
 class KoreanDefaults(Language.Defaults):
-    config = Config().from_str(DEFAULT_CONFIG)
+    config = load_config_from_str(DEFAULT_CONFIG)
     lex_attr_getters = LEX_ATTRS
     stop_words = STOP_WORDS
     writing_system = {"direction": "ltr", "has_case": False, "has_letters": False}

--- a/spacy/lang/lb/__init__.py
+++ b/spacy/lang/lb/__init__.py
@@ -3,9 +3,21 @@ from .punctuation import TOKENIZER_INFIXES
 from .lex_attrs import LEX_ATTRS
 from .stop_words import STOP_WORDS
 from ...language import Language
+from ...util import load_config_from_str
+
+
+DEFAULT_CONFIG = """
+[initialize]
+
+[initialize.lookups]
+@misc = "spacy.LookupsDataLoader.v1"
+lang = ${nlp.lang}
+tables = ["lexeme_norm"]
+"""
 
 
 class LuxembourgishDefaults(Language.Defaults):
+    config = load_config_from_str(DEFAULT_CONFIG)
     tokenizer_exceptions = TOKENIZER_EXCEPTIONS
     infixes = TOKENIZER_INFIXES
     lex_attr_getters = LEX_ATTRS

--- a/spacy/lang/pt/__init__.py
+++ b/spacy/lang/pt/__init__.py
@@ -3,9 +3,21 @@ from .stop_words import STOP_WORDS
 from .lex_attrs import LEX_ATTRS
 from .punctuation import TOKENIZER_INFIXES, TOKENIZER_PREFIXES
 from ...language import Language
+from ...util import load_config_from_str
+
+
+DEFAULT_CONFIG = """
+[initialize]
+
+[initialize.lookups]
+@misc = "spacy.LookupsDataLoader.v1"
+lang = ${nlp.lang}
+tables = ["lexeme_norm"]
+"""
 
 
 class PortugueseDefaults(Language.Defaults):
+    config = load_config_from_str(DEFAULT_CONFIG)
     tokenizer_exceptions = TOKENIZER_EXCEPTIONS
     infixes = TOKENIZER_INFIXES
     prefixes = TOKENIZER_PREFIXES

--- a/spacy/lang/ru/__init__.py
+++ b/spacy/lang/ru/__init__.py
@@ -1,5 +1,4 @@
 from typing import Optional
-
 from thinc.api import Model
 
 from .stop_words import STOP_WORDS
@@ -8,9 +7,21 @@ from .lex_attrs import LEX_ATTRS
 from .lemmatizer import RussianLemmatizer
 from ...language import Language
 from ...lookups import Lookups
+from ...util import load_config_from_str
+
+
+DEFAULT_CONFIG = """
+[initialize]
+
+[initialize.lookups]
+@misc = "spacy.LookupsDataLoader.v1"
+lang = ${nlp.lang}
+tables = ["lexeme_norm"]
+"""
 
 
 class RussianDefaults(Language.Defaults):
+    config = load_config_from_str(DEFAULT_CONFIG)
     tokenizer_exceptions = TOKENIZER_EXCEPTIONS
     lex_attr_getters = LEX_ATTRS
     stop_words = STOP_WORDS

--- a/spacy/lang/sr/__init__.py
+++ b/spacy/lang/sr/__init__.py
@@ -2,9 +2,21 @@ from .stop_words import STOP_WORDS
 from .tokenizer_exceptions import TOKENIZER_EXCEPTIONS
 from .lex_attrs import LEX_ATTRS
 from ...language import Language
+from ...util import load_config_from_str
+
+
+DEFAULT_CONFIG = """
+[initialize]
+
+[initialize.lookups]
+@misc = "spacy.LookupsDataLoader.v1"
+lang = ${nlp.lang}
+tables = ["lexeme_norm"]
+"""
 
 
 class SerbianDefaults(Language.Defaults):
+    config = load_config_from_str(DEFAULT_CONFIG)
     tokenizer_exceptions = TOKENIZER_EXCEPTIONS
     lex_attr_getters = LEX_ATTRS
     stop_words = STOP_WORDS

--- a/spacy/lang/ta/__init__.py
+++ b/spacy/lang/ta/__init__.py
@@ -1,9 +1,21 @@
 from .stop_words import STOP_WORDS
 from .lex_attrs import LEX_ATTRS
 from ...language import Language
+from ...util import load_config_from_str
+
+
+DEFAULT_CONFIG = """
+[initialize]
+
+[initialize.lookups]
+@misc = "spacy.LookupsDataLoader.v1"
+lang = ${nlp.lang}
+tables = ["lexeme_norm"]
+"""
 
 
 class TamilDefaults(Language.Defaults):
+    config = load_config_from_str(DEFAULT_CONFIG)
     lex_attr_getters = LEX_ATTRS
     stop_words = STOP_WORDS
 

--- a/spacy/lang/th/__init__.py
+++ b/spacy/lang/th/__init__.py
@@ -1,10 +1,8 @@
-from thinc.api import Config
-
 from .stop_words import STOP_WORDS
 from .lex_attrs import LEX_ATTRS
 from ...language import Language
 from ...tokens import Doc
-from ...util import DummyTokenizer, registry
+from ...util import DummyTokenizer, registry, load_config_from_str
 
 
 DEFAULT_CONFIG = """
@@ -12,6 +10,13 @@ DEFAULT_CONFIG = """
 
 [nlp.tokenizer]
 @tokenizers = "spacy.th.ThaiTokenizer"
+
+[initialize]
+
+[initialize.lookups]
+@misc = "spacy.LookupsDataLoader.v1"
+lang = ${nlp.lang}
+tables = ["lexeme_norm"]
 """
 
 
@@ -42,7 +47,7 @@ class ThaiTokenizer(DummyTokenizer):
 
 
 class ThaiDefaults(Language.Defaults):
-    config = Config().from_str(DEFAULT_CONFIG)
+    config = load_config_from_str(DEFAULT_CONFIG)
     lex_attr_getters = LEX_ATTRS
     stop_words = STOP_WORDS
 

--- a/spacy/lang/vi/__init__.py
+++ b/spacy/lang/vi/__init__.py
@@ -1,10 +1,8 @@
-from thinc.api import Config
-
+from .stop_words import STOP_WORDS
+from .lex_attrs import LEX_ATTRS
 from ...language import Language
 from ...tokens import Doc
-from .stop_words import STOP_WORDS
-from ...util import DummyTokenizer, registry
-from .lex_attrs import LEX_ATTRS
+from ...util import DummyTokenizer, registry, load_config_from_str
 
 
 DEFAULT_CONFIG = """
@@ -55,7 +53,7 @@ class VietnameseTokenizer(DummyTokenizer):
 
 
 class VietnameseDefaults(Language.Defaults):
-    config = Config().from_str(DEFAULT_CONFIG)
+    config = load_config_from_str(DEFAULT_CONFIG)
     lex_attr_getters = LEX_ATTRS
     stop_words = STOP_WORDS
 

--- a/spacy/lang/zh/__init__.py
+++ b/spacy/lang/zh/__init__.py
@@ -56,9 +56,7 @@ def create_chinese_tokenizer(segmenter: Segmenter = Segmenter.char,):
 
 class ChineseTokenizer(DummyTokenizer):
     def __init__(
-        self,
-        nlp: Language,
-        segmenter: Segmenter = Segmenter.char,
+        self, nlp: Language, segmenter: Segmenter = Segmenter.char,
     ):
         self.vocab = nlp.vocab
         if isinstance(segmenter, Segmenter):
@@ -80,9 +78,9 @@ class ChineseTokenizer(DummyTokenizer):
 
     def initialize(
         self,
-        get_examples: Callable[[], Iterable[Example]],
+        get_examples: Optional[Callable[[], Iterable[Example]]] = None,
         *,
-        nlp: Optional[Language],
+        nlp: Optional[Language] = None,
         pkuseg_model: Optional[str] = None,
         pkuseg_user_dict: str = "default",
     ):

--- a/spacy/lang/zh/__init__.py
+++ b/spacy/lang/zh/__init__.py
@@ -4,14 +4,13 @@ import tempfile
 import srsly
 import warnings
 from pathlib import Path
-from thinc.api import Config
 
 from ...errors import Warnings, Errors
 from ...language import Language
 from ...scorer import Scorer
 from ...tokens import Doc
 from ...training import validate_examples, Example
-from ...util import DummyTokenizer, registry
+from ...util import DummyTokenizer, registry, load_config_from_str
 from .lex_attrs import LEX_ATTRS
 from .stop_words import STOP_WORDS
 from ... import util
@@ -329,7 +328,7 @@ class ChineseTokenizer(DummyTokenizer):
 
 
 class ChineseDefaults(Language.Defaults):
-    config = Config().from_str(DEFAULT_CONFIG)
+    config = load_config_from_str(DEFAULT_CONFIG)
     lex_attr_getters = LEX_ATTRS
     stop_words = STOP_WORDS
     writing_system = {"direction": "ltr", "has_case": False, "has_letters": False}

--- a/spacy/tests/conftest.py
+++ b/spacy/tests/conftest.py
@@ -284,11 +284,16 @@ def zh_tokenizer_pkuseg():
     pytest.importorskip("pkuseg")
     pytest.importorskip("pickle5")
     config = {
-        "@tokenizers": "spacy.zh.ChineseTokenizer",
-        "segmenter": "pkuseg",
-        "pkuseg_model": "default",
+        "nlp": {
+            "tokenizer": {
+                "@tokenizers": "spacy.zh.ChineseTokenizer",
+                "segmenter": "pkuseg",
+            }
+        },
+        "initialize": {"tokenizer": {"pkuseg_model": "default"}},
     }
-    nlp = get_lang_class("zh").from_config({"nlp": {"tokenizer": config}})
+    nlp = get_lang_class("zh").from_config(config)
+    nlp.initialize()
     return nlp.tokenizer
 
 

--- a/spacy/tests/conftest.py
+++ b/spacy/tests/conftest.py
@@ -272,10 +272,14 @@ def zh_tokenizer_char():
 def zh_tokenizer_jieba():
     pytest.importorskip("jieba")
     config = {
-        "@tokenizers": "spacy.zh.ChineseTokenizer",
-        "segmenter": "jieba",
+        "nlp": {
+            "tokenizer": {
+                "@tokenizers": "spacy.zh.ChineseTokenizer",
+                "segmenter": "jieba",
+            }
+        }
     }
-    nlp = get_lang_class("zh").from_config({"nlp": {"tokenizer": config}})
+    nlp = get_lang_class("zh").from_config(config)
     return nlp.tokenizer
 
 
@@ -290,7 +294,10 @@ def zh_tokenizer_pkuseg():
                 "segmenter": "pkuseg",
             }
         },
-        "initialize": {"tokenizer": {"pkuseg_model": "default"}},
+        "initialize": {"tokenizer": {
+                "pkuseg_model": "default",
+            }
+        },
     }
     nlp = get_lang_class("zh").from_config(config)
     nlp.initialize()

--- a/spacy/tests/lang/zh/test_serialize.py
+++ b/spacy/tests/lang/zh/test_serialize.py
@@ -28,9 +28,17 @@ def test_zh_tokenizer_serialize_jieba(zh_tokenizer_jieba):
 @pytest.mark.slow
 def test_zh_tokenizer_serialize_pkuseg_with_processors(zh_tokenizer_pkuseg):
     config = {
-        "@tokenizers": "spacy.zh.ChineseTokenizer",
-        "segmenter": "pkuseg",
-        "pkuseg_model": "medicine",
+        "nlp": {
+            "tokenizer": {
+                "@tokenizers": "spacy.zh.ChineseTokenizer",
+                "segmenter": "pkuseg",
+            }
+        },
+        "initialize": {"tokenizer": {
+                "pkuseg_model": "medicine",
+            }
+        },
     }
-    nlp = Chinese.from_config({"nlp": {"tokenizer": config}})
+    nlp = Chinese.from_config(config)
+    nlp.initialize()
     zh_tokenizer_serialize(nlp.tokenizer)

--- a/spacy/tests/parser/test_ner.py
+++ b/spacy/tests/parser/test_ner.py
@@ -339,6 +339,7 @@ def test_ner_warns_no_lookups(caplog):
     nlp.vocab.lookups = Lookups()
     assert not len(nlp.vocab.lookups)
     nlp.add_pipe("ner")
+    nlp.config["initialize"]["lookups"] = None
     with caplog.at_level(logging.DEBUG):
         nlp.initialize()
         assert "W033" in caplog.text


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Just a quick experiment to test the `[initialize]` block with a tokenizer that depends on data. Could probably be more elegant but I think conceptually, it works well?

Also included an `[initialize.lookups]` block as default for all languages we have lexeme normalization for. This will only run during `nlp.initialize` (e.g. if the user exports a config and wants to train from it) and if the package is not installed, they will see an error. Users can always choose to remove the data but by default, they get the best possible configuration (and won't have to know that they need to add this slightly obscure block for better performance).

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
