### PR TITLE
Bugfix multi-label textcat reproducibility

### DIFF
--- a/spacy/ml/extract_ngrams.py
+++ b/spacy/ml/extract_ngrams.py
@@ -23,9 +23,6 @@ def forward(model: Model, docs, is_train: bool):
         keys, vals = model.ops.xp.unique(keys, return_counts=True)
         batch_keys.append(keys)
         batch_vals.append(vals)
-    # The dtype here matches what thinc is expecting -- which differs per
-    # platform (by int definition). This should be fixed once the problem
-    # is fixed on Thinc's side.
     lengths = model.ops.asarray([arr.shape[0] for arr in batch_keys], dtype="int32")
     batch_keys = model.ops.xp.concatenate(batch_keys)
     batch_vals = model.ops.asarray(model.ops.xp.concatenate(batch_vals), dtype="f")

--- a/spacy/ml/extract_ngrams.py
+++ b/spacy/ml/extract_ngrams.py
@@ -26,7 +26,7 @@ def forward(model: Model, docs, is_train: bool):
     # The dtype here matches what thinc is expecting -- which differs per
     # platform (by int definition). This should be fixed once the problem
     # is fixed on Thinc's side.
-    lengths = model.ops.asarray([arr.shape[0] for arr in batch_keys], dtype=numpy.int_)
+    lengths = model.ops.asarray([arr.shape[0] for arr in batch_keys], dtype="int32")
     batch_keys = model.ops.xp.concatenate(batch_keys)
     batch_vals = model.ops.asarray(model.ops.xp.concatenate(batch_vals), dtype="f")
 

--- a/spacy/tests/pipeline/test_textcat.py
+++ b/spacy/tests/pipeline/test_textcat.py
@@ -135,7 +135,7 @@ def test_initialize_examples():
 
 
 def test_overfitting_IO():
-    # Simple test to try and quickly overfit the textcat component - ensuring the ML models work correctly
+    # Simple test to try and quickly overfit the single-label textcat component - ensuring the ML models work correctly
     fix_random_seed(0)
     nlp = English()
     nlp.config["initialize"]["components"]["textcat"] = {"positive_label": "POSITIVE"}
@@ -177,15 +177,15 @@ def test_overfitting_IO():
 
     # Make sure that running pipe twice, or comparing to call, always amounts to the same predictions
     texts = ["Just a sentence.", "I like green eggs.", "I am happy.", "I eat ham."]
-    batch_deps_1 = [doc.cats for doc in nlp.pipe(texts)]
-    batch_deps_2 = [doc.cats for doc in nlp.pipe(texts)]
-    no_batch_deps = [doc.cats for doc in [nlp(text) for text in texts]]
-    assert_equal(batch_deps_1, batch_deps_2)
-    assert_equal(batch_deps_1, no_batch_deps)
+    batch_cats_1 = [doc.cats for doc in nlp.pipe(texts)]
+    batch_cats_2 = [doc.cats for doc in nlp.pipe(texts)]
+    no_batch_cats = [doc.cats for doc in [nlp(text) for text in texts]]
+    assert_equal(batch_cats_1, batch_cats_2)
+    assert_equal(batch_cats_1, no_batch_cats)
 
 
 def test_overfitting_IO_multi():
-    # Simple test to try and quickly overfit the textcat component - ensuring the ML models work correctly
+    # Simple test to try and quickly overfit the multi-label textcat component - ensuring the ML models work correctly
     fix_random_seed(0)
     nlp = English()
     # Set exclusive labels to False
@@ -224,11 +224,11 @@ def test_overfitting_IO_multi():
 
     # Make sure that running pipe twice, or comparing to call, always amounts to the same predictions
     texts = ["Just a sentence.", "I like green eggs.", "I am happy.", "I eat ham."]
-    batch_deps_1 = [doc.cats for doc in nlp.pipe(texts)]
-    batch_deps_2 = [doc.cats for doc in nlp.pipe(texts)]
-    no_batch_deps = [doc.cats for doc in [nlp(text) for text in texts]]
-    assert_equal(batch_deps_1, batch_deps_2)
-    assert_equal(batch_deps_1, no_batch_deps)
+    batch_cats_1 = [doc.cats for doc in nlp.pipe(texts)]
+    batch_cats_2 = [doc.cats for doc in nlp.pipe(texts)]
+    no_batch_cats = [doc.cats for doc in [nlp(text) for text in texts]]
+    assert_equal(batch_cats_1, batch_cats_2)
+    assert_equal(batch_cats_1, no_batch_cats)
 
 
 # fmt: off

--- a/spacy/tests/pipeline/test_textcat.py
+++ b/spacy/tests/pipeline/test_textcat.py
@@ -188,8 +188,7 @@ def test_overfitting_IO_multi():
     # Simple test to try and quickly overfit the textcat component - ensuring the ML models work correctly
     fix_random_seed(0)
     nlp = English()
-    nlp.config["initialize"]["components"]["textcat"] = {"positive_label": "POSITIVE"}
-    # Set exclusive labels
+    # Set exclusive labels to False
     config = {"model": {"linear_model": {"exclusive_classes": False}}}
     textcat = nlp.add_pipe("textcat", config=config)
     train_examples = []

--- a/spacy/tests/pipeline/test_textcat.py
+++ b/spacy/tests/pipeline/test_textcat.py
@@ -184,6 +184,54 @@ def test_overfitting_IO():
     assert_equal(batch_deps_1, no_batch_deps)
 
 
+def test_overfitting_IO_multi():
+    # Simple test to try and quickly overfit the textcat component - ensuring the ML models work correctly
+    fix_random_seed(0)
+    nlp = English()
+    nlp.config["initialize"]["components"]["textcat"] = {"positive_label": "POSITIVE"}
+    # Set exclusive labels
+    config = {"model": {"linear_model": {"exclusive_classes": False}}}
+    textcat = nlp.add_pipe("textcat", config=config)
+    train_examples = []
+    for text, annotations in TRAIN_DATA:
+        train_examples.append(Example.from_dict(nlp.make_doc(text), annotations))
+    optimizer = nlp.initialize(get_examples=lambda: train_examples)
+    assert textcat.model.get_dim("nO") == 2
+
+    for i in range(50):
+        losses = {}
+        nlp.update(train_examples, sgd=optimizer, losses=losses)
+    assert losses["textcat"] < 0.01
+
+    # test the trained model
+    test_text = "I am happy."
+    doc = nlp(test_text)
+    cats = doc.cats
+    assert cats["POSITIVE"] > 0.9
+
+    # Also test the results are still the same after IO
+    with make_tempdir() as tmp_dir:
+        nlp.to_disk(tmp_dir)
+        nlp2 = util.load_model_from_path(tmp_dir)
+        doc2 = nlp2(test_text)
+        cats2 = doc2.cats
+        assert cats2["POSITIVE"] > 0.9
+
+    # Test scoring
+    scores = nlp.evaluate(train_examples)
+    assert scores["cats_micro_f"] == 1.0
+    assert scores["cats_score"] == 1.0
+    assert "cats_score_desc" in scores
+
+    # Make sure that running pipe twice, or comparing to call, always amounts to the same predictions
+    texts = ["Just a sentence.", "I like green eggs.", "I am happy.", "I eat ham."]
+    batch_deps_1 = [doc.cats for doc in nlp.pipe(texts)]
+    batch_deps_2 = [doc.cats for doc in nlp.pipe(texts)]
+    no_batch_deps = [doc.cats for doc in [nlp(text) for text in texts]]
+    assert_equal(batch_deps_1, batch_deps_2)
+    assert_equal(batch_deps_1, no_batch_deps)
+
+
 # fmt: off
 @pytest.mark.parametrize(
     "textcat_config",


### PR DESCRIPTION
Fixing a small little bug that took quite a bit of time to find, but required only one word to fix :-)

## Description
The `textcat` architecture `with_cpu(extract_ngrams>>sparse_linear)>>...` had a problem: `extract_ngrams` would create a `lengths` array with `dtype=numpy.int_` that would later on be [interpreted](https://github.com/explosion/thinc/blob/master/thinc/layers/sparselinear.pyx#L76) as an array with `int32` values. However, on MacOS & Unix, `numpy.int_` resolves to `int64`.

As a result, [this loop](https://github.com/explosion/thinc/blob/master/thinc/layers/sparselinear.pyx#L118) would not read the proper lengths, and ultimately the wrong scores would be passed forward. I think this got compensated by other parts of the neural network, but you could see the difference in predictions when comparing `nlp.pipe(texts)` to `[nlp(text) for text in texts]` - all predictions except for the first text would be slightly different. I'm not sure how much of an influence this bug has been on textcat performances on Linux. When I was running benchmarks [earlier](https://github.com/explosion/spaCy/pull/6263), I ran them on Windows so I guess I got lucky ;-) 

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
