### PR TITLE
Update REL example in docs

### DIFF
--- a/website/docs/usage/layers-architectures.md
+++ b/website/docs/usage/layers-architectures.md
@@ -728,7 +728,7 @@ are within a **maximum distance** (in number of tokens) of eachother:
 > ```
 
 ```python
-### Candiate generation
+### Candidate generation
 @spacy.registry.misc.register("rel_instance_generator.v1")
 def create_instances(max_length: int) -> Callable[[Doc], List[Tuple[Span, Span]]]:
     def get_candidates(doc: "Doc") -> List[Tuple[Span, Span]]:

--- a/website/docs/usage/layers-architectures.md
+++ b/website/docs/usage/layers-architectures.md
@@ -567,10 +567,10 @@ def create_relation_model(...) -> Model[List[Doc], Floats2d]:
     return model
 ```
 
-We will adapt a **modular approach** to the definition of this relation model,
-and define it as chaining two layers together: the first layer that generates an
+We adapt a **modular approach** to the definition of this relation model, and
+define it as chaining two layers together: the first layer that generates an
 instance tensor from a given set of documents, and the second layer that
-transforms the instance tensor into a final tensor holding the predictions.
+transforms the instance tensor into a final tensor holding the predictions:
 
 > #### config.cfg (excerpt)
 >
@@ -586,7 +586,7 @@ transforms the instance tensor into a final tensor holding the predictions.
 > ```
 
 ```python
-### The model architecture
+### The model architecture {highlight="6"}
 @spacy.registry.architectures.register("rel_model.v1")
 def create_relation_model(
     create_instance_tensor: Model[List[Doc], Floats2d],
@@ -596,8 +596,9 @@ def create_relation_model(
     return model
 ```
 
-The `classification_layer` could be something like a Linear layer followed by a
-logistic activation function:
+The `classification_layer` could be something like a
+[Linear](https://thinc.ai/docs/api-layers#linear) layer followed by a
+[logistic](https://thinc.ai/docs/api-layers#logistic) activation function:
 
 > #### config.cfg (excerpt)
 >
@@ -748,16 +749,6 @@ generation function.
 
 #### Intermezzo: define how to store the relations data {#component-rel-attribute}
 
-For our new relation extraction component, we will use a custom
-[extension attribute](/usage/processing-pipelines#custom-components-attributes)
-`doc._.rel` in which we store relation data. The attribute refers to a
-dictionary, keyed by the **start offsets of each entity** involved in the
-candidate relation. The values in the dictionary refer to another dictionary
-where relation labels are mapped to values between 0 and 1. We assume anything
-above 0.5 to be a `True` relation. The ~~Example~~ instances that we'll use as
-training data, will include their gold-standard relation annotations in
-`example.reference._.rel`.
-
 > #### Example output
 >
 > ```python
@@ -770,6 +761,16 @@ training data, will include their gold-standard relation annotations in
 > # (0, 6): {'CAPITAL_OF': 0.89, 'LOCATED_IN': 0.75, 'UNRELATED': 0.002}
 > # (6, 0): {'CAPITAL_OF': 0.01, 'LOCATED_IN': 0.13, 'UNRELATED': 0.017}
 > ```
+
+For our new relation extraction component, we will use a custom
+[extension attribute](/usage/processing-pipelines#custom-components-attributes)
+`doc._.rel` in which we store relation data. The attribute refers to a
+dictionary, keyed by the **start offsets of each entity** involved in the
+candidate relation. The values in the dictionary refer to another dictionary
+where relation labels are mapped to values between 0 and 1. We assume anything
+above 0.5 to be a `True` relation. The ~~Example~~ instances that we'll use as
+training data, will include their gold-standard relation annotations in
+`example.reference._.rel`.
 
 ```python
 ### Registering the extension attribute
@@ -817,11 +818,11 @@ class RelationExtractor(TrainablePipe):
         ...
 ```
 
-Typically, the constructor defines the vocab, the Machine Learning model, and
-the name of this component. Additionally, this component, just like the
-`textcat` and the `tagger`, stores an internal list of labels. The ML model will
-predict scores for each label. We add convenience method to easily retrieve and
-add to them.
+Typically, the **constructor** defines the vocab, the Machine Learning model,
+and the name of this component. Additionally, this component, just like the
+`textcat` and the `tagger`, stores an **internal list of labels**. The ML model
+will predict scores for each label. We add convenience methods to easily
+retrieve and add to them.
 
 ```python
     def __init__(self, vocab, model, name="rel"):
@@ -1002,7 +1003,6 @@ assigns it a name and lets you create the component with
 > [components.relation_extractor.model]
 > @architectures = "rel_model.v1"
 > # ...
->
 >
 > [training.score_weights]
 > rel_micro_p = 0.0

--- a/website/docs/usage/layers-architectures.md
+++ b/website/docs/usage/layers-architectures.md
@@ -534,9 +534,14 @@ steps required:
    machine learning model that sets annotations on the [`Doc`](/api/doc) passing
    through the pipeline.
 
-<!-- TODO: <Project id="tutorials/ner-relations">
-
-</Project> -->
+<Project id="tutorials/rel_component">
+Run this example use-case by using our project template. It includes all the 
+code to create the ML model and the pipeline component from scratch.
+It contains two config files to train the model: 
+one to run on CPU with a Tok2Vec layer, and one for the GPU using a transformer.
+The project applies the relation extraction component to identify biomolecular 
+interactions, but you can easily swap in your own dataset for your experiments.
+</Project>
 
 #### Step 1: Implementing the Model {#component-rel-model}
 
@@ -924,6 +929,11 @@ def make_relation_extractor(nlp, name, model):
     return RelationExtractor(nlp.vocab, model, name)
 ```
 
-<!-- TODO: <Project id="tutorials/ner-relations">
-
-</Project> -->
+<Project id="tutorials/rel_component">
+Run this example use-case by using our project template. It includes all the 
+code to create the ML model and the pipeline component from scratch.
+It contains two config files to train the model: 
+one to run on CPU with a Tok2Vec layer, and one for the GPU using a transformer.
+The project applies the relation extraction component to identify biomolecular 
+interactions, but you can easily swap in your own dataset for your experiments.
+</Project>

--- a/website/docs/usage/layers-architectures.md
+++ b/website/docs/usage/layers-architectures.md
@@ -644,7 +644,6 @@ that has the full implementation.
 >
 > [model.create_instance_tensor.get_instances]
 > # ...
-> `
 > ```
 
 ```python
@@ -666,7 +665,7 @@ def create_tensors(
     )
 
 
-### The custom forward function
+# The custom forward function
 def instance_forward(
     model: Model[List[Doc], Floats2d],
     docs: List[Doc],
@@ -686,7 +685,7 @@ def instance_forward(
     return relations, backprop
 
 
-### The custom initialization method
+# The custom initialization method
 def instance_init(
     model: Model,
     X: List[Doc] = None,
@@ -712,6 +711,13 @@ several
 [built-in pooling operators](https://thinc.ai/docs/api-layers#reduction-ops) for
 this purpose.
 
+Finally, we need a `get_instances` method that **generates pairs of entities**
+that we want to classify as being related or not. As these candidate pairs are
+typically formed within one document, this function takes a [`Doc`](/api/doc) as
+input and outputs a `List` of `Span` tuples. For instance, the following
+implementation takes any two entities from the same document, as long as they
+are within a **maximum distance** (in number of tokens) of eachother:
+
 > #### config.cfg (excerpt)
 >
 > ```ini
@@ -721,17 +727,10 @@ this purpose.
 > max_length = 100
 > ```
 
-Finally, we need a `get_instances` method that **generates pairs of entities**
-that we want to classify as being related or not. As these candidate pairs are
-typically formed within one document, this function takes a [`Doc`](/api/doc) as
-input and outputs a `List` of `Span` tuples. For instance, the following
-implementation takes any two entities from the same document, as long as they
-are within a **maximum distance** (in number of tokens) of eachother:
-
 ```python
 ### Candiate generation
 @spacy.registry.misc.register("rel_instance_generator.v1")
-def create_candidate_indices(max_length: int) -> Callable[[Doc], List[Tuple[Span, Span]]]:
+def create_instances(max_length: int) -> Callable[[Doc], List[Tuple[Span, Span]]]:
     def get_candidates(doc: "Doc") -> List[Tuple[Span, Span]]:
         candidates = []
         for ent1 in doc.ents:
@@ -825,6 +824,7 @@ will predict scores for each label. We add convenience methods to easily
 retrieve and add to them.
 
 ```python
+### The constructor (continued) 
     def __init__(self, vocab, model, name="rel"):
         """Create a component instance."""
         # ...


### PR DESCRIPTION
## Description 
Updating the REL documentation section and syncing it with the latest code from https://github.com/explosion/projects/tree/v3/tutorials/rel_component

I'm not in favor of directly showing the actual code from the project repo, as sometimes I simplified the code a little to avoid clutter and focus on the main parts. I also really like the current way of showing the implementation in the main body of the docs and the corresponding config section on the right.

### Types of change
docs update

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
