### PR TITLE
Clear rule-based components on initialize

### DIFF
--- a/spacy/pipeline/attributeruler.py
+++ b/spacy/pipeline/attributeruler.py
@@ -53,8 +53,16 @@ class AttributeRuler(Pipe):
         self.name = name
         self.vocab = vocab
         self.matcher = Matcher(self.vocab, validate=validate)
+        self.validate = validate
         self.attrs = []
         self._attrs_unnormed = []  # store for reference
+        self.indices = []
+
+    def clear(self) -> None:
+        """Reset all patterns."""
+        self.matcher = Matcher(self.vocab, validate=self.validate)
+        self.attrs = []
+        self._attrs_unnormed = []
         self.indices = []
 
     def initialize(
@@ -65,13 +73,14 @@ class AttributeRuler(Pipe):
         patterns: Optional[Iterable[AttributeRulerPatternType]] = None,
         tag_map: Optional[TagMapType] = None,
         morph_rules: Optional[MorphRulesType] = None,
-    ):
+    ) -> None:
         """Initialize the attribute ruler by adding zero or more patterns.
 
         Rules can be specified as a sequence of dicts using the `patterns`
         keyword argument. You can also provide rules using the "tag map" or
         "morph rules" formats supported by spaCy prior to v3.
         """
+        self.clear()
         if patterns:
             self.add_patterns(patterns)
         if tag_map:

--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -201,9 +201,9 @@ class EntityRuler(Pipe):
 
         DOCS: https://nightly.spacy.io/api/entityruler#initialize
         """
+        self.clear()
         if patterns:
             self.add_patterns(patterns)
-
 
     @property
     def ent_ids(self) -> Tuple[str, ...]:

--- a/spacy/tests/pipeline/test_attributeruler.py
+++ b/spacy/tests/pipeline/test_attributeruler.py
@@ -136,6 +136,16 @@ def test_attributeruler_init_patterns(nlp, pattern_dicts):
     assert doc.has_annotation("MORPH")
 
 
+def test_attributeruler_init_clear(nlp, pattern_dicts):
+    """Test that initialization clears patterns."""
+    ruler = nlp.add_pipe("attribute_ruler")
+    assert not len(ruler.matcher)
+    ruler.add_patterns(pattern_dicts)
+    assert len(ruler.matcher)
+    ruler.initialize(lambda: [])
+    assert not len(ruler.matcher)
+
+
 def test_attributeruler_score(nlp, pattern_dicts):
     # initialize with patterns
     ruler = nlp.add_pipe("attribute_ruler")

--- a/spacy/tests/pipeline/test_entity_ruler.py
+++ b/spacy/tests/pipeline/test_entity_ruler.py
@@ -68,6 +68,15 @@ def test_entity_ruler_init_patterns(nlp, patterns):
     assert doc.ents[1].label_ == "BYE"
 
 
+def test_entity_ruler_init_clear(nlp, patterns):
+    """Test that initialization clears patterns."""
+    ruler = nlp.add_pipe("entity_ruler")
+    ruler.add_patterns(patterns)
+    assert len(ruler.labels) == 4
+    ruler.initialize(lambda: [])
+    assert len(ruler.labels) == 0
+
+
 def test_entity_ruler_existing(nlp, patterns):
     ruler = nlp.add_pipe("entity_ruler")
     ruler.add_patterns(patterns)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Just like the model weights, `initialize` should also reset rule-based components and start with a blank component that's then initialized with the data. Otherwise, you can end up with pretty confusing results.

### Types of change
fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
