### PR TITLE
Add token_splitter component

### DIFF
--- a/spacy/pipeline/functions.py
+++ b/spacy/pipeline/functions.py
@@ -71,44 +71,33 @@ def merge_subtokens(doc: Doc, label: str = "subtok") -> Doc:
     return doc
 
 
-default_long_token_splitter_config = """
-[config]
-long_token_length = 25
-split_length = 10
-"""
-
-DEFAULT_LONG_TOKEN_SPLITTER_CONFIG = Config().from_str(
-    default_long_token_splitter_config
-)["config"]
-
-
 @Language.factory(
-    "long_token_splitter",
-    default_config=DEFAULT_LONG_TOKEN_SPLITTER_CONFIG,
+    "token_splitter",
+    default_config={"min_length": 25, "split_length": 10},
     retokenizes=True,
 )
 def make_long_token_splitter(
     nlp: Language,
     name: str,
     *,
-    long_token_length=0,
+    min_length=0,
     split_length=0,
 ):
-    return LongTokenSplitter(
-        long_token_length=long_token_length, split_length=split_length
+    return TokenSplitter(
+        min_length=min_length, split_length=split_length
     )
 
 
-class LongTokenSplitter:
-    def __init__(self, long_token_length: int = 0, split_length: int = 0):
-        self.long_token_length = long_token_length
+class TokenSplitter:
+    def __init__(self, min_length: int = 0, split_length: int = 0):
+        self.min_length = min_length
         self.split_length = split_length
 
     def __call__(self, doc: Doc) -> Doc:
-        if self.long_token_length > 0 and self.split_length > 0:
+        if self.min_length > 0 and self.split_length > 0:
             with doc.retokenize() as retokenizer:
                 for t in doc:
-                    if len(t.text) >= self.long_token_length:
+                    if len(t.text) >= self.min_length:
                         orths = []
                         heads = []
                         attrs = {}
@@ -120,12 +109,12 @@ class LongTokenSplitter:
 
     def _get_config(self) -> Dict[str, Any]:
         return {
-            "long_token_length": self.long_token_length,
+            "min_length": self.min_length,
             "split_length": self.split_length,
         }
 
     def _set_config(self, config: Dict[str, Any] = {}) -> None:
-        self.long_token_length = config.get("long_token_length", 0)
+        self.min_length = config.get("min_length", 0)
         self.split_length = config.get("split_length", 0)
 
     def to_bytes(self, **kwargs):

--- a/spacy/pipeline/functions.py
+++ b/spacy/pipeline/functions.py
@@ -1,7 +1,11 @@
+import srsly
+from thinc.api import Config
+from typing import Dict, Any
 from ..language import Language
 from ..matcher import Matcher
 from ..tokens import Doc
 from ..util import filter_spans
+from .. import util
 
 
 @Language.component(
@@ -65,3 +69,88 @@ def merge_subtokens(doc: Doc, label: str = "subtok") -> Doc:
         for span in spans:
             retokenizer.merge(span)
     return doc
+
+
+default_long_token_splitter_config = """
+[config]
+long_token_length = 25
+split_length = 10
+"""
+
+DEFAULT_LONG_TOKEN_SPLITTER_CONFIG = Config().from_str(
+    default_long_token_splitter_config
+)["config"]
+
+
+@Language.factory(
+    "long_token_splitter",
+    default_config=DEFAULT_LONG_TOKEN_SPLITTER_CONFIG,
+    retokenizes=True,
+)
+def make_long_token_splitter(
+    nlp: Language,
+    name: str,
+    *,
+    long_token_length=0,
+    split_length=0,
+):
+    return LongTokenSplitter(
+        long_token_length=long_token_length, split_length=split_length
+    )
+
+
+class LongTokenSplitter:
+    def __init__(self, long_token_length: int = 0, split_length: int = 0):
+        self.long_token_length = long_token_length
+        self.split_length = split_length
+
+    def __call__(self, doc: Doc) -> Doc:
+        if self.long_token_length > 0 and self.split_length > 0:
+            with doc.retokenize() as retokenizer:
+                for t in doc:
+                    if len(t.text) >= self.long_token_length:
+                        orths = []
+                        heads = []
+                        attrs = {}
+                        for i in range(0, len(t.text), self.split_length):
+                            orths.append(t.text[i : i + self.split_length])
+                            heads.append((t, i / self.split_length))
+                        retokenizer.split(t, orths, heads, attrs)
+        return doc
+
+    def _get_config(self) -> Dict[str, Any]:
+        return {
+            "long_token_length": self.long_token_length,
+            "split_length": self.split_length,
+        }
+
+    def _set_config(self, config: Dict[str, Any] = {}) -> None:
+        self.long_token_length = config.get("long_token_length", 0)
+        self.split_length = config.get("split_length", 0)
+
+    def to_bytes(self, **kwargs):
+        serializers = {
+            "cfg": lambda: srsly.json_dumps(self._get_config()),
+        }
+        return util.to_bytes(serializers, [])
+
+    def from_bytes(self, data, **kwargs):
+        deserializers = {
+            "cfg": lambda b: self._set_config(srsly.json_loads(b)),
+        }
+        util.from_bytes(data, deserializers, [])
+        return self
+
+    def to_disk(self, path, **kwargs):
+        path = util.ensure_path(path)
+        serializers = {
+            "cfg": lambda p: srsly.write_json(p, self._get_config()),
+        }
+        return util.to_disk(path, serializers, [])
+
+    def from_disk(self, path, **kwargs):
+        path = util.ensure_path(path)
+        serializers = {
+            "cfg": lambda p: self._set_config(srsly.read_json(p)),
+        }
+        util.from_disk(path, serializers, [])

--- a/spacy/pipeline/functions.py
+++ b/spacy/pipeline/functions.py
@@ -76,7 +76,7 @@ def merge_subtokens(doc: Doc, label: str = "subtok") -> Doc:
     default_config={"min_length": 25, "split_length": 10},
     retokenizes=True,
 )
-def make_long_token_splitter(
+def make_token_splitter(
     nlp: Language,
     name: str,
     *,

--- a/spacy/tests/pipeline/test_functions.py
+++ b/spacy/tests/pipeline/test_functions.py
@@ -53,3 +53,24 @@ def test_factories_merge_ents(doc2):
     assert len(doc2) == 6
     assert len(list(doc2.ents)) == 1
     assert doc2[2].text == "New York"
+
+
+def test_token_splitter():
+    nlp = Language()
+    config = {"min_length": 20, "split_length": 5}
+    token_splitter = nlp.add_pipe("token_splitter", config=config)
+    doc = nlp("aaaaabbbbbcccccdddd e f g")
+    assert [t.text for t in doc] == ["aaaaabbbbbcccccdddd", "e", "f", "g"]
+    doc = nlp("aaaaabbbbbcccccdddddeeeeeff g h i")
+    assert [t.text for t in doc] == [
+        "aaaaa",
+        "bbbbb",
+        "ccccc",
+        "ddddd",
+        "eeeee",
+        "ff",
+        "g",
+        "h",
+        "i",
+    ]
+    assert all(len(t.text) <= token_splitter.split_length for t in doc)

--- a/website/docs/api/pipeline-functions.md
+++ b/website/docs/api/pipeline-functions.md
@@ -6,6 +6,7 @@ menu:
   - ['merge_noun_chunks', 'merge_noun_chunks']
   - ['merge_entities', 'merge_entities']
   - ['merge_subtokens', 'merge_subtokens']
+  - ['token_splitter', 'token_splitter']
 ---
 
 ## merge_noun_chunks {#merge_noun_chunks tag="function"}
@@ -107,3 +108,25 @@ end of the pipeline and after all other components.
 | `doc`       | The `Doc` object to process, e.g. the `Doc` in the pipeline. ~~Doc~~ |
 | `label`     | The subtoken dependency label. Defaults to `"subtok"`. ~~str~~       |
 | **RETURNS** | The modified `Doc` with merged subtokens. ~~Doc~~                    |
+
+## token_splitter {#token_splitter tag="function" new="3.0"}
+
+Split tokens longer than a minimum length into shorter tokens. Intended for use
+with transformer pipelines where long spaCy tokens lead to input text that
+exceed the transformer model max length. See
+[managing transformer model max length limitations](/usage/embeddings-transformers#transformer-max-length).
+
+> #### Example
+>
+> ```python
+> config={"min_length": 20, "split_length": 5}
+> nlp.add_pipe("token_splitter", config=config, first=True)
+> doc = nlp("aaaaabbbbbcccccdddddee")
+> print([token.text for token in doc])
+> # ['aaaaa', 'bbbbb', 'ccccc', 'ddddd', 'ee']
+> ```
+
+| Setting        | Description                                                           |
+| -------------- | --------------------------------------------------------------------- |
+| `min_length`   | The minimum length for a token to be split. Defaults to `25`. ~~int~~ |
+| `split_length` | The length of the split tokens. Defaults to `5`. ~~int~~              |

--- a/website/docs/usage/embeddings-transformers.md
+++ b/website/docs/usage/embeddings-transformers.md
@@ -513,12 +513,12 @@ pipeline** like `en_core_web_trf` with a fixed `window` size for
 pipeline so that you have shorter spaCy tokens. Some options:
 
 - Preprocess your texts to clean up noise and split long tokens with whitespace
-- Add a `long_token_splitter` to the beginning of your pipeline to break up
+- Add a `token_splitter` to the beginning of your pipeline to break up
   tokens that are longer than a specified length:
 
   ```python
-  config={"long_token_length": 20, "split_length": 5}
-  nlp.add_pipe("long_token_splitter", config=config, first=True)
+  config={"min_length": 20, "split_length": 5}
+  nlp.add_pipe("token_splitter", config=config, first=True)
   ```
 
   In this example, tokens that are at least 20 characters long will be split up


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Add a `token_splitter` component for use with transformer pipelines. This component splits up long tokens like URLs into smaller tokens. This is particularly relevant for pretrained pipelines with `strided_spans`, since the user can't change the length of the span `window` and may not wish to preprocess the input texts.

The `token_splitter` splits tokens that are at least `min_length` chars long into smaller tokens of `split_length` chars size.

Notes:

* Since this is intended for use as the first component in a pipeline, the token splitter does not try to preserve any token annotation.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Enhancement.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
