### PR TITLE
warn when frozen components break listener pattern

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1497,8 +1497,7 @@ class Language:
         for i, (name1, proc1) in enumerate(self.pipeline):
             if hasattr(proc1, "find_listeners"):
                 for name2, proc2 in self.pipeline[i + 1 :]:
-                    if isinstance(getattr(proc2, "model", None), Model):
-                        proc1.find_listeners(proc2.model)
+                    proc1.find_listeners(proc2)
 
     @classmethod
     def from_config(

--- a/spacy/pipeline/tok2vec.py
+++ b/spacy/pipeline/tok2vec.py
@@ -85,10 +85,10 @@ class Tok2Vec(TrainablePipe):
         self.listener_map[component_name].append(listener)
 
     def find_listeners(self, component) -> None:
-        """Walk over a model of a processing component, looking for layers that are Tok2vecListener
-        subclasses that have an upstream_name that matches this component.
-        Listeners can also set their upstream_name attribute to the wildcard
-        string '*' to match any `Tok2Vec`.
+        """Walk over a model of a processing component, looking for layers that
+        are Tok2vecListener subclasses that have an upstream_name that matches
+        this component. Listeners can also set their upstream_name attribute to
+        the wildcard string '*' to match any `Tok2Vec`.
 
         You're unlikely to ever need multiple `Tok2Vec` components, so it's
         fine to leave your listeners upstream_name on '*'.

--- a/spacy/pipeline/tok2vec.py
+++ b/spacy/pipeline/tok2vec.py
@@ -79,10 +79,10 @@ class Tok2Vec(TrainablePipe):
         """
         return list(self.listener_map.keys())
 
-    def add_listener(self, listener: "Tok2VecListener", component: str) -> None:
+    def add_listener(self, listener: "Tok2VecListener", component_name: str) -> None:
         """Add a listener for a downstream component. Usually internals."""
-        self.listener_map.setdefault(component, [])
-        self.listener_map[component].append(listener)
+        self.listener_map.setdefault(component_name, [])
+        self.listener_map[component_name].append(listener)
 
     def find_listeners(self, component) -> None:
         """Walk over a model of a processing component, looking for layers that are Tok2vecListener

--- a/spacy/pipeline/tok2vec.py
+++ b/spacy/pipeline/tok2vec.py
@@ -93,12 +93,10 @@ class Tok2Vec(TrainablePipe):
         You're unlikely to ever need multiple `Tok2Vec` components, so it's
         fine to leave your listeners upstream_name on '*'.
         """
+        names = ("*", self.name)
         if isinstance(getattr(component, "model", None), Model):
             for node in component.model.walk():
-                if isinstance(node, Tok2VecListener) and node.upstream_name in (
-                    "*",
-                    self.name,
-                ):
+                if isinstance(node, Tok2VecListener) and node.upstream_name in names:
                     self.add_listener(node, component.name)
 
     def __call__(self, doc: Doc) -> Doc:

--- a/spacy/pipeline/tok2vec.py
+++ b/spacy/pipeline/tok2vec.py
@@ -66,8 +66,8 @@ class Tok2Vec(TrainablePipe):
         self.cfg = {}
 
     @property
-    def listeners(self) -> List[Model]:
-        """RETURNS (List[Model]): The listener models listening to this
+    def listeners(self) -> List["Tok2VecListener"]:
+        """RETURNS (List[Tok2VecListener]): The listener models listening to this
         component. Usually internals.
         """
         return [m for c in self.listening_components for m in self.listener_map[c]]

--- a/website/docs/usage/processing-pipelines.md
+++ b/website/docs/usage/processing-pipelines.md
@@ -400,7 +400,8 @@ vectors available – otherwise, it won't be able to make the same predictions.
 > ```
 >
 > By default, sourced components will be updated with your data during training.
-> If you want to preserve the component as-is, you can "freeze" it:
+> If you want to preserve the component as-is, you can "freeze" it if the pipeline 
+> is not using a shared `Tok2Vec` layer:
 >
 > ```ini
 > [training]

--- a/website/docs/usage/training.md
+++ b/website/docs/usage/training.md
@@ -419,6 +419,16 @@ pipeline = ["parser", "ner", "textcat", "custom"]
 frozen_components = ["parser", "custom"]
 ```
 
+<Infobox variant="warning" title="Shared Tok2Vec layer">
+
+When the components in your pipeline
+[share an embedding layer](/usage/embeddings-transformers#embedding-layers), the
+**performance** of your frozen component will be **degraded** if you continue training
+other layers with the same underlying `Tok2Vec` instance. As a rule of thumb,
+ensure that your frozen components are truly **independent** in the pipeline.
+
+</Infobox>
+
 ### Using registered functions {#config-functions}
 
 The training configuration defined in the config file doesn't have to only


### PR DESCRIPTION
## Description
- Change in `Tok2Vec` to store not only the listener `Model` instances, but also the downstream component names to which those listeners belong.
- Warn when trying to train a component which has a frozen tok2vec layer, or when (re)training a tok2vec layer which has a downstream frozen component listening to it.
- Added a few notes in the documentation

### Types of change
UX enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

## TODO
- [x] Update `Transformer` accordingly if we agree on this PR

