### PR TITLE
Fix serialization of disabled 'base' components

### DIFF
--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -204,7 +204,7 @@ def train(
                     "positive_label": textcat_positive_label,
                 }
             if pipe not in nlp.pipe_names:
-                msg.text("Adding component to base model '{}'".format(pipe))
+                msg.text("Adding component to base model: '{}'".format(pipe))
                 nlp.add_pipe(nlp.create_pipe(pipe, config=pipe_cfg))
                 pipes_added = True
             elif replace_components:
@@ -574,6 +574,7 @@ def train(
         best_pipes = nlp.pipe_names
         if disabled_pipes:
             disabled_pipes.restore()
+            meta["pipeline"] = nlp.pipe_names
         with nlp.use_params(optimizer.averages):
             final_model_path = output_path / "model-final"
             nlp.to_disk(final_model_path)


### PR DESCRIPTION
Fixes #6140

## Description
Bugfix for v2, ensuring that (disabled) pipeline components from a base model are added back to the `meta.json` after training.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
