### PR TITLE
Add specific error when StaticVectors can't read the vectors data

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -456,6 +456,9 @@ class Errors:
             "issue tracker: http://github.com/explosion/spaCy/issues")
 
     # TODO: fix numbering after merging develop into master
+    E896 = ("There was an error using the static vectors. Ensure that the vectors "
+            "of the vocab are properly initialized, or set 'include_static_vectors' "
+            "to False.")
     E897 = ("Field '{field}' should be a dot-notation string referring to the "
             "relevant section in the config, but found type {type} instead.")
     E898 = ("Can't serialize trainable pipe '{name}': the `model` attribute "

--- a/spacy/ml/staticvectors.py
+++ b/spacy/ml/staticvectors.py
@@ -42,9 +42,13 @@ def forward(
     rows = model.ops.flatten(
         [doc.vocab.vectors.find(keys=doc.to_array(key_attr)) for doc in docs]
     )
+    try:
+        vectors_data = model.ops.gemm(model.ops.as_contig(V[rows]), W, trans2=True)
+    except ValueError:
+        raise RuntimeError(Errors.E896)
     output = Ragged(
-        model.ops.gemm(model.ops.as_contig(V[rows]), W, trans2=True),
-        model.ops.asarray([len(doc) for doc in docs], dtype="i"),
+        vectors_data,
+        model.ops.asarray([len(doc) for doc in docs], dtype="i")
     )
     mask = None
     if is_train:

--- a/spacy/training/initialize.py
+++ b/spacy/training/initialize.py
@@ -103,7 +103,7 @@ def load_vectors_into_model(
             "with the packaged vectors. Make sure that the vectors package you're "
             "loading is compatible with the current version of spaCy."
         )
-        err = ConfigValidationError.from_error(e, config=None, title=title, desc=desc)
+        err = ConfigValidationError.from_error(e, title=title, desc=desc)
         raise err from None
     nlp.vocab.vectors = vectors_nlp.vocab.vectors
     if add_strings:


### PR DESCRIPTION

## Description
Catch an error that occurs when using `StaticVectors` without initializing the vectors in the vocab properly. Thinc throws a "_Buffer and memoryview are not contiguous in the same dimension_" `ValueError` which is a bit confusing ;-)

& small fix removing an non-existing argument from a `ConfigValidationError.from_error` call.

### Types of change
UX enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
