### PR TITLE
remove cause without apostrophe from norm exceptions

### DIFF
--- a/spacy/lang/en/tokenizer_exceptions.py
+++ b/spacy/lang/en/tokenizer_exceptions.py
@@ -319,7 +319,6 @@ for exc_data in [
 # Other contractions with leading apostrophe
 
 for exc_data in [
-    {ORTH: "cause", NORM: "because"},
     {ORTH: "em", LEMMA: PRON_LEMMA, NORM: "them"},
     {ORTH: "ll", LEMMA: "will", NORM: "will"},
     {ORTH: "nuff", LEMMA: "enough", NORM: "enough"},

--- a/spacy/tests/lang/en/test_exceptions.py
+++ b/spacy/tests/lang/en/test_exceptions.py
@@ -111,7 +111,15 @@ def test_en_tokenizer_handles_times(en_tokenizer, text):
 
 
 @pytest.mark.parametrize(
-    "text,norms", [("I'm", ["i", "am"]), ("shan't", ["shall", "not"])]
+    "text,norms",
+    [
+        ("I'm", ["i", "am"]),
+        ("shan't", ["shall", "not"]),
+        (
+            "Many factors cause cancer 'cause it is complex",
+            ["many", "factors", "cause", "cancer", "because", "it", "is", "complex"],
+        ),
+    ],
 )
 def test_en_tokenizer_norm_exceptions(en_tokenizer, text, norms):
     tokens = en_tokenizer(text)


### PR DESCRIPTION
Fixes #6624 

## Description
Removing `cause` from norm exceptions so it's not normalized to `because` if there is no leading apostrophe. The case with the leading apostrophe (with and without capitalization) was already present in the file around L422. Added test for both cases.

### Types of change
bug fix / enhancement in English tokenizer

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
