### PR TITLE
Fix morph in Doc.to_json

### DIFF
--- a/spacy/tests/doc/test_to_json.py
+++ b/spacy/tests/doc/test_to_json.py
@@ -10,8 +10,16 @@ def doc(en_vocab):
     heads = [0, 0, 0]
     deps = ["ROOT", "dobj", "dobj"]
     ents = ["O", "B-ORG", "O"]
+    morphs = ["Feat1=A", "Feat1=B", "Feat1=A|Feat2=D"]
     return Doc(
-        en_vocab, words=words, pos=pos, tags=tags, heads=heads, deps=deps, ents=ents
+        en_vocab,
+        words=words,
+        pos=pos,
+        tags=tags,
+        heads=heads,
+        deps=deps,
+        ents=ents,
+        morphs=morphs,
     )
 
 

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -1398,8 +1398,6 @@ cdef class Doc:
         attributes. Attribute values need to be JSON-serializable. Values will
         be added to an "_" key in the data, e.g. "_": {"foo": "bar"}.
         RETURNS (dict): The data in spaCy's JSON format.
-
-        DOCS: https://nightly.spacy.io/api/doc#to_json
         """
         data = {"text": self.text}
         if self.has_annotation("ENT_IOB"):
@@ -1421,7 +1419,7 @@ cdef class Doc:
             if include_annotation["POS"]:
                 token_data["pos"] = token.pos_
             if include_annotation["MORPH"]:
-                token_data["morph"] = token.morph_
+                token_data["morph"] = token.morph
             if include_annotation["LEMMA"]:
                 token_data["lemma"] = token.lemma_
             if include_annotation["DEP"]:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

The method is mostly internals at the moment (I think because we weren't sure whether we wanted it like this?) but I've been using it in the Streamlit integration. This fixes the integration of `Token.morph`.

### Types of change
bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
