### PR TITLE
Fix  parser resizing when there is no upper layer

### DIFF
--- a/spacy/cli/templates/quickstart_training.jinja
+++ b/spacy/cli/templates/quickstart_training.jinja
@@ -74,7 +74,7 @@ grad_factor = 1.0
 factory = "parser"
 
 [components.parser.model]
-@architectures = "spacy.TransitionBasedParser.v1"
+@architectures = "spacy.TransitionBasedParser.v2"
 state_type = "parser"
 extra_state_tokens = false
 hidden_width = 128
@@ -95,7 +95,7 @@ grad_factor = 1.0
 factory = "ner"
 
 [components.ner.model]
-@architectures = "spacy.TransitionBasedParser.v1"
+@architectures = "spacy.TransitionBasedParser.v2"
 state_type = "ner"
 extra_state_tokens = false
 hidden_width = 64
@@ -225,7 +225,7 @@ width = ${components.tok2vec.model.encode.width}
 factory = "parser"
 
 [components.parser.model]
-@architectures = "spacy.TransitionBasedParser.v1"
+@architectures = "spacy.TransitionBasedParser.v2"
 state_type = "parser"
 extra_state_tokens = false
 hidden_width = 128
@@ -243,7 +243,7 @@ width = ${components.tok2vec.model.encode.width}
 factory = "ner"
 
 [components.ner.model]
-@architectures = "spacy.TransitionBasedParser.v1"
+@architectures = "spacy.TransitionBasedParser.v2"
 state_type = "ner"
 extra_state_tokens = false
 hidden_width = 64

--- a/spacy/ml/models/parser.py
+++ b/spacy/ml/models/parser.py
@@ -17,7 +17,7 @@ def build_tb_parser_model(
     extra_state_tokens: bool,
     hidden_width: int,
     maxout_pieces: int,
-    use_upper: bool = True,
+    use_upper: bool,
     nO: Optional[int] = None,
 ) -> Model:
     """
@@ -72,16 +72,101 @@ def build_tb_parser_model(
     t2v_width = tok2vec.get_dim("nO") if tok2vec.has_dim("nO") else None
     tok2vec = chain(tok2vec, list2array(), Linear(hidden_width, t2v_width))
     tok2vec.set_dim("nO", hidden_width)
-    lower = PrecomputableAffine(
+    lower = _define_lower(
         nO=hidden_width if use_upper else nO,
         nF=nr_feature_tokens,
         nI=tok2vec.get_dim("nO"),
         nP=maxout_pieces,
     )
+    upper = None
     if use_upper:
         with use_ops("numpy"):
             # Initialize weights at zero, as it's a classification layer.
-            upper = Linear(nO=nO, init_W=zero_init)
-    else:
-        upper = None
-    return TransitionModel(tok2vec, lower, upper)
+            upper = _define_upper(nO=nO, nI=None)
+    return TransitionModel(tok2vec, lower, upper, resize_output)
+
+
+def _define_upper(nO, nI):
+    return Linear(nO=nO, init_W=zero_init)
+
+
+def _define_lower(nO, nF, nI, nP):
+    return PrecomputableAffine(nO=nO, nF=nF, nI=nI, nP=nP)
+
+
+def resize_output(model, new_nO):
+    if model.attrs["has_upper"]:
+        return _resize_upper(model, new_nO)
+    return _resize_lower(model, new_nO)
+
+
+def _resize_upper(model, new_nO):
+    upper = model.get_ref("upper")
+
+    if upper.has_dim("nO") is None:
+        upper.set_dim("nO", new_nO)
+        return model
+    elif new_nO == upper.get_dim("nO"):
+        return model
+
+    smaller = upper
+    nI = smaller.maybe_get_dim("nI")
+    with use_ops("numpy"):
+        larger = _define_upper(nO=new_nO, nI=nI)
+    # it could be that the model is not initialized yet, then skip this bit
+    if smaller.has_param("W"):
+        larger_W = larger.ops.alloc2f(new_nO, nI)
+        larger_b = larger.ops.alloc1f(new_nO)
+        smaller_W = smaller.get_param("W")
+        smaller_b = smaller.get_param("b")
+        # Weights are stored in (nr_out, nr_in) format, so we're basically
+        # just adding rows here.
+        if smaller.has_dim("nO"):
+            old_nO = smaller.get_dim("nO")
+            larger_W[: old_nO] = smaller_W
+            larger_b[: old_nO] = smaller_b
+            for i in range(old_nO, new_nO):
+                model.attrs["unseen_classes"].add(i)
+
+        larger.set_param("W", larger_W)
+        larger.set_param("b", larger_b)
+    model._layers[-1] = larger
+    model.set_ref("upper", larger)
+    return model
+
+
+def _resize_lower(model, new_nO):
+    lower = model.get_ref("lower")
+    if lower.has_dim("nO") is None:
+        lower.set_dim("nO", new_nO)
+        return model
+
+    smaller = lower
+    nI = smaller.maybe_get_dim("nI")
+    nF = smaller.maybe_get_dim("nF")
+    nP = smaller.maybe_get_dim("nP")
+    with use_ops("numpy"):
+        larger = _define_lower(nO=new_nO, nI=nI, nF=nF, nP=nP)
+    # it could be that the model is not initialized yet, then skip this bit
+    if smaller.has_param("W"):
+        larger_W = larger.ops.alloc4f(nF, new_nO, nP, nI)
+        larger_b = larger.ops.alloc2f(new_nO, nP)
+        larger_pad = larger.ops.alloc4f(1, nF, new_nO, nP)
+        smaller_W = smaller.get_param("W")
+        smaller_b = smaller.get_param("b")
+        smaller_pad = smaller.get_param("pad")
+        # Copy the old weights and padding into the new layer
+        if smaller.has_dim("nO"):
+            old_nO = smaller.get_dim("nO")
+            larger_W[:, 0:old_nO, :, :] = smaller_W
+            larger_pad[:, :, 0:old_nO, :] = smaller_pad
+            larger_b[0:old_nO, :] = smaller_b
+            for i in range(old_nO, new_nO):
+                model.attrs["unseen_classes"].add(i)
+
+        larger.set_param("W", larger_W)
+        larger.set_param("b", larger_b)
+        larger.set_param("pad", larger_pad)
+    model._layers[1] = larger
+    model.set_ref("lower", larger)
+    return model

--- a/spacy/ml/models/parser.py
+++ b/spacy/ml/models/parser.py
@@ -11,6 +11,46 @@ from ...tokens import Doc
 
 
 @registry.architectures.register("spacy.TransitionBasedParser.v1")
+def transition_parser_v1(
+    tok2vec: Model[List[Doc], List[Floats2d]],
+    state_type: Literal["parser", "ner"],
+    extra_state_tokens: bool,
+    hidden_width: int,
+    maxout_pieces: int,
+    use_upper: bool = True,
+    nO: Optional[int] = None,
+) -> Model:
+    return build_tb_parser_model(
+    tok2vec,
+    state_type,
+    extra_state_tokens,
+    hidden_width,
+    maxout_pieces,
+    use_upper,
+    nO,
+)
+
+
+@registry.architectures.register("spacy.TransitionBasedParser.v2")
+def transition_parser_v2(
+    tok2vec: Model[List[Doc], List[Floats2d]],
+    state_type: Literal["parser", "ner"],
+    extra_state_tokens: bool,
+    hidden_width: int,
+    maxout_pieces: int,
+    use_upper: bool,
+    nO: Optional[int] = None,
+) -> Model:
+    return build_tb_parser_model(
+    tok2vec,
+    state_type,
+    extra_state_tokens,
+    hidden_width,
+    maxout_pieces,
+    use_upper,
+    nO,
+)
+
 def build_tb_parser_model(
     tok2vec: Model[List[Doc], List[Floats2d]],
     state_type: Literal["parser", "ner"],
@@ -102,7 +142,6 @@ def resize_output(model, new_nO):
 
 def _resize_upper(model, new_nO):
     upper = model.get_ref("upper")
-
     if upper.has_dim("nO") is None:
         upper.set_dim("nO", new_nO)
         return model

--- a/spacy/ml/models/parser.py
+++ b/spacy/ml/models/parser.py
@@ -127,7 +127,7 @@ def build_tb_parser_model(
 
 
 def _define_upper(nO, nI):
-    return Linear(nO=nO, init_W=zero_init)
+    return Linear(nO=nO, nI=nI, init_W=zero_init)
 
 
 def _define_lower(nO, nF, nI, nP):

--- a/spacy/ml/tb_framework.py
+++ b/spacy/ml/tb_framework.py
@@ -2,7 +2,7 @@ from thinc.api import Model, noop, use_ops, Linear
 from .parser_model import ParserStepModel
 
 
-def TransitionModel(tok2vec, lower, upper, dropout=0.2, unseen_classes=set()):
+def TransitionModel(tok2vec, lower, upper, resize_output, dropout=0.2, unseen_classes=set()):
     """Set up a stepwise transition-based model"""
     if upper is None:
         has_upper = False
@@ -45,42 +45,3 @@ def init(model, X=None, Y=None):
         statevecs = model.ops.alloc2f(2, lower.get_dim("nO"))
         model.get_ref("upper").initialize(X=statevecs)
 
-
-def resize_output(model, new_nO):
-    lower = model.get_ref("lower")
-    upper = model.get_ref("upper")
-    if not model.attrs["has_upper"]:
-        if lower.has_dim("nO") is None:
-            lower.set_dim("nO", new_nO)
-        return
-    elif upper.has_dim("nO") is None:
-        upper.set_dim("nO", new_nO)
-        return
-    elif new_nO == upper.get_dim("nO"):
-        return
-    smaller = upper
-    nI = None
-    if smaller.has_dim("nI"):
-        nI = smaller.get_dim("nI")
-    with use_ops("numpy"):
-        larger = Linear(nO=new_nO, nI=nI)
-        larger.init = smaller.init
-    # it could be that the model is not initialized yet, then skip this bit
-    if nI:
-        larger_W = larger.ops.alloc2f(new_nO, nI)
-        larger_b = larger.ops.alloc1f(new_nO)
-        smaller_W = smaller.get_param("W")
-        smaller_b = smaller.get_param("b")
-        # Weights are stored in (nr_out, nr_in) format, so we're basically
-        # just adding rows here.
-        if smaller.has_dim("nO"):
-            larger_W[: smaller.get_dim("nO")] = smaller_W
-            larger_b[: smaller.get_dim("nO")] = smaller_b
-            for i in range(smaller.get_dim("nO"), new_nO):
-                model.attrs["unseen_classes"].add(i)
-
-        larger.set_param("W", larger_W)
-        larger.set_param("b", larger_b)
-    model._layers[-1] = larger
-    model.set_ref("upper", larger)
-    return model

--- a/spacy/pipeline/dep_parser.pyx
+++ b/spacy/pipeline/dep_parser.pyx
@@ -14,11 +14,12 @@ from ..training import validate_examples
 
 default_model_config = """
 [model]
-@architectures = "spacy.TransitionBasedParser.v1"
+@architectures = "spacy.TransitionBasedParser.v2"
 state_type = "parser"
 extra_state_tokens = false
 hidden_width = 64
 maxout_pieces = 2
+use_upper = true
 
 [model.tok2vec]
 @architectures = "spacy.HashEmbedCNN.v1"

--- a/spacy/pipeline/ner.pyx
+++ b/spacy/pipeline/ner.pyx
@@ -17,6 +17,7 @@ state_type = "ner"
 extra_state_tokens = false
 hidden_width = 64
 maxout_pieces = 2
+use_upper = true
 
 [model.tok2vec]
 @architectures = "spacy.HashEmbedCNN.v1"

--- a/spacy/pipeline/ner.pyx
+++ b/spacy/pipeline/ner.pyx
@@ -12,7 +12,7 @@ from ..training import validate_examples
 
 default_model_config = """
 [model]
-@architectures = "spacy.TransitionBasedParser.v1"
+@architectures = "spacy.TransitionBasedParser.v2"
 state_type = "ner"
 extra_state_tokens = false
 hidden_width = 64

--- a/spacy/tests/serialize/test_serialize_config.py
+++ b/spacy/tests/serialize/test_serialize_config.py
@@ -66,7 +66,7 @@ width = ${components.tok2vec.model.width}
 
 parser_config_string_upper = """
 [model]
-@architectures = "spacy.TransitionBasedParser.v1"
+@architectures = "spacy.TransitionBasedParser.v2"
 state_type = "parser"
 extra_state_tokens = false
 hidden_width = 66
@@ -87,7 +87,7 @@ subword_features = false
 
 parser_config_string_no_upper = """
 [model]
-@architectures = "spacy.TransitionBasedParser.v1"
+@architectures = "spacy.TransitionBasedParser.v2"
 state_type = "parser"
 extra_state_tokens = false
 hidden_width = 66

--- a/website/docs/api/architectures.md
+++ b/website/docs/api/architectures.md
@@ -427,17 +427,18 @@ one component.
 
 ## Parser & NER architectures {#parser}
 
-### spacy.TransitionBasedParser.v1 {#TransitionBasedParser source="spacy/ml/models/parser.py"}
+### spacy.TransitionBasedParser.v2 {#TransitionBasedParser source="spacy/ml/models/parser.py"}
 
 > #### Example Config
 >
 > ```ini
 > [model]
-> @architectures = "spacy.TransitionBasedParser.v1"
+> @architectures = "spacy.TransitionBasedParser.v2"
 > state_type = "ner"
 > extra_state_tokens = false
 > hidden_width = 64
 > maxout_pieces = 2
+> use_upper = true
 >
 > [model.tok2vec]
 > @architectures = "spacy.HashEmbedCNN.v1"


### PR DESCRIPTION

## Description
Our pretrained models would usually have `use_upper=True` for the `TransitionBasedParser`, but the new transformer models have `use_upper=False`. In this latter case, it seems like there was a bug when trying to resize the parser. For instance, this would fail:
```
    import spacy
    import os

    nlp = spacy.load("en_core_web_trf")
    ner = nlp.get_pipe('ner')
    ner.add_label("FRIENDS")
    ner.add_label("LOC")
    nlp("Test sentence")

    output_dir = "test_dir"
    os.mkdir(output_dir)
    nlp.to_disk(output_dir)
    model = spacy.load(output_dir)
```
as reported in https://stackoverflow.com/questions/64968313/error-loading-trained-en-core-web-trf-spacyv3-ner-model.

The reason seems to be this bit of code in `resize_output`:
```
if not model.attrs["has_upper"]:
    if lower.has_dim("nO") is None:
        lower.set_dim("nO", new_nO)
    return
```
-> No attempt is made to create a new, resized `lower` layer and substitute that in the network, as is being done for the `upper` layer.

### This PR
- Removes the default value `True` for `use_upper` in `spacy.TransitionBasedParser.v1`
- Bumps the version to `spacy.TransitionBasedParser.v2` because technically existing configs may break otherwise
- Moves the resizing into the definition of `TransitionBasedParser` in `parser.py`, because `TransitionModel` theoretically can't know what kind of `lower`/`upper` layer it should create to substitute with.
- Builds an appropriate larger layer to replace the `lower` layer when `model.attrs["has_upper"]` is `False` --> cf new `_resize_lower` function
- Extends existing unit checks to ensure the structure and content of the trained ML model are consistent after the resizing

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
