### PR TITLE
JapaneseTokenizer.pipe added

### DIFF
--- a/spacy/lang/ja/__init__.py
+++ b/spacy/lang/ja/__init__.py
@@ -223,10 +223,6 @@ class JapaneseTokenizer(DummyTokenizer):
     def _set_config(self, config={}):
         self.split_mode = config.get("split_mode", None)
 
-    def pipe(self, texts, batch_size=1000, n_threads=-1):
-        for text in texts:
-            yield self(text)
-
     def to_bytes(self, **kwargs):
         serializers = OrderedDict(
             (

--- a/spacy/lang/ja/__init__.py
+++ b/spacy/lang/ja/__init__.py
@@ -223,6 +223,10 @@ class JapaneseTokenizer(DummyTokenizer):
     def _set_config(self, config={}):
         self.split_mode = config.get("split_mode", None)
 
+    def pipe(self, texts, batch_size=1000, n_threads=-1):
+        for text in texts:
+            yield self(text)
+
     def to_bytes(self, **kwargs):
         serializers = OrderedDict(
             (

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -838,6 +838,13 @@ class SimpleFrozenDict(dict):
 
 
 class DummyTokenizer(object):
+    def __call__(self, text):
+        raise NotImplementedError
+
+    def pipe(self, texts, **kwargs):
+        for text in texts:
+            yield self(text)
+
     # add dummy methods for to_bytes, from_bytes, to_disk and from_disk to
     # allow serialization (see #1557)
     def to_bytes(self, **kwargs):


### PR DESCRIPTION
## Description
For [spacymoji](https://spacy.io/universe/project/spacymoji)  with `Japanese()`.

### Types of change
To use JapaneseTokenizer.pipe as same as Tokenizer.pipe

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ ] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
