### PR TITLE
Avoid assuming encode nO dimension is preset in tok2vec

### DIFF
--- a/spacy/ml/models/tok2vec.py
+++ b/spacy/ml/models/tok2vec.py
@@ -101,7 +101,8 @@ def build_Tok2Vec_model(
         embeddings, using an architecture such as a CNN, BiLSTM or transformer.
     """
     tok2vec = chain(embed, encode)
-    tok2vec.set_dim("nO", encode.get_dim("nO"))
+    if encode.has_dim("nO"):
+        tok2vec.set_dim("nO", encode.get_dim("nO"))
     tok2vec.set_ref("embed", embed)
     tok2vec.set_ref("encode", encode)
     return tok2vec


### PR DESCRIPTION
We've been making a number of fixes to the `tok2vec` layer definitions, including @sofie's fix to make other encoders work. Those problems masked this issue, which I hit when doing the spancat testing.


## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
