### PR TITLE
ensure span.text works for an empty span

### DIFF
--- a/spacy/tests/regression/test_issue6755.py
+++ b/spacy/tests/regression/test_issue6755.py
@@ -1,0 +1,9 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+
+def test_issue6755(en_tokenizer):
+    doc = en_tokenizer("This is a magnificent sentence.")
+    span = doc[:0]
+    assert span.text_with_ws == ""
+    assert span.text == ""

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -500,7 +500,7 @@ cdef class Span:
     def text(self):
         """RETURNS (unicode): The original verbatim text of the span."""
         text = self.text_with_ws
-        if self[-1].whitespace_:
+        if len(self) > 0 and self[-1].whitespace_:
             text = text[:-1]
         return text
 


### PR DESCRIPTION
Fixes #6755

## Description
Ensure `span.text` works for an empty span, and is consistent with the behaviour in `text_with_ws`

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
