### PR TITLE
Allow binarized vectors to save memory

### DIFF
--- a/.github/contributors/forgetso.md
+++ b/.github/contributors/forgetso.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI GmbH](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [X] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           |Chris Taylor          |
+| Company name (if applicable)   |                      |
+| Title or role (if applicable)  |                      |
+| Date                           |2020-11-11            |
+| GitHub username                |forgetso              |
+| Website (optional)             |                      |

--- a/spacy/lexeme.pyx
+++ b/spacy/lexeme.pyx
@@ -133,7 +133,26 @@ cdef class Lexeme:
             return 0.0
         vector = self.vector
         xp = get_array_module(vector)
-        return (xp.dot(vector, other.vector) / (self.vector_norm * other.vector_norm))
+        return self._similarity()(xp, vector, other)
+
+    def _similarity(self):
+        sim_fn = self._similarity_float
+        if self.vocab.vectors_dtype == numpy.int8:
+            sim_fn = self._similarity_binary
+        return sim_fn
+
+    def _similarity_float(self, xp, vector, other):
+        """Calculate cosine similarity."""
+        return xp.dot(vector, other.vector) / (self.vector_norm * other.vector_norm)
+
+    def _similarity_binary(self, xp, vec1, other):
+        """Calculate Sokal Michener similarity."""
+        vec2 = other.vector
+        ntt = xp.dot(vec1, vec2.T)
+        ntf = xp.dot(vec1, 1 - vec2.T)
+        nff = xp.dot((1.0 - vec1), (1.0 - vec2.T))
+        nft = xp.dot((1.0 - vec1), vec2.T)
+        return (ntt + nff) / (ntt + ntf + nff + nft)
 
     @property
     def has_vector(self):

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -343,7 +343,26 @@ cdef class Span:
             return 0.0
         vector = self.vector
         xp = get_array_module(vector)
+        return self._similarity()(xp, vector, other)
+
+    def _similarity(self):
+        sim_fn = self._similarity_float
+        if self.vocab.vectors_dtype == numpy.int8:
+            sim_fn = self._similarity_binary
+        return sim_fn
+
+    def _similarity_float(self, xp, vector, other):
+        """Calculate cosine similarity."""
         return xp.dot(vector, other.vector) / (self.vector_norm * other.vector_norm)
+
+    def _similarity_binary(self, xp, vec1, other):
+        """Calculate Sokal Michener similarity."""
+        vec2 = other.vector
+        ntt = xp.dot(vec1, vec2.T)
+        ntf = xp.dot(vec1, 1 - vec2.T)
+        nff = xp.dot((1.0 - vec1), (1.0 - vec2.T))
+        nft = xp.dot((1.0 - vec1), vec2.T)
+        return (ntt + nff) / (ntt + ntf + nff + nft)
 
     cpdef np.ndarray to_array(self, object py_attr_ids):
         """Given a list of M attribute IDs, export the tokens to a numpy
@@ -456,7 +475,7 @@ cdef class Span:
             return self.doc.user_span_hooks["vector"](self)
         if self._vector is None:
             self._vector = sum(t.vector for t in self) / len(self)
-        return self._vector
+        return self._vector.astype(self.vocab.vectors_dtype)
 
     @property
     def vector_norm(self):

--- a/spacy/tokens/token.pyx
+++ b/spacy/tokens/token.pyx
@@ -218,7 +218,27 @@ cdef class Token:
             return 0.0
         vector = self.vector
         xp = get_array_module(vector)
-        return (xp.dot(vector, other.vector) / (self.vector_norm * other.vector_norm))
+        return self._similarity()(xp, vector, other)
+
+    def _similarity(self):
+        sim_fn = self._similarity_float
+        if self.vocab.vectors_dtype == numpy.int8:
+            sim_fn = self._similarity_binary
+        return sim_fn
+
+    def _similarity_float(self, xp, vector, other):
+        """Calculate cosine similarity."""
+        return xp.dot(vector, other.vector) / (self.vector_norm * other.vector_norm)
+
+    def _similarity_binary(self, xp, vec1, other):
+        """Calculate Sokal Michener similarity."""
+        vec2 = other.vector
+        ntt = xp.dot(vec1, vec2.T)
+        ntf = xp.dot(vec1, 1 - vec2.T)
+        nff = xp.dot((1.0 - vec1), (1.0 - vec2.T))
+        nft = xp.dot((1.0 - vec1), vec2.T)
+        return (ntt + nff) / (ntt + ntf + nff + nft)
+
 
     @property
     def morph(self):

--- a/spacy/vocab.pyx
+++ b/spacy/vocab.pyx
@@ -276,17 +276,21 @@ cdef class Vocab:
     def vectors_length(self):
         return self.vectors.data.shape[1]
 
-    def reset_vectors(self, *, width=None, shape=None):
+    @property
+    def vectors_dtype(self):
+        return self.vectors.data.dtype
+
+    def reset_vectors(self, *, width=None, shape=None, dtype=None):
         """Drop the current vector table. Because all vectors must be the same
         width, you have to call this to change the size of the vectors.
         """
         if width is not None and shape is not None:
             raise ValueError(Errors.E065.format(width=width, shape=shape))
         elif shape is not None:
-            self.vectors = Vectors(shape=shape)
+            self.vectors = Vectors(shape=shape, dtype=dtype)
         else:
             width = width if width is not None else self.vectors.data.shape[1]
-            self.vectors = Vectors(shape=(self.vectors.shape[0], width))
+            self.vectors = Vectors(shape=(self.vectors.shape[0], width), dtype=dtype)
 
     def prune_vectors(self, nr_row, batch_size=1024):
         """Reduce the current vector table to `nr_row` unique entries. Words
@@ -367,7 +371,7 @@ cdef class Vocab:
         if maxn is None:
             maxn = len(word)
         xp = get_array_module(self.vectors.data)
-        vectors = xp.zeros((self.vectors_length,), dtype="f")
+        vectors = xp.zeros((self.vectors_length,), dtype=self.vectors_dtype)
         # Fasttext's ngram computation taken from
         # https://github.com/facebookresearch/fastText
         ngrams_size = 0;


### PR DESCRIPTION
## Description
It is possible to binarize existing word embeddings so that they use 37.5 times less memory and perform a top-k query 30 times faster (See [Near-lossless Binarization of Word Embeddings](https://arxiv.org/pdf/1803.09065.pdf)). spaCy should be able to init models and perform most_similar calculations using binary vectors. This pull request enables spaCy to do this by checking the data type of vectors during init-model and by using an appropriate similarity function in most_similar.

### Types of change
Enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [X] I have submitted the spaCy Contributor Agreement.
- [X] I ran the tests, and all new and existing tests passed.
- [X] My changes don't require a change to the documentation, or if they do, I've added all required information.
