### PR TITLE
sync parser labels in _resize

### DIFF
--- a/spacy/pipeline/transition_parser.pyx
+++ b/spacy/pipeline/transition_parser.pyx
@@ -120,7 +120,6 @@ cdef class Parser(TrainablePipe):
                 resized = True
         if resized:
             self._resize()
-            self.add_string(label)
             return 1
         return 0
 
@@ -130,6 +129,9 @@ cdef class Parser(TrainablePipe):
             self._rehearsal_model.attrs["resize_output"](
                 self._rehearsal_model, self.moves.n_moves
             )
+        self._added_strings = set()
+        for label in self.labels:
+            self.add_string(label)
 
     def add_multitask_objective(self, target):
         # Defined in subclasses, to avoid circular import

--- a/spacy/tests/parser/test_ner.py
+++ b/spacy/tests/parser/test_ner.py
@@ -321,6 +321,7 @@ def test_overfitting_IO():
     assert len(ents) == 1
     assert ents[0].text == "London"
     assert ents[0].label_ == "LOC"
+    assert ner._added_strings == {"LOC", "PERSON"}
 
     # Also test the results are still the same after IO
     with make_tempdir() as tmp_dir:
@@ -331,6 +332,8 @@ def test_overfitting_IO():
         assert len(ents2) == 1
         assert ents2[0].text == "London"
         assert ents2[0].label_ == "LOC"
+        ner2 = nlp2.get_pipe("ner")
+        assert ner2._added_strings == {"LOC", "PERSON"}
 
 
 def test_ner_warns_no_lookups(caplog):

--- a/spacy/tests/parser/test_parse.py
+++ b/spacy/tests/parser/test_parse.py
@@ -202,6 +202,9 @@ def test_overfitting_IO():
     assert doc[0].dep_ == "nsubj"
     assert doc[2].dep_ == "dobj"
     assert doc[3].dep_ == "punct"
+    assert parser._added_strings == {"dep", "dobj", "cc", "nsubj", "compound", "punct", "conj", "nmod", "ROOT"}
+
+
     # Also test the results are still the same after IO
     with make_tempdir() as tmp_dir:
         nlp.to_disk(tmp_dir)
@@ -210,3 +213,5 @@ def test_overfitting_IO():
         assert doc2[0].dep_ == "nsubj"
         assert doc2[2].dep_ == "dobj"
         assert doc2[3].dep_ == "punct"
+        parser2 = nlp2.get_pipe("parser")
+        assert parser2._added_strings == {"dep", "dobj", "cc", "nsubj", "compound", "punct", "conj", "nmod", "ROOT"}

--- a/spacy/tests/parser/test_parse.py
+++ b/spacy/tests/parser/test_parse.py
@@ -202,8 +202,17 @@ def test_overfitting_IO():
     assert doc[0].dep_ == "nsubj"
     assert doc[2].dep_ == "dobj"
     assert doc[3].dep_ == "punct"
-    assert parser._added_strings == {"dep", "dobj", "cc", "nsubj", "compound", "punct", "conj", "nmod", "ROOT"}
-
+    assert parser._added_strings == {
+        "dep",
+        "dobj",
+        "cc",
+        "nsubj",
+        "compound",
+        "punct",
+        "conj",
+        "nmod",
+        "ROOT",
+    }
 
     # Also test the results are still the same after IO
     with make_tempdir() as tmp_dir:
@@ -214,4 +223,14 @@ def test_overfitting_IO():
         assert doc2[2].dep_ == "dobj"
         assert doc2[3].dep_ == "punct"
         parser2 = nlp2.get_pipe("parser")
-        assert parser2._added_strings == {"dep", "dobj", "cc", "nsubj", "compound", "punct", "conj", "nmod", "ROOT"}
+        assert parser2._added_strings == {
+            "dep",
+            "dobj",
+            "cc",
+            "nsubj",
+            "compound",
+            "punct",
+            "conj",
+            "nmod",
+            "ROOT",
+        }


### PR DESCRIPTION

## Description
Ensure that parser labels are properly synced in `self._added_strings`, also when they are defined in `initialize`.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
