### PR TITLE
Small fix for config resolving when pretraining

### DIFF
--- a/spacy/training/pretrain.py
+++ b/spacy/training/pretrain.py
@@ -17,7 +17,7 @@ from ..ml.models.multi_task import build_cloze_multi_task_model
 from ..ml.models.multi_task import build_cloze_characters_multi_task_model
 from ..schemas import ConfigSchemaTraining, ConfigSchemaPretrain
 from ..errors import Errors
-from ..util import registry, load_model_from_config, resolve_dot_names
+from ..util import registry, load_model_from_config, dot_to_object
 
 
 def pretrain(
@@ -38,7 +38,8 @@ def pretrain(
     _config = nlp.config.interpolate()
     T = registry.resolve(_config["training"], schema=ConfigSchemaTraining)
     P = registry.resolve(_config["pretraining"], schema=ConfigSchemaPretrain)
-    corpus = resolve_dot_names(_config, [P["corpus"]])[0]
+    corpus = dot_to_object(_config, P["corpus"])
+    corpus = registry.resolve({"corpus": corpus})["corpus"]
     batcher = P["batcher"]
     model = create_pretraining_model(nlp, P)
     optimizer = P["optimizer"]


### PR DESCRIPTION
##  Description
Avoid resolving the full config to get the pretraining corpus, because that would mean you'd already have to fill in the paths to `dev` and `train` datasets, which you don't necessarily have yet at the moment of pretraining.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
