### PR TITLE
Add speed benchmark

### DIFF
--- a/website/docs/usage/_benchmarks-models.md
+++ b/website/docs/usage/_benchmarks-models.md
@@ -4,11 +4,13 @@ import { Help } from 'components/typography'; import Link from 'components/link'
 
 | Pipeline                                                   | Parser | Tagger |  NER |
 | ---------------------------------------------------------- | -----: | -----: | ---: |
-| [`en_core_web_trf`](/models/en#en_core_web_trf) (spaCy v3) |   95.5 |   98.3 | 89.4 |
-| [`en_core_web_lg`](/models/en#en_core_web_lg) (spaCy v3)   |   92.2 |   97.4 | 85.4 |
+| [`en_core_web_trf`](/models/en#en_core_web_trf) (spaCy v3) |   95.2 |   97.8 | 89.9 |
+| [`en_core_web_lg`](/models/en#en_core_web_lg) (spaCy v3)   |   91.9 |   97.4 | 85.5 |
 | `en_core_web_lg` (spaCy v2)                                |   91.9 |   97.2 | 85.5 |
 
 <figcaption class="caption">
+
+<!-- TODO: speed (or update caption below) -->
 
 **Full pipeline accuracy and speed** on the
 [OntoNotes 5.0](https://catalog.ldc.upenn.edu/LDC2013T19) corpus (reported on

--- a/website/docs/usage/_benchmarks-models.md
+++ b/website/docs/usage/_benchmarks-models.md
@@ -10,9 +10,7 @@ import { Help } from 'components/typography'; import Link from 'components/link'
 
 <figcaption class="caption">
 
-<!-- TODO: speed (or update caption below) -->
-
-**Full pipeline accuracy and speed** on the
+**Full pipeline accuracy** on the
 [OntoNotes 5.0](https://catalog.ldc.upenn.edu/LDC2013T19) corpus (reported on
 the development set).
 

--- a/website/docs/usage/facts-figures.md
+++ b/website/docs/usage/facts-figures.md
@@ -92,6 +92,30 @@ results. Project template:
 
 </figure>
 
+### Speed comparison {#benchmarks-speed}
+
+We compare the speed of different NLP libraries, measured in words per second.
+The evaluation was run on 10,000 Reddit comments.
+
+<figure>
+
+| Library | Pipeline                                        | WPS CPU <Help>words per second on CPU, higher is better</Help> | WPS GPU <Help>words per second on GPU, higher is better</Help> |
+| ------- | ----------------------------------------------- | -------------------------------------------------------------: | -------------------------------------------------------------: |
+| spaCy   | [`en_core_web_lg`](/models/en#en_core_web_lg)   |                                                         10,014 |                                                         14,954 |
+| spaCy   | [`en_core_web_trf`](/models/en#en_core_web_trf) |                                                            684 |                                                          3,768 |
+| Stanza  | `en_ewt`                                        |                                                            878 |                                                          2,180 |
+| Flair   | `pos`(`-fast`) & `ner`(`-fast`)                 |                                                            323 |                                                          1,184 |
+| UDPipe  | `english-ewt-ud-2.5`                            |                                                          1,101 |                                                             NA |
+
+<figcaption class="caption">
+
+**End-to-end processing speed** on raw unannotated text. Project template:
+[`benchmarks/speed`](%%GITHUB_PROJECTS/benchmarks/speed).
+
+</figcaption>
+
+</figure>
+
 <!-- TODO: ## Citing spaCy {#citation}
 
 -->

--- a/website/docs/usage/facts-figures.md
+++ b/website/docs/usage/facts-figures.md
@@ -94,8 +94,8 @@ results. Project template:
 
 ### Speed comparison {#benchmarks-speed}
 
-We compare the speed of different NLP libraries, measured in words per second.
-The evaluation was run on 10,000 Reddit comments.
+We compare the speed of different NLP libraries, measured in words per second
+(WPS) - higher is better. The evaluation was performed on 10,000 Reddit comments.
 
 <figure>
 


### PR DESCRIPTION


## Description
Speed benchmark on 10K reddit comments. Ran this on larger datasets too, the results are virtually the same, but the trf model had some issues with some of the texts, so not sure if it's worth the trouble. The relative timings between libraries were pretty stable across runs.

Also updated the accuracy numbers for the recent a1 models.

### Types of change
doc update

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
