### PR TITLE
prevent overwriting existing config file

### DIFF
--- a/spacy/cli/init_config.py
+++ b/spacy/cli/init_config.py
@@ -32,7 +32,7 @@ def init_config_cli(
     optimize: Optimizations = Opt(Optimizations.efficiency.value, "--optimize", "-o", help="Whether to optimize for efficiency (faster inference, smaller model, lower memory consumption) or higher accuracy (potentially larger and slower model). This will impact the choice of architecture, pretrained weights and related hyperparameters."),
     gpu: bool = Opt(False, "--gpu", "-G", help="Whether the model can run on GPU. This will impact the choice of architecture, pretrained weights and related hyperparameters."),
     pretraining: bool = Opt(False, "--pretraining", "-pt", help="Include config for pretraining (with 'spacy pretrain')"),
-    overwrite: bool = Opt(False, "--overwrite", "-W", help="Whether or not to overwrite the file if it already exists."),
+    force_overwrite: bool = Opt(False, "--force", "-F", help="Force overwriting the output file"),
     # fmt: on
 ):
     """
@@ -47,9 +47,12 @@ def init_config_cli(
         optimize = optimize.value
     pipeline = string_to_list(pipeline)
     is_stdout = str(output_file) == "-"
-    if not is_stdout and output_file.exists() and not overwrite:
-        msg = Printer(no_print=False)
-        msg.fail("The provided output file already exists. To overwrite, set the flag -W", exits=1)
+    if not is_stdout and output_file.exists() and not force_overwrite:
+        msg = Printer()
+        msg.fail(
+            "The provided output file already exists. To force overwriting the config file, set the --force or -F flag.",
+            exits=1,
+        )
     config = init_config(
         lang=lang,
         pipeline=pipeline,

--- a/spacy/cli/init_config.py
+++ b/spacy/cli/init_config.py
@@ -32,6 +32,7 @@ def init_config_cli(
     optimize: Optimizations = Opt(Optimizations.efficiency.value, "--optimize", "-o", help="Whether to optimize for efficiency (faster inference, smaller model, lower memory consumption) or higher accuracy (potentially larger and slower model). This will impact the choice of architecture, pretrained weights and related hyperparameters."),
     gpu: bool = Opt(False, "--gpu", "-G", help="Whether the model can run on GPU. This will impact the choice of architecture, pretrained weights and related hyperparameters."),
     pretraining: bool = Opt(False, "--pretraining", "-pt", help="Include config for pretraining (with 'spacy pretrain')"),
+    overwrite: bool = Opt(False, "--overwrite", "-W", help="Whether or not to overwrite the file if it already exists."),
     # fmt: on
 ):
     """
@@ -46,6 +47,9 @@ def init_config_cli(
         optimize = optimize.value
     pipeline = string_to_list(pipeline)
     is_stdout = str(output_file) == "-"
+    if not is_stdout and output_file.exists() and not overwrite:
+        msg = Printer(no_print=False)
+        msg.fail("The provided output file already exists. To overwrite, set the flag -W", exits=1)
     config = init_config(
         lang=lang,
         pipeline=pipeline,

--- a/website/docs/api/cli.md
+++ b/website/docs/api/cli.md
@@ -121,7 +121,7 @@ customize those settings in your config file later.
 > ```
 
 ```cli
-$ python -m spacy init config [output_file] [--lang] [--pipeline] [--optimize] [--gpu] [--pretraining]
+$ python -m spacy init config [output_file] [--lang] [--pipeline] [--optimize] [--gpu] [--pretraining] [--force]
 ```
 
 | Name                   | Description                                                                                                                                                                                                                                                                                                                        |
@@ -132,6 +132,7 @@ $ python -m spacy init config [output_file] [--lang] [--pipeline] [--optimize] [
 | `--optimize`, `-o`     | `"efficiency"` or `"accuracy"`. Whether to optimize for efficiency (faster inference, smaller model, lower memory consumption) or higher accuracy (potentially larger and slower model). This will impact the choice of architecture, pretrained weights and related hyperparameters. Defaults to `"efficiency"`. ~~str (option)~~ |
 | `--gpu`, `-G`          | Whether the model can run on GPU. This will impact the choice of architecture, pretrained weights and related hyperparameters. ~~bool (flag)~~                                                                                                                                                                                     |
 | `--pretraining`, `-pt` | Include config for pretraining (with [`spacy pretrain`](/api/cli#pretrain)). Defaults to `False`. ~~bool (flag)~~                                                                                                                                                                                                                  |
+| `--force`, `-f`        | Force overwriting the output file if it already exists. ~~bool (flag)~~                                                                                                                                                                                                                                                            |
 | `--help`, `-h`         | Show help message and available arguments. ~~bool (flag)~~                                                                                                                                                                                                                                                                         |
 | **CREATES**            | The config file for training.                                                                                                                                                                                                                                                                                                      |
 


### PR DESCRIPTION

## Description
- By default, don't overwrite an existing config file with `init config` (as this can be quite unfortunate)
- Allow overwriting with a `-W` flag

### Types of change
enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
