### PR TITLE
Copy the Example objects (and their predicted Doc) in nlp.evaluate() and nlp.update()

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1298,8 +1298,9 @@ class Language:
 
         DOCS: https://nightly.spacy.io/api/language#evaluate
         """
-        examples = _copy_examples(examples)
+        examples = list(examples)
         validate_examples(examples, "Language.evaluate")
+        examples = _copy_examples(examples)
         if batch_size is None:
             batch_size = self.batch_size
         if component_cfg is None:

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -1420,15 +1420,6 @@ def check_bool_env_var(env_var: str) -> bool:
     return bool(value)
 
 
-def copy_examples(examples: Iterable[Example]) -> List[Example]:
-    """Make a copy of a batch of examples, copying the predicted Doc as well.
-    This is used in contexts where we need to take ownership of the examples
-    so that they can be mutated, for instance during Language.evaluate and 
-    Language.update.
-    """
-    return [Example(eg.x.copy(), eg.y) for eg in examples]
-
-
 def _pipe(docs, proc, kwargs):
     if hasattr(proc, "pipe"):
         yield from proc.pipe(docs, **kwargs)

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -1420,6 +1420,15 @@ def check_bool_env_var(env_var: str) -> bool:
     return bool(value)
 
 
+def copy_examples(examples: Iterable[Example]) -> List[Example]:
+    """Make a copy of a batch of examples, copying the predicted Doc as well.
+    This is used in contexts where we need to take ownership of the examples
+    so that they can be mutated, for instance during Language.evaluate and 
+    Language.update.
+    """
+    return [Example(eg.x.copy(), eg.y) for eg in examples]
+
+
 def _pipe(docs, proc, kwargs):
     if hasattr(proc, "pipe"):
         yield from proc.pipe(docs, **kwargs)


### PR DESCRIPTION
We want to let the pipeline mutate the `example.predicted` `Doc` object during training and evaluation without the user having to worry about their data changing. The solution is to make our own copy of the relevant data once we're inside the methods, so that we can mutate it freely.

This will allow allow a subsequent change to `component.update()`: we'll be able to add `component.set_annotations()` calls within the component, which should make it quite a lot easier to have components communicate with each other. The change is potentially breaking though, so it's probably better to put it in a second PR.

### Types of change

(Potentially breaking) change.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
