### PR TITLE
Make init_config return nlp object

### DIFF
--- a/spacy/cli/init_config.py
+++ b/spacy/cli/init_config.py
@@ -8,7 +8,7 @@ import re
 from jinja2 import Template
 
 from .. import util
-from ..language import DEFAULT_CONFIG_PRETRAIN_PATH
+from ..language import Language, DEFAULT_CONFIG_PRETRAIN_PATH
 from ..schemas import RecommendationSchema
 from ._util import init_cli, Arg, Opt, show_validation_error, COMMAND, string_to_list
 
@@ -53,7 +53,7 @@ def init_config_cli(
             "The provided output file already exists. To force overwriting the config file, set the --force or -F flag.",
             exits=1,
         )
-    config = init_config(
+    nlp = init_config(
         lang=lang,
         pipeline=pipeline,
         optimize=optimize,
@@ -61,7 +61,7 @@ def init_config_cli(
         pretraining=pretraining,
         silent=is_stdout,
     )
-    save_config(config, output_file, is_stdout=is_stdout)
+    save_config(nlp.config, output_file, is_stdout=is_stdout)
 
 
 @init_cli.command("fill-config")
@@ -134,7 +134,7 @@ def init_config(
     gpu: bool,
     pretraining: bool = False,
     silent: bool = True,
-) -> Config:
+) -> Language:
     msg = Printer(no_print=silent)
     with TEMPLATE_PATH.open("r") as f:
         template = Template(f.read())
@@ -181,7 +181,7 @@ def init_config(
             pretrain_config = util.load_config(DEFAULT_CONFIG_PRETRAIN_PATH)
             config = pretrain_config.merge(config)
     msg.good("Auto-filled config with all values")
-    return config
+    return nlp
 
 
 def save_config(

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -382,8 +382,7 @@ def test_parse_cli_overrides():
 @pytest.mark.parametrize("optimize", ["efficiency", "accuracy"])
 def test_init_config(lang, pipeline, optimize):
     # TODO: add more tests and also check for GPU with transformers
-    config = init_config(lang=lang, pipeline=pipeline, optimize=optimize, gpu=False)
-    assert isinstance(config, Config)
+    init_config(lang=lang, pipeline=pipeline, optimize=optimize, gpu=False)
 
 
 def test_model_recommendations():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

This came up in Prodigy nightly: `init_config` creates an `nlp` object from the auto-generated config to make sure everything works and to auto-fill sections if needed. If we're calling into `init_config` to auto-generate a config to use for training, we'd be creating the `nlp` object from the config twice. So we might as well make the function return the `nlp` object it created (and refer to `nlp.config` if we only need the config).

### Types of change
fix / enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
