### PR TITLE
support IS_SENT_START in PhraseMatcher

### DIFF
--- a/spacy/matcher/phrasematcher.pyx
+++ b/spacy/matcher/phrasematcher.pyx
@@ -8,6 +8,7 @@ from preshed.maps cimport map_init, map_set, map_get, map_clear, map_iter
 
 import warnings
 
+from ..attrs import IDS
 from ..attrs cimport ORTH, POS, TAG, DEP, LEMMA
 from ..structs cimport TokenC
 from ..tokens.token cimport Token
@@ -52,21 +53,17 @@ cdef class PhraseMatcher:
         self._terminal_hash = 826361138722620965
         map_init(self.mem, self.c_map, 8)
 
-        if attr == "IS_SENT_START":
-            attr = "SENT_START"
-
         if isinstance(attr, (int, long)):
             self.attr = attr
         else:
             attr = attr.upper()
             if attr == "TEXT":
                 attr = "ORTH"
+            if attr == "IS_SENT_START":
+                attr = "SENT_START"
             if attr not in TOKEN_PATTERN_SCHEMA["items"]["properties"]:
                 raise ValueError(Errors.E152.format(attr=attr))
-            try:
-                self.attr = self.vocab.strings[attr]
-            except OverflowError:
-                raise ValueError(Errors.E152.format(attr=attr))
+            self.attr = IDS.get(attr)
 
     def __len__(self):
         """Get the number of match IDs added to the matcher.

--- a/spacy/matcher/phrasematcher.pyx
+++ b/spacy/matcher/phrasematcher.pyx
@@ -52,6 +52,9 @@ cdef class PhraseMatcher:
         self._terminal_hash = 826361138722620965
         map_init(self.mem, self.c_map, 8)
 
+        if attr == "IS_SENT_START":
+            attr = "SENT_START"
+
         if isinstance(attr, (int, long)):
             self.attr = attr
         else:

--- a/spacy/matcher/phrasematcher.pyx
+++ b/spacy/matcher/phrasematcher.pyx
@@ -63,7 +63,10 @@ cdef class PhraseMatcher:
                 attr = "ORTH"
             if attr not in TOKEN_PATTERN_SCHEMA["items"]["properties"]:
                 raise ValueError(Errors.E152.format(attr=attr))
-            self.attr = self.vocab.strings[attr]
+            try:
+                self.attr = self.vocab.strings[attr]
+            except OverflowError:
+                raise ValueError(Errors.E152.format(attr=attr))
 
     def __len__(self):
         """Get the number of match IDs added to the matcher.

--- a/spacy/tests/matcher/test_phrase_matcher.py
+++ b/spacy/tests/matcher/test_phrase_matcher.py
@@ -290,3 +290,8 @@ def test_phrase_matcher_pickle(en_vocab):
     # clunky way to vaguely check that callback is unpickled
     (vocab, docs, callbacks, attr) = matcher_unpickled.__reduce__()[1]
     assert isinstance(callbacks.get("TEST2"), Mock)
+
+
+@pytest.mark.parametrize("attr", ["SENT_START", "IS_SENT_START"])
+def test_phrase_matcher_sent_start(en_vocab, attr):
+    matcher = PhraseMatcher(en_vocab, attr=attr)


### PR DESCRIPTION
Fixes #6770

## Description
support `IS_SENT_START` in `PhraseMatcher`, just like we do in `Matcher`

### Types of change
enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
