### PR TITLE
compat warning for pipe.begin_training

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -85,9 +85,9 @@ class Warnings:
             "attribute or operator.")
 
     # TODO: fix numbering after merging develop into master
-    W089 = ("The 'begin_training' method has been renamed to 'initialize', "
-            "for calls to 'nlp' as well as for the individual pipeline "
-            "components.")
+    W088 = ("This component implements a 'begin_training' method, "
+            "which should probably be renamed to 'initialize'.")
+    W089 = ("The nlp.begin_training method has been renamed to nlp.initialize.")
     W090 = ("Could not locate any {format} files in path '{path}'.")
     W091 = ("Could not clean/remove the temp directory at {dir}: {msg}.")
     W092 = ("Ignoring annotations for sentence starts, as dependency heads are set.")

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -85,7 +85,9 @@ class Warnings:
             "attribute or operator.")
 
     # TODO: fix numbering after merging develop into master
-    W089 = ("The nlp.begin_training method has been renamed to nlp.initialize.")
+    W089 = ("The 'begin_training' method has been renamed to 'initialize', "
+            "for calls to 'nlp' as well as for the individual pipeline "
+            "components.")
     W090 = ("Could not locate any {format} files in path '{path}'.")
     W091 = ("Could not clean/remove the temp directory at {dir}: {msg}.")
     W092 = ("Ignoring annotations for sentence starts, as dependency heads are set.")

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1207,7 +1207,11 @@ class Language:
             )
             self.tokenizer.initialize(get_examples, nlp=self, **tok_settings)
         for name, proc in self.pipeline:
-            if hasattr(proc, "initialize"):
+            # backwards compatibility for older components
+            if hasattr(proc, "begin_training"):
+                warnings.warn(Warnings.W089, DeprecationWarning)
+                proc.begin_training(get_examples, pipeline=self.pipeline, sgd=self._optimizer)
+            elif hasattr(proc, "initialize"):
                 p_settings = I["components"].get(name, {})
                 p_settings = validate_init_settings(
                     proc.initialize, p_settings, section="components", name=name

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1207,11 +1207,7 @@ class Language:
             )
             self.tokenizer.initialize(get_examples, nlp=self, **tok_settings)
         for name, proc in self.pipeline:
-            # backwards compatibility for older components
-            if hasattr(proc, "begin_training"):
-                warnings.warn(Warnings.W089, DeprecationWarning)
-                proc.begin_training(get_examples, pipeline=self.pipeline, sgd=self._optimizer)
-            elif hasattr(proc, "initialize"):
+            if hasattr(proc, "initialize"):
                 p_settings = I["components"].get(name, {})
                 p_settings = validate_init_settings(
                     proc.initialize, p_settings, section="components", name=name

--- a/spacy/pipeline/pipe.pyx
+++ b/spacy/pipeline/pipe.pyx
@@ -1,4 +1,5 @@
 # cython: infer_types=True, profile=True
+import warnings
 from typing import Optional, Tuple
 import srsly
 from thinc.api import set_dropout_rate, Model
@@ -6,7 +7,7 @@ from thinc.api import set_dropout_rate, Model
 from ..tokens.doc cimport Doc
 
 from ..training import validate_examples
-from ..errors import Errors
+from ..errors import Errors, Warnings
 from .. import util
 
 
@@ -32,6 +33,13 @@ cdef class Pipe:
         self.model = model
         self.name = name
         self.cfg = dict(cfg)
+
+    @classmethod
+    def __init_subclass__(cls, **kwargs):
+        """Raise a warning if an inheriting class implements 'begin_training'
+         (from v2) instead of the new 'initialize' method (from v3)"""
+        if hasattr(cls, "begin_training"):
+            warnings.warn(Warnings.W088)
 
     @property
     def labels(self) -> Optional[Tuple[str]]:


### PR DESCRIPTION
## Description
We currently provide bwd-compatibility in case users call the old `nlp.begin_training()` instead of the new `nlp.initialize()`. But there would also be a problem if a user has a custom component that extends `Pipe` and implements `begin_training`: because of the "dummy" implementation in `Pipe.initialize`, the user's `begin_training` would silently be ignored as `Pipe.initialize` would be called, causing potentially weird problems downstream when it looks like the component is initialized, but in practice it's not. 

I'm not particularly fond of the solution proposed in this PR, and I wouldn't necessarily keep it in the codebase very long, but I think we need something especially right after the launch of v3, to warn users that they should rename this function name in their custom component. Another solution would be to just raise the warning, but not actually call (the old) `proc.begin_training`.

(the reason why I'm not happy with this solution is because we need to put this `if` first and we can't have it second, as the condition `if hasattr(proc, "initialize")` is always `True` when inheriting from `Pipe`.)

### Types of change
enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
