### PR TITLE
Limit pydantic pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pathy
 numpy>=1.15.0
 requests>=2.13.0,<3.0.0
 tqdm>=4.38.0,<5.0.0
-pydantic>=1.5.0,<2.0.0
+pydantic>=1.5.0,<1.7.0
 pytokenizations
 # Official Python utilities
 setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     tqdm>=4.38.0,<5.0.0
     numpy>=1.15.0
     requests>=2.13.0,<3.0.0
-    pydantic>=1.5.0,<2.0.0
+    pydantic>=1.5.0,<1.7.0
     pytokenizations
     jinja2
     # Official Python utilities


### PR DESCRIPTION
## Description
We get a
```
RuntimeError: no validator found for <class 'spacy.tokens.span.Span'>, see `arbitrary_types_allowed` in Config
```
with Pydantic 1.7, which was released today. I couldn't find the culprit immediately, so let's pin the upper version as a temporary hot fix. See also https://github.com/explosion/thinc/pull/413 which is being released as v8.0.0rc1 (which should, in practice, already sufficiently limit the pydantic version during a spaCy install)

### Types of change
hot fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
