### PR TITLE
Update tokenizer_exceptions.py

### DIFF
--- a/spacy/lang/es/tokenizer_exceptions.py
+++ b/spacy/lang/es/tokenizer_exceptions.py
@@ -22,7 +22,6 @@ for exc_data in [
     {ORTH: "Uds.", LEMMA: PRON_LEMMA, NORM: "ustedes"},
     {ORTH: "Vds.", LEMMA: PRON_LEMMA, NORM: "ustedes"},
     {ORTH: "vol.", NORM: "volúmen"},
-
 ]:
     _exc[exc_data[ORTH]] = [exc_data]
 
@@ -51,6 +50,7 @@ for orth in [
     "Dr.",
     "Dra.",
     "EE.UU.",
+    "EE. UU.",
     "etc.",
     "fig.",
     "Gob.",


### PR DESCRIPTION
`EE.UU.` (meaing "USA") is already a tokenizer exception for Spanish.  Now we're adding `EE. UU.` with a space.

## Description
This variant is also common, for example in Wikipedia and as the output of Google Translate.

### Types of change
Enhancement

## Checklist

- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
