### PR TITLE
Fix `spacy.util.minibatch` when the size iterator is finished

### DIFF
--- a/spacy/util.py
+++ b/spacy/util.py
@@ -513,7 +513,7 @@ def minibatch(items, size=8):
         size_ = size
     items = iter(items)
     while True:
-        batch_size = next(size_)
+        batch_size = next(size_, 0)  # StopIteration isn't handled in generators in Python >= 3.7.
         batch = list(itertools.islice(items, int(batch_size)))
         if len(batch) == 0:
             break


### PR DESCRIPTION
Fix the `minibatch` function in `spacy.util` when the size `iterator` is finished.

## Description

This may seem unnecessary, and I'd be skeptical of the change. However, since Python 3.7, if a `StopIteration` exception is raised inside generators or coroutines, they are converted into runtime errors, thus not interpreted as the end of the iteration anymore but they're vanilla exceptions. See [this SO answer](https://stackoverflow.com/a/51701040/1165181) for more info.

So when an iterator is provided in `minibatch` (instead of an `int`), there are chances it's finished, and then this problem can happen. I added a default value to `next` so it isn't raised and the behavior is the expected one.

### Types of change

Bugfix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
