### PR TITLE
Fixing CLI info command

### DIFF
--- a/spacy/cli/info.py
+++ b/spacy/cli/info.py
@@ -19,7 +19,7 @@ def info_cli(
     # fmt: on
 ):
     """
-    Print info about spaCy installation. If a pipeline is speficied as an argument,
+    Print info about spaCy installation. If a pipeline is specified as an argument,
     print its meta information. Flag --markdown prints details in Markdown for easy
     copy-pasting to GitHub issues.
 

--- a/spacy/cli/info.py
+++ b/spacy/cli/info.py
@@ -1,10 +1,10 @@
-from typing import Optional, Dict, Any, Union
+from typing import Optional, Dict, Any, Union, List
 import platform
 from pathlib import Path
 from wasabi import Printer, MarkdownRenderer
 import srsly
 
-from ._util import app, Arg, Opt
+from ._util import app, Arg, Opt, string_to_list
 from .. import util
 from .. import about
 
@@ -15,6 +15,7 @@ def info_cli(
     model: Optional[str] = Arg(None, help="Optional loadable spaCy pipeline"),
     markdown: bool = Opt(False, "--markdown", "-md", help="Generate Markdown for GitHub issues"),
     silent: bool = Opt(False, "--silent", "-s", "-S", help="Don't print anything (just return)"),
+    exclude: Optional[str] = Opt("labels", "--exclude", "-e", help="Comma-separated keys to exclude from the print-out"),
     # fmt: on
 ):
     """
@@ -24,11 +25,12 @@ def info_cli(
 
     DOCS: https://nightly.spacy.io/api/cli#info
     """
-    info(model, markdown=markdown, silent=silent)
+    exclude = string_to_list(exclude)
+    info(model, markdown=markdown, silent=silent, exclude=exclude)
 
 
 def info(
-    model: Optional[str] = None, *, markdown: bool = False, silent: bool = True
+    model: Optional[str] = None, *, markdown: bool = False, silent: bool = True, exclude: List[str]
 ) -> Union[str, dict]:
     msg = Printer(no_print=silent, pretty=not silent)
     if model:
@@ -42,13 +44,13 @@ def info(
         data["Pipelines"] = ", ".join(
             f"{n} ({v})" for n, v in data["Pipelines"].items()
         )
-    markdown_data = get_markdown(data, title=title)
+    markdown_data = get_markdown(data, title=title, exclude=exclude)
     if markdown:
         if not silent:
             print(markdown_data)
         return markdown_data
     if not silent:
-        table_data = dict(data)
+        table_data = {k: v for k, v in data.items() if k not in exclude}
         msg.table(table_data, title=title)
     return raw_data
 
@@ -82,7 +84,7 @@ def info_model(model: str, *, silent: bool = True) -> Dict[str, Any]:
     if util.is_package(model):
         model_path = util.get_package_path(model)
     else:
-        model_path = model
+        model_path = Path(model)
     meta_path = model_path / "meta.json"
     if not meta_path.is_file():
         msg.fail("Can't find pipeline meta.json", meta_path, exits=1)
@@ -96,7 +98,7 @@ def info_model(model: str, *, silent: bool = True) -> Dict[str, Any]:
     }
 
 
-def get_markdown(data: Dict[str, Any], title: Optional[str] = None) -> str:
+def get_markdown(data: Dict[str, Any], title: Optional[str] = None, exclude: List[str] = None) -> str:
     """Get data in GitHub-flavoured Markdown format for issues etc.
 
     data (dict or list of tuples): Label/value pairs.
@@ -108,8 +110,16 @@ def get_markdown(data: Dict[str, Any], title: Optional[str] = None) -> str:
         md.add(md.title(2, title))
     items = []
     for key, value in data.items():
-        if isinstance(value, str) and Path(value).exists():
+        if exclude and key in exclude:
             continue
+        if isinstance(value, str):
+            try:
+                existing_path = Path(value).exists()
+            except:
+                # invalid Path, like a URL string
+                existing_path = False
+            if existing_path:
+                continue
         items.append(f"{md.bold(f'{key}:')} {value}")
     md.add(md.list(items))
     return f"\n{md.text}\n"

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -13,6 +13,19 @@ import srsly
 import os
 
 from .util import make_tempdir
+from .. import info
+from ..lang.nl import Dutch
+
+
+def test_cli_info():
+    nlp = Dutch()
+    nlp.add_pipe("textcat")
+    with make_tempdir() as tmp_dir:
+        nlp.to_disk(tmp_dir)
+        raw_data = info(tmp_dir, exclude=[""])
+        assert raw_data["lang"] == "nl"
+        assert raw_data["components"] == ["textcat"]
+        assert raw_data["source"] == str(tmp_dir)
 
 
 def test_cli_converters_conllu_to_docs():

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -3,7 +3,9 @@ from click import NoSuchOption
 from spacy.training import docs_to_json, offsets_to_biluo_tags
 from spacy.training.converters import iob_to_docs, conll_ner_to_docs, conllu_to_docs
 from spacy.schemas import ProjectConfigSchema, RecommendationSchema, validate
+from spacy.lang.nl import Dutch
 from spacy.util import ENV_VARS
+from spacy.cli import info
 from spacy.cli.init_config import init_config, RECOMMENDATIONS
 from spacy.cli._util import validate_project_commands, parse_config_overrides
 from spacy.cli._util import load_project_config, substitute_project_variables
@@ -13,8 +15,6 @@ import srsly
 import os
 
 from .util import make_tempdir
-from .. import info
-from ..lang.nl import Dutch
 
 
 def test_cli_info():

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -25,7 +25,6 @@ def test_cli_info():
         raw_data = info(tmp_dir, exclude=[""])
         assert raw_data["lang"] == "nl"
         assert raw_data["components"] == ["textcat"]
-        assert raw_data["source"] == str(tmp_dir)
 
 
 def test_cli_converters_conllu_to_docs():

--- a/website/docs/api/cli.md
+++ b/website/docs/api/cli.md
@@ -61,20 +61,27 @@ markup to copy-paste into
 [GitHub issues](https://github.com/explosion/spaCy/issues).
 
 ```cli
-$ python -m spacy info [--markdown] [--silent]
+$ python -m spacy info [--markdown] [--silent] [--exclude]
 ```
+
+> #### Example
+>
+> ```cli
+> $ python -m spacy info en_core_web_lg --markdown
+> ```
 
 ```cli
-$ python -m spacy info [model] [--markdown] [--silent]
+$ python -m spacy info [model] [--markdown] [--silent] [--exclude]
 ```
 
-| Name                                             | Description                                                                               |
-| ------------------------------------------------ | ----------------------------------------------------------------------------------------- |
-| `model`                                          | A trained pipeline, i.e. package name or path (optional). ~~Optional[str] \(positional)~~ |
-| `--markdown`, `-md`                              | Print information as Markdown. ~~bool (flag)~~                                            |
-| `--silent`, `-s` <Tag variant="new">2.0.12</Tag> | Don't print anything, just return the values. ~~bool (flag)~~                             |
-| `--help`, `-h`                                   | Show help message and available arguments. ~~bool (flag)~~                                |
-| **PRINTS**                                       | Information about your spaCy installation.                                                |
+| Name                                             | Description                                                                                   |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| `model`                                          | A trained pipeline, i.e. package name or path (optional). ~~Optional[str] \(positional)~~     |
+| `--markdown`, `-md`                              | Print information as Markdown. ~~bool (flag)~~                                                |
+| `--silent`, `-s` <Tag variant="new">2.0.12</Tag> | Don't print anything, just return the values. ~~bool (flag)~~                                 |
+| `--exclude`, `-e`                                | Comma-separated keys to exclude from the print-out. Defaults to `"labels"`. ~~Optional[str]~~ |
+| `--help`, `-h`                                   | Show help message and available arguments. ~~bool (flag)~~                                    |
+| **PRINTS**                                       | Information about your spaCy installation.                                                    |
 
 ## validate {#validate new="2" tag="command"}
 


### PR DESCRIPTION
## Description
Fixes to `spacy info` command:
- Avoid issues when trying to parse a URL as a `Path`
- Fix code when path is not a package but a directory
- Avoid printing labels by setting a default "exclude" parameter. This makes the output pretty much unreadable otherwise if there's a `morphologizer`. If you do still want the labels, you can run with
```
spacy info es_core_news_lg --exclude ""
```
(this is not very intuitive but I think it's fine, as typically we'll probably be the ones to ask this to users if we really want the label information to solve a specific ticket)

### Types of change
bug fixes & enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
