### PR TITLE
docs: fix simple typo, speficied -> specified

### DIFF
--- a/spacy/cli/info.py
+++ b/spacy/cli/info.py
@@ -20,7 +20,7 @@ from .. import about
 def info(model=None, markdown=False, silent=False):
     """
     Print info about spaCy installation. If a model shortcut link is
-    speficied as an argument, print model information. Flag --markdown
+    specified as an argument, print model information. Flag --markdown
     prints details in Markdown for easy copy-pasting to GitHub issues.
     """
     if model:


### PR DESCRIPTION
There is a small typo in spacy/cli/info.py.

Should read `specified` rather than `speficied`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md