### PR TITLE
Fix textcat + transformer architecture

### DIFF
--- a/spacy/cli/templates/quickstart_training.jinja
+++ b/spacy/cli/templates/quickstart_training.jinja
@@ -143,6 +143,9 @@ nO = null
 @architectures = "spacy-transformers.TransformerListener.v1"
 grad_factor = 1.0
 
+[components.textcat.model.tok2vec.pooling]
+@layers = "reduce_mean.v1"
+
 [components.textcat.model.linear_model]
 @architectures = "spacy.TextCatBOW.v1"
 exclusive_classes = false

--- a/spacy/ml/models/textcat.py
+++ b/spacy/ml/models/textcat.py
@@ -61,14 +61,14 @@ def build_bow_text_classifier(
 
 
 @registry.architectures.register("spacy.TextCatEnsemble.v2")
-def build_text_classifier(
+def build_text_classifier_v2(
     tok2vec: Model[List[Doc], List[Floats2d]],
     linear_model: Model[List[Doc], Floats2d],
     nO: Optional[int] = None,
 ) -> Model[List[Doc], Floats2d]:
     exclusive_classes = not linear_model.attrs["multi_label"]
     with Model.define_operators({">>": chain, "|": concatenate}):
-        width = tok2vec.get_dim("nO")
+        width = tok2vec.maybe_get_dim("nO")
         cnn_model = (
                 tok2vec
                 >> list2ragged()
@@ -94,7 +94,7 @@ def build_text_classifier(
 
 # TODO: move to legacy
 @registry.architectures.register("spacy.TextCatEnsemble.v1")
-def build_text_classifier(
+def build_text_classifier_v1(
     width: int,
     embed_size: int,
     pretrained_vectors: Optional[bool],


### PR DESCRIPTION
Fixes #6340

## Description

- Add `pooling` argument to the `textcat`'s `tok2vec` layer when using a `Transformer`
- Allow `width` to  be `None` when building `spacy.TextCatEnsemble.v2`

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
