### PR TITLE
Fix pretrain

### DIFF
--- a/spacy/training/pretrain.py
+++ b/spacy/training/pretrain.py
@@ -17,7 +17,7 @@ from ..ml.models.multi_task import build_cloze_multi_task_model
 from ..ml.models.multi_task import build_cloze_characters_multi_task_model
 from ..schemas import ConfigSchemaTraining, ConfigSchemaPretrain
 from ..errors import Errors
-from ..util import registry, load_model_from_config, dot_to_object
+from ..util import registry, load_model_from_config, resolve_dot_names
 
 
 def pretrain(
@@ -38,7 +38,7 @@ def pretrain(
     _config = nlp.config.interpolate()
     T = registry.resolve(_config["training"], schema=ConfigSchemaTraining)
     P = registry.resolve(_config["pretraining"], schema=ConfigSchemaPretrain)
-    corpus = dot_to_object(T, P["corpus"])
+    corpus = resolve_dot_names(_config, [P["corpus"]])[0]
     batcher = P["batcher"]
     model = create_pretraining_model(nlp, P)
     optimizer = P["optimizer"]


### PR DESCRIPTION
## Description
The dot notation of the pretraining corpus was not resolved correctly anymore. It was looking for `corpora.pretrain` only in `_config["training"]` instead of in the whole ` _config`.

Fixes #6325

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
