### PR TITLE
Update tokenizer_exceptions.py

### DIFF
--- a/spacy/lang/es/tokenizer_exceptions.py
+++ b/spacy/lang/es/tokenizer_exceptions.py
@@ -52,8 +52,8 @@ for orth in [
     "Dra.",
     "EE.UU.",
     "Ee.Uu.",
-    "UU.", # For "EE. UU."
-    "Uu.", # For "Ee. Uu."
+    "EE. UU.",
+    "Ee. Uu.",
     "etc.",
     "fig.",
     "Gob.",

--- a/spacy/lang/es/tokenizer_exceptions.py
+++ b/spacy/lang/es/tokenizer_exceptions.py
@@ -51,6 +51,9 @@ for orth in [
     "Dr.",
     "Dra.",
     "EE.UU.",
+    "Ee.Uu.",
+    "UU.", # For "EE. UU."
+    "Uu.", # For "Ee. Uu."
     "etc.",
     "fig.",
     "Gob.",
@@ -65,9 +68,11 @@ for orth in [
     "Prof.",
     "Profa.",
     "q.e.p.d.",
-    "Q.E.P.D." "S.A.",
+    "Q.E.P.D.",
+    "S.A.",
     "S.L.",
-    "S.R.L." "s.s.s.",
+    "S.R.L.",
+    "s.s.s.",
     "Sr.",
     "Sra.",
     "Srta.",


### PR DESCRIPTION
`EE.UU.` (meaning "USA") is already a tokenizer exception for Spanish.

Now we're adding `EE. UU.` with a space, and other variants.

## Description
This variant with the space is also common, for example in Wikipedia and as the output of Google Translate.

Spaces are not allowed in exceptions, so we just add the final subtoken.

I'm also fixing the missing commas, which is a nasty risk with Python.  (The strings get concatenated...)

### Types of change
Enhancement
Bug fix

## Checklist

- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
