### PR TITLE
returning config in init_config

### DIFF
--- a/spacy/cli/init_config.py
+++ b/spacy/cli/init_config.py
@@ -45,7 +45,7 @@ def init_config_cli(
     if isinstance(optimize, Optimizations):  # instance of enum from the CLI
         optimize = optimize.value
     pipeline = string_to_list(pipeline)
-    init_config(
+    config = init_config(
         output_file,
         lang=lang,
         pipeline=pipeline,
@@ -53,6 +53,8 @@ def init_config_cli(
         cpu=cpu,
         pretraining=pretraining,
     )
+    is_stdout = str(output_file) == "-"
+    save_config(config, output_file, is_stdout=is_stdout)
 
 
 @init_cli.command("fill-config")
@@ -125,7 +127,7 @@ def init_config(
     optimize: str,
     cpu: bool,
     pretraining: bool = False,
-) -> None:
+) -> Config:
     is_stdout = str(output_file) == "-"
     msg = Printer(no_print=is_stdout)
     with TEMPLATE_PATH.open("r") as f:
@@ -173,7 +175,7 @@ def init_config(
             pretrain_config = util.load_config(DEFAULT_CONFIG_PRETRAIN_PATH)
             config = pretrain_config.merge(config)
     msg.good("Auto-filled config with all values")
-    save_config(config, output_file, is_stdout=is_stdout)
+    return config
 
 
 def save_config(

--- a/spacy/cli/init_config.py
+++ b/spacy/cli/init_config.py
@@ -45,15 +45,15 @@ def init_config_cli(
     if isinstance(optimize, Optimizations):  # instance of enum from the CLI
         optimize = optimize.value
     pipeline = string_to_list(pipeline)
+    is_stdout = str(output_file) == "-"
     config = init_config(
-        output_file,
         lang=lang,
         pipeline=pipeline,
         optimize=optimize,
         cpu=cpu,
         pretraining=pretraining,
+        silent=is_stdout,
     )
-    is_stdout = str(output_file) == "-"
     save_config(config, output_file, is_stdout=is_stdout)
 
 
@@ -120,16 +120,15 @@ def fill_config(
 
 
 def init_config(
-    output_file: Path,
     *,
     lang: str,
     pipeline: List[str],
     optimize: str,
     cpu: bool,
     pretraining: bool = False,
+    silent: bool = True,
 ) -> Config:
-    is_stdout = str(output_file) == "-"
-    msg = Printer(no_print=is_stdout)
+    msg = Printer(no_print=silent)
     with TEMPLATE_PATH.open("r") as f:
         template = Template(f.read())
     # Filter out duplicates since tok2vec and transformer are added by template

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -368,7 +368,7 @@ def test_parse_cli_overrides():
 @pytest.mark.parametrize("optimize", ["efficiency", "accuracy"])
 def test_init_config(lang, pipeline, optimize):
     # TODO: add more tests and also check for GPU with transformers
-    config = init_config("-", lang=lang, pipeline=pipeline, optimize=optimize, cpu=True)
+    config = init_config(lang=lang, pipeline=pipeline, optimize=optimize, cpu=True)
     assert isinstance(config, Config)
 
 

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -8,7 +8,7 @@ from spacy.cli.init_config import init_config, RECOMMENDATIONS
 from spacy.cli._util import validate_project_commands, parse_config_overrides
 from spacy.cli._util import load_project_config, substitute_project_variables
 from spacy.cli._util import string_to_list
-from thinc.api import ConfigValidationError
+from thinc.api import ConfigValidationError, Config
 import srsly
 import os
 
@@ -368,7 +368,8 @@ def test_parse_cli_overrides():
 @pytest.mark.parametrize("optimize", ["efficiency", "accuracy"])
 def test_init_config(lang, pipeline, optimize):
     # TODO: add more tests and also check for GPU with transformers
-    init_config("-", lang=lang, pipeline=pipeline, optimize=optimize, cpu=True)
+    config = init_config("-", lang=lang, pipeline=pipeline, optimize=optimize, cpu=True)
+    assert isinstance(config, Config)
 
 
 def test_model_recommendations():


### PR DESCRIPTION
## Description
Very small edit making `init_config` return the `Config` instead of calling `save_config` itself. Allows for more modularity if other scripts wish to create a new config file (but not necessarily save it)

### Types of change
enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
