### PR TITLE
Bugfix in disabled context manager

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -457,7 +457,7 @@ class Errors:
 
     # TODO: fix numbering after merging develop into master
     E900 = ("Could not run the full 'nlp' pipeline for evaluation. If you specified "
-            "frozen components, make sure they were already trained and initialized. ")
+            "frozen components, make sure they were already initialized and trained. ")
     E901 = ("Failed to remove existing output directory: {path}. If your "
             "config and the components you train change between runs, a "
             "non-empty output directory can lead to stale pipeline data. To "

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -457,8 +457,7 @@ class Errors:
 
     # TODO: fix numbering after merging develop into master
     E900 = ("Could not run the full 'nlp' pipeline for evaluation. If you specified "
-            "frozen components, make sure they were already trained and initialized. "
-            "You can also consider moving them to the 'disabled' list instead.")
+            "frozen components, make sure they were already trained and initialized. ")
     E901 = ("Failed to remove existing output directory: {path}. If your "
             "config and the components you train change between runs, a "
             "non-empty output directory can lead to stale pipeline data. To "

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -456,6 +456,9 @@ class Errors:
             "issue tracker: http://github.com/explosion/spaCy/issues")
 
     # TODO: fix numbering after merging develop into master
+    E900 = ("Could not run the full 'nlp' pipeline for evaluation. If you specified "
+            "frozen components, make sure they were already trained and initialized. "
+            "You can also consider moving them to the 'disabled' list instead.")
     E901 = ("Failed to remove existing output directory: {path}. If your "
             "config and the components you train change between runs, a "
             "non-empty output directory can lead to stale pipeline data. To "

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1034,6 +1034,9 @@ class Language:
                     )
                 )
             disable = to_disable
+        # DisabledPipes will restore the pipes in 'disable' when it's done, so we need to exclude
+        # those pipes that were already disabled.
+        disable = [d for d in disable if d not in self._disabled]
         return DisabledPipes(self, disable)
 
     def make_doc(self, text: str) -> Doc:

--- a/spacy/tests/pipeline/test_pipe_methods.py
+++ b/spacy/tests/pipeline/test_pipe_methods.py
@@ -129,11 +129,25 @@ def test_enable_pipes_method(nlp, name):
 
 @pytest.mark.parametrize("name", ["my_component"])
 def test_disable_pipes_context(nlp, name):
+    """Test that an enabled component stays enabled after running the context manager."""
     nlp.add_pipe("new_pipe", name=name)
     assert nlp.has_pipe(name)
     with nlp.select_pipes(disable=name):
         assert not nlp.has_pipe(name)
     assert nlp.has_pipe(name)
+
+
+@pytest.mark.parametrize("name", ["my_component"])
+def test_disable_pipes_context_restore(nlp, name):
+    """Test that a disabled component stays disabled after running the context manager."""
+    nlp.add_pipe("new_pipe", name=name)
+    assert nlp.has_pipe(name)
+    nlp.disable_pipes(name)
+    assert not nlp.has_pipe(name)
+    with nlp.select_pipes(disable=name):
+        assert not nlp.has_pipe(name)
+    assert not nlp.has_pipe(name)
+
 
 
 def test_select_pipes_list_arg(nlp):

--- a/spacy/tests/pipeline/test_pipe_methods.py
+++ b/spacy/tests/pipeline/test_pipe_methods.py
@@ -149,7 +149,6 @@ def test_disable_pipes_context_restore(nlp, name):
     assert not nlp.has_pipe(name)
 
 
-
 def test_select_pipes_list_arg(nlp):
     for name in ["c1", "c2", "c3"]:
         nlp.add_pipe("new_pipe", name=name)

--- a/spacy/training/loop.py
+++ b/spacy/training/loop.py
@@ -249,7 +249,10 @@ def create_evaluation_callback(
 
     def evaluate() -> Tuple[float, Dict[str, float]]:
         dev_examples = list(dev_corpus(nlp))
-        scores = nlp.evaluate(dev_examples)
+        try:
+            scores = nlp.evaluate(dev_examples)
+        except KeyError as e:
+            raise KeyError(Errors.E900) from e
         # Calculate a weighted sum based on score_weights for the main score.
         # We can only consider scores that are ints/floats, not dicts like
         # entity scores per type etc.


### PR DESCRIPTION

## Description
If you had a pipeline with the tagger disabled, and you would run the context manager `with nlp.select_pipes` to disable the tagger (again), the tagger would actually be enabled when the context manager exists. This is fixed by ensuring that `DisabledPipes` only gets pipes that are currently enabled.

This actually came up when your config would define a component both as "disabled" as well as "frozen". Temporarily disabling it as "frozen" would actually result it being enabled again for evaluation etc. 

Cf also new unit test.

Also added a UX warning about non-initialized frozen components, inspired by Issue #6226.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
