### PR TITLE
Prevent root logger from initialising

### DIFF
--- a/spacy/util.py
+++ b/spacy/util.py
@@ -67,8 +67,10 @@ CONFIG_SECTION_ORDER = ["paths", "variables", "system", "nlp", "components", "co
 # fmt: on
 
 
-logging.basicConfig(format="%(message)s")
 logger = logging.getLogger("spacy")
+logger_stream_handler = logging.StreamHandler()
+logger_stream_handler.setFormatter(logging.Formatter('%(message)s'))
+logger.addHandler(logger_stream_handler)
 
 
 class ENV_VARS:


### PR DESCRIPTION
The root logger is initialised in v3 of spaCy when the format is set, this causes repeated logging messages in other applications that import spacy. Instead the spacy logger should should be initialised with the correct formatting.

The below is an example which causes this issue:

```
import spacy
import logging

logger = logging.getLogger('example_package')

ch = logging.StreamHandler()
ch.setFormatter(logging.Formatter("EXAMPLE: %(message)s"))
logger.addHandler(ch)

logger.error('hello')
```

This produces:
```
EXAMPLE: hello
hello
```

Instead of simply:
```
EXAMPLE: hello
```

The changes produce the same logging messages within spacy, but prevent it from changing the output of other packages when spacy is imported.

Let me know if you need anything further to merge this, thanks for a great package!

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
