### PR TITLE
Avoid dropout at runtime

### DIFF
--- a/spacy/about.py
+++ b/spacy/about.py
@@ -1,6 +1,6 @@
 # fmt: off
 __title__ = "spacy-nightly"
-__version__ = "3.0.0a40"
+__version__ = "3.0.0a41"
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"
 __projects__ = "https://github.com/explosion/projects"


### PR DESCRIPTION

## Description
Avoid applying the dropout at runtime.

I'll add more unit tests in Thinc & spaCy in a follow-up PR, but this version (3.0.0a41) could already be used to restart the model training, if we want (otherwise we also have to build a new thinc etc)

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
