### PR TITLE
Avoid Doc owning LexemeC data and fix parser set_annotations during update

### DIFF
--- a/spacy/about.py
+++ b/spacy/about.py
@@ -1,6 +1,6 @@
 # fmt: off
 __title__ = "spacy-nightly"
-__version__ = "3.0.0rc4.dev19"
+__version__ = "3.0.0rc4.dev20"
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"
 __projects__ = "https://github.com/explosion/projects"

--- a/spacy/about.py
+++ b/spacy/about.py
@@ -1,6 +1,6 @@
 # fmt: off
 __title__ = "spacy-nightly"
-__version__ = "3.0.0rc4.dev15"
+__version__ = "3.0.0rc4.dev16"
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"
 __projects__ = "https://github.com/explosion/projects"

--- a/spacy/about.py
+++ b/spacy/about.py
@@ -1,6 +1,6 @@
 # fmt: off
 __title__ = "spacy-nightly"
-__version__ = "3.0.0rc4.dev13"
+__version__ = "3.0.0rc4.dev14"
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"
 __projects__ = "https://github.com/explosion/projects"

--- a/spacy/about.py
+++ b/spacy/about.py
@@ -1,6 +1,6 @@
 # fmt: off
 __title__ = "spacy-nightly"
-__version__ = "3.0.0rc4"
+__version__ = "3.0.0rc4.dev10"
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"
 __projects__ = "https://github.com/explosion/projects"

--- a/spacy/about.py
+++ b/spacy/about.py
@@ -1,6 +1,6 @@
 # fmt: off
 __title__ = "spacy-nightly"
-__version__ = "3.0.0rc4.dev17"
+__version__ = "3.0.0rc4.dev18"
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"
 __projects__ = "https://github.com/explosion/projects"

--- a/spacy/about.py
+++ b/spacy/about.py
@@ -1,6 +1,6 @@
 # fmt: off
 __title__ = "spacy-nightly"
-__version__ = "3.0.0rc4.dev12"
+__version__ = "3.0.0rc4.dev13"
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"
 __projects__ = "https://github.com/explosion/projects"

--- a/spacy/about.py
+++ b/spacy/about.py
@@ -1,6 +1,6 @@
 # fmt: off
 __title__ = "spacy-nightly"
-__version__ = "3.0.0rc4.dev11"
+__version__ = "3.0.0rc4.dev12"
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"
 __projects__ = "https://github.com/explosion/projects"

--- a/spacy/about.py
+++ b/spacy/about.py
@@ -1,6 +1,6 @@
 # fmt: off
 __title__ = "spacy-nightly"
-__version__ = "3.0.0rc4.dev18"
+__version__ = "3.0.0rc4.dev19"
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"
 __projects__ = "https://github.com/explosion/projects"

--- a/spacy/about.py
+++ b/spacy/about.py
@@ -1,6 +1,6 @@
 # fmt: off
 __title__ = "spacy-nightly"
-__version__ = "3.0.0rc4.dev16"
+__version__ = "3.0.0rc4.dev17"
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"
 __projects__ = "https://github.com/explosion/projects"

--- a/spacy/about.py
+++ b/spacy/about.py
@@ -1,6 +1,6 @@
 # fmt: off
 __title__ = "spacy-nightly"
-__version__ = "3.0.0rc4.dev10"
+__version__ = "3.0.0rc4.dev11"
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"
 __projects__ = "https://github.com/explosion/projects"

--- a/spacy/about.py
+++ b/spacy/about.py
@@ -1,6 +1,6 @@
 # fmt: off
 __title__ = "spacy-nightly"
-__version__ = "3.0.0rc4.dev14"
+__version__ = "3.0.0rc4.dev15"
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"
 __projects__ = "https://github.com/explosion/projects"

--- a/spacy/pipeline/_parser_internals/_beam_utils.pyx
+++ b/spacy/pipeline/_parser_internals/_beam_utils.pyx
@@ -193,11 +193,7 @@ def update_beam(TransitionSystem moves, states, golds, model, int width, beam_de
     for i, (d_scores, bp_scores) in enumerate(zip(states_d_scores, backprops)):
         loss += (d_scores**2).mean()
         bp_scores(d_scores)
-    # Return the predicted sequence for each doc.
-    predicted_histories = []
-    for i in range(len(pbeam)):
-        predicted_histories.append(pbeam[i].histories[0])
-    return predicted_histories, loss
+    return loss
 
 
 def collect_states(beams, docs):

--- a/spacy/pipeline/_parser_internals/_beam_utils.pyx
+++ b/spacy/pipeline/_parser_internals/_beam_utils.pyx
@@ -193,7 +193,11 @@ def update_beam(TransitionSystem moves, states, golds, model, int width, beam_de
     for i, (d_scores, bp_scores) in enumerate(zip(states_d_scores, backprops)):
         loss += (d_scores**2).mean()
         bp_scores(d_scores)
-    return loss
+    # Return the predicted sequence for each doc.
+    predicted_histories = []
+    for i in range(len(pbeam)):
+        predicted_histories.append(pbeam[i].histories[0])
+    return predicted_histories, loss
 
 
 def collect_states(beams, docs):

--- a/spacy/pipeline/_parser_internals/_state.pxd
+++ b/spacy/pipeline/_parser_internals/_state.pxd
@@ -32,6 +32,7 @@ cdef cppclass StateC:
     vector[ArcC] _left_arcs
     vector[ArcC] _right_arcs
     vector[libcpp.bool] _unshiftable
+    vector[int] history
     set[int] _sent_starts
     TokenC _empty_token
     int length
@@ -382,3 +383,4 @@ cdef cppclass StateC:
         this._b_i = src._b_i
         this.offset = src.offset
         this._empty_token = src._empty_token
+        this.history = src.history

--- a/spacy/pipeline/_parser_internals/arc_eager.pyx
+++ b/spacy/pipeline/_parser_internals/arc_eager.pyx
@@ -638,17 +638,16 @@ cdef class ArcEager(TransitionSystem):
         return gold
 
     def init_gold_batch(self, examples):
+        # TODO: Projectivity?
         all_states = self.init_batch([eg.predicted for eg in examples])
         golds = []
         states = []
-        docs = []
         for state, eg in zip(all_states, examples):
             if self.has_gold(eg) and not state.is_final():
                 golds.append(self.init_gold(state, eg))
                 states.append(state)
-                docs.append(eg.x)
         n_steps = sum([len(s.queue) for s in states])
-        return states, golds, docs
+        return states, golds, n_steps
 
     def _replace_unseen_labels(self, ArcEagerGold gold):
         backoff_label = self.strings["dep"]

--- a/spacy/pipeline/_parser_internals/arc_eager.pyx
+++ b/spacy/pipeline/_parser_internals/arc_eager.pyx
@@ -757,6 +757,8 @@ cdef class ArcEager(TransitionSystem):
         return list(arcs)
 
     def has_gold(self, Example eg, start=0, end=None):
+        if end is not None and end < 0:
+            end = None
         for word in eg.y[start:end]:
             if word.dep != 0:
                 return True

--- a/spacy/pipeline/_parser_internals/arc_eager.pyx
+++ b/spacy/pipeline/_parser_internals/arc_eager.pyx
@@ -844,6 +844,7 @@ cdef class ArcEager(TransitionSystem):
                             state.print_state()
                         )))
                     action.do(state.c, action.label)
+                    state.c.history.push_back(i)
                     break
             else:
                 failed = False

--- a/spacy/pipeline/_parser_internals/arc_eager.pyx
+++ b/spacy/pipeline/_parser_internals/arc_eager.pyx
@@ -638,16 +638,17 @@ cdef class ArcEager(TransitionSystem):
         return gold
 
     def init_gold_batch(self, examples):
-        # TODO: Projectivity?
         all_states = self.init_batch([eg.predicted for eg in examples])
         golds = []
         states = []
+        docs = []
         for state, eg in zip(all_states, examples):
             if self.has_gold(eg) and not state.is_final():
                 golds.append(self.init_gold(state, eg))
                 states.append(state)
+                docs.append(eg.x)
         n_steps = sum([len(s.queue) for s in states])
-        return states, golds, n_steps
+        return states, golds, docs
 
     def _replace_unseen_labels(self, ArcEagerGold gold):
         backoff_label = self.strings["dep"]

--- a/spacy/pipeline/_parser_internals/ner.pyx
+++ b/spacy/pipeline/_parser_internals/ner.pyx
@@ -266,6 +266,8 @@ cdef class BiluoPushDown(TransitionSystem):
         return BiluoGold(self, state, example)
 
     def has_gold(self, Example eg, start=0, end=None):
+        if end is not None and end < 0:
+            end = None
         for word in eg.y[start:end]:
             if word.ent_iob != 0:
                 return True

--- a/spacy/pipeline/_parser_internals/stateclass.pyx
+++ b/spacy/pipeline/_parser_internals/stateclass.pyx
@@ -21,6 +21,10 @@ cdef class StateClass:
             del self.c
 
     @property
+    def history(self):
+        return list(self.c.history)
+
+    @property
     def stack(self):
         return [self.S(i) for i in range(self.c.stack_depth())]
 

--- a/spacy/pipeline/_parser_internals/transition_system.pyx
+++ b/spacy/pipeline/_parser_internals/transition_system.pyx
@@ -70,6 +70,8 @@ cdef class TransitionSystem:
         return state
 
     def get_oracle_sequence(self, Example example, _debug=False):
+        if not self.has_gold(example):
+            return []
         states, golds, _ = self.init_gold_batch([example])
         if not states:
             return []

--- a/spacy/pipeline/_parser_internals/transition_system.pyx
+++ b/spacy/pipeline/_parser_internals/transition_system.pyx
@@ -83,6 +83,8 @@ cdef class TransitionSystem:
     def get_oracle_sequence_from_state(self, StateClass state, gold, _debug=None):
         if state.is_final():
             return []
+        if not self.has_gold(eg):
+            return []
         cdef Pool mem = Pool()
         # n_moves should not be zero at this point, but make sure to avoid zero-length mem alloc
         assert self.n_moves > 0

--- a/spacy/pipeline/_parser_internals/transition_system.pyx
+++ b/spacy/pipeline/_parser_internals/transition_system.pyx
@@ -67,6 +67,7 @@ cdef class TransitionSystem:
         for clas in history:
             action = self.c[clas]
             action.do(state.c, action.label)
+            state.c.history.push_back(clas)
         return state
 
     def get_oracle_sequence(self, Example example, _debug=False):
@@ -110,6 +111,7 @@ cdef class TransitionSystem:
                             "S0 head?", str(state.has_head(state.S(0))),
                         )))
                     action.do(state.c, action.label)
+                    state.c.history.push_back(i)
                     break
             else:
                 if _debug:
@@ -137,6 +139,7 @@ cdef class TransitionSystem:
             raise ValueError(Errors.E170.format(name=name))
         action = self.lookup_transition(name)
         action.do(state.c, action.label)
+        state.c.history.push_back(action.clas)
 
     cdef Transition lookup_transition(self, object name) except *:
         raise NotImplementedError

--- a/spacy/pipeline/_parser_internals/transition_system.pyx
+++ b/spacy/pipeline/_parser_internals/transition_system.pyx
@@ -61,6 +61,14 @@ cdef class TransitionSystem:
             offset += len(doc)
         return states
 
+    def follow_history(self, doc, history):
+        cdef int clas
+        cdef StateClass state = StateClass(doc)
+        for clas in history:
+            action = self.c[clas]
+            action.do(state.c, action.label)
+        return state
+
     def get_oracle_sequence(self, Example example, _debug=False):
         states, golds, _ = self.init_gold_batch([example])
         if not states:

--- a/spacy/pipeline/_parser_internals/transition_system.pyx
+++ b/spacy/pipeline/_parser_internals/transition_system.pyx
@@ -83,8 +83,6 @@ cdef class TransitionSystem:
     def get_oracle_sequence_from_state(self, StateClass state, gold, _debug=None):
         if state.is_final():
             return []
-        if not self.has_gold(eg):
-            return []
         cdef Pool mem = Pool()
         # n_moves should not be zero at this point, but make sure to avoid zero-length mem alloc
         assert self.n_moves > 0

--- a/spacy/pipeline/_parser_internals/transition_system.pyx
+++ b/spacy/pipeline/_parser_internals/transition_system.pyx
@@ -120,16 +120,6 @@ cdef class TransitionSystem:
                 raise ValueError(Errors.E024)
         return history
 
-    def follow_history(self, doc, history):
-        """Get the state that results from following a sequence of actions."""
-        cdef int clas
-        cdef StateClass state
-        state = self.init_batch([doc])[0]
-        for clas in history:
-            action = self.c[clas]
-            action.do(state.c, action.label)
-        return state
-
     def apply_transition(self, StateClass state, name):
         if not self.is_valid(state, name):
             raise ValueError(Errors.E170.format(name=name))

--- a/spacy/pipeline/_parser_internals/transition_system.pyx
+++ b/spacy/pipeline/_parser_internals/transition_system.pyx
@@ -120,6 +120,16 @@ cdef class TransitionSystem:
                 raise ValueError(Errors.E024)
         return history
 
+    def follow_history(self, doc, history):
+        """Get the state that results from following a sequence of actions."""
+        cdef int clas
+        cdef StateClass state
+        state = self.init_batch([doc])[0]
+        for clas in history:
+            action = self.c[clas]
+            action.do(state.c, action.label)
+        return state
+
     def apply_transition(self, StateClass state, name):
         if not self.is_valid(state, name):
             raise ValueError(Errors.E170.format(name=name))

--- a/spacy/pipeline/_parser_internals/transition_system.pyx
+++ b/spacy/pipeline/_parser_internals/transition_system.pyx
@@ -81,6 +81,8 @@ cdef class TransitionSystem:
             return self.get_oracle_sequence_from_state(state, gold)
 
     def get_oracle_sequence_from_state(self, StateClass state, gold, _debug=None):
+        if state.is_final():
+            return []
         cdef Pool mem = Pool()
         # n_moves should not be zero at this point, but make sure to avoid zero-length mem alloc
         assert self.n_moves > 0

--- a/spacy/pipeline/transition_parser.pyx
+++ b/spacy/pipeline/transition_parser.pyx
@@ -370,7 +370,11 @@ cdef class Parser(TrainablePipe):
         if sgd not in (None, False):
             self.finish_update(sgd)
         docs = [eg.predicted for eg in examples]
-        self.set_annotations(docs, all_states)
+        # TODO: Refactor so we don't have to parse twice like this (ugh)
+        # The issue is that we cut up the gold batch into sub-states, and that
+        # makes it hard to get the actual predicted transition sequence.
+        predicted_states = self.predict(docs)
+        self.set_annotations(docs, predicted_states)
         # Ugh, this is annoying. If we're working on GPU, we want to free the
         # memory ASAP. It seems that Python doesn't necessarily get around to
         # removing these in time if we don't explicitly delete? It's confusing.

--- a/spacy/pipeline/transition_parser.pyx
+++ b/spacy/pipeline/transition_parser.pyx
@@ -337,21 +337,22 @@ cdef class Parser(TrainablePipe):
             # Chop sequences into lengths of this many words, to make the
             # batch uniform length.
             max_moves = int(random.uniform(max_moves // 2, max_moves * 2))
-            states, golds, _ = self._init_gold_batch(
+            states, golds, max_moves, state2doc = self._init_gold_batch(
                 examples,
                 max_length=max_moves
             )
         else:
-            states, golds, _ = self.moves.init_gold_batch(examples)
+            states, golds, state2doc = self.moves.init_gold_batch(examples)
         if not states:
             return losses
         model, backprop_tok2vec = self.model.begin_update([eg.x for eg in examples])
  
+        histories = [[] for example in examples]
         all_states = list(states)
-        states_golds = list(zip(states, golds))
+        states_golds = list(zip(states, golds, state2doc))
         n_moves = 0
         while states_golds:
-            states, golds = zip(*states_golds)
+            states, golds, state2doc = zip(*states_golds)
             scores, backprop = model.begin_update(states)
             d_scores = self.get_batch_loss(states, golds, scores, losses)
             # Note that the gradient isn't normalized by the batch size
@@ -360,8 +361,13 @@ cdef class Parser(TrainablePipe):
             # be getting smaller gradients for states in long sequences.
             backprop(d_scores)
             # Follow the predicted action
-            self.transition_states(states, scores)
-            states_golds = [(s, g) for (s, g) in zip(states, golds) if not s.is_final()]
+            actions = self.transition_states(states, scores)
+            for i, action in enumerate(actions):
+                histories[i].append(action)
+            states_golds = [
+                s for s  in zip(states, golds, state2doc)
+                if not s[0].is_final()
+            ]
             if max_moves >= 1 and n_moves >= max_moves:
                 break
             n_moves += 1
@@ -370,11 +376,11 @@ cdef class Parser(TrainablePipe):
         if sgd not in (None, False):
             self.finish_update(sgd)
         docs = [eg.predicted for eg in examples]
-        # TODO: Refactor so we don't have to parse twice like this (ugh)
-        # The issue is that we cut up the gold batch into sub-states, and that
-        # makes it hard to get the actual predicted transition sequence.
-        predicted_states = self.predict(docs)
-        self.set_annotations(docs, predicted_states)
+        states = [
+            self.moves.follow_history(doc, history)
+            for doc, history in zip(docs, histories)
+        ]
+        self.set_annotations(docs, self._get_states(docs, states))
         # Ugh, this is annoying. If we're working on GPU, we want to free the
         # memory ASAP. It seems that Python doesn't necessarily get around to
         # removing these in time if we don't explicitly delete? It's confusing.
@@ -435,13 +441,16 @@ cdef class Parser(TrainablePipe):
 
     def update_beam(self, examples, *, beam_width,
             drop=0., sgd=None, losses=None, beam_density=0.0):
-        states, golds, _ = self.moves.init_gold_batch(examples)
+        if losses is None:
+            losses = {}
+        losses.setdefault(self.name, 0.0)
+        states, golds, docs = self.moves.init_gold_batch(examples)
         if not states:
             return losses
         # Prepare the stepwise model, and get the callback for finishing the batch
         model, backprop_tok2vec = self.model.begin_update(
             [eg.predicted for eg in examples])
-        loss = _beam_utils.update_beam(
+        predicted_histories, loss = _beam_utils.update_beam(
             self.moves,
             states,
             golds,
@@ -453,6 +462,12 @@ cdef class Parser(TrainablePipe):
         backprop_tok2vec(golds)
         if sgd is not None:
             self.finish_update(sgd)
+        states = [
+            self.moves.follow_history(doc, history)
+            for doc, history in zip(docs, predicted_histories)
+        ]
+        self.set_annotations(docs, states)
+        return losses
 
     def get_batch_loss(self, states, golds, float[:, ::1] scores, losses):
         cdef StateClass state
@@ -595,18 +610,24 @@ cdef class Parser(TrainablePipe):
         states = []
         golds = []
         to_cut = []
+        # Return a list indicating the position in the batch that each state
+        # refers to. This lets us put together the full list of predicted 
+        # histories.
+        state2doc = []
+        doc2i = {eg.x: i for i, eg in enumerate(examples)}
         for state, eg in zip(all_states, examples):
             if self.moves.has_gold(eg) and not state.is_final():
                 gold = self.moves.init_gold(state, eg)
                 if len(eg.x) < max_length:
                     states.append(state)
                     golds.append(gold)
+                    state2doc.append(doc2i[eg.x])
                 else:
                     oracle_actions = self.moves.get_oracle_sequence_from_state(
                         state.copy(), gold)
                     to_cut.append((eg, state, gold, oracle_actions))
         if not to_cut:
-            return states, golds, 0
+            return states, golds, 0, state2doc
         cdef int clas
         for eg, state, gold, oracle_actions in to_cut:
             for i in range(0, len(oracle_actions), max_length):
@@ -619,6 +640,7 @@ cdef class Parser(TrainablePipe):
                 if self.moves.has_gold(eg, start_state.B(0), state.B(0)):
                     states.append(start_state)
                     golds.append(gold)
+                    state2doc.append(doc2i[eg.x])
                 if state.is_final():
                     break
-        return states, golds, max_length
+        return states, golds, max_length, state2doc

--- a/spacy/pipeline/transition_parser.pyx
+++ b/spacy/pipeline/transition_parser.pyx
@@ -290,6 +290,9 @@ cdef class Parser(TrainablePipe):
 
     cdef void c_transition_batch(self, StateC** states, const float* scores,
             int nr_class, int batch_size) nogil:
+        # n_moves should not be zero at this point, but make sure to avoid zero-length mem alloc
+        with gil:
+            assert self.moves.n_moves > 0, Errors.E924.format(name=self.name)
         is_valid = <int*>calloc(self.moves.n_moves, sizeof(int))
         cdef int i, guess
         cdef Transition action
@@ -307,7 +310,6 @@ cdef class Parser(TrainablePipe):
 
     def update(self, examples, *, drop=0., sgd=None, losses=None):
         cdef StateClass state
-        cdef Transition action
         if losses is None:
             losses = {}
         losses.setdefault(self.name, 0.)
@@ -349,9 +351,6 @@ cdef class Parser(TrainablePipe):
         all_states = list(states)
         states_golds = list(zip(states, golds, state2doc))
         n_moves = 0
-        mem = Pool()
-        is_valid = <int*>mem.alloc(self.moves.n_moves, sizeof(int))
-        cdef float[::1] scores_row
         while states_golds:
             states, golds, state2doc = zip(*states_golds)
             scores, backprop = model.begin_update(states)
@@ -361,20 +360,10 @@ cdef class Parser(TrainablePipe):
             # can't normalize by the number of states either, as then we'd
             # be getting smaller gradients for states in long sequences.
             backprop(d_scores)
-            # Ugh, we need to get the actions for the histories, so we're
-            # duplicating work that's being done in transition_states. This
-            # should be refactored.
-            scores_view = scores
-            for i, state in enumerate(states):
-                self.moves.set_valid(is_valid, state.c)
-                scores_row = scores[i]
-                guess = arg_max_if_valid(&scores_row[0], is_valid, scores.shape[1])
-                if guess == -1:
-                    raise ValueError("Could not find valid transition")
-                histories[state2doc[i]].append(guess)
-                # Follow the predicted action
-                action = self.moves.c[guess]
-                action.do(state.c, action.label)
+            # Follow the predicted action
+            actions = self.transition_states(states, scores)
+            for i, action in enumerate(actions):
+                histories[i].append(action)
             states_golds = [
                 s for s  in zip(states, golds, state2doc)
                 if not s[0].is_final()

--- a/spacy/tokens/_dict_proxies.py
+++ b/spacy/tokens/_dict_proxies.py
@@ -34,7 +34,7 @@ class SpanGroups(UserDict):
         return SpanGroup(self.doc_ref(), name=name, spans=spans)
 
     def copy(self) -> "SpanGroups":
-        return SpanGroup(self.doc_ref()).from_bytes(self.to_bytes())
+        return SpanGroups(self.doc_ref()).from_bytes(self.to_bytes())
 
     def to_bytes(self) -> bytes:
         # We don't need to serialize this as a dict, because the groups

--- a/spacy/tokens/_dict_proxies.py
+++ b/spacy/tokens/_dict_proxies.py
@@ -33,6 +33,9 @@ class SpanGroups(UserDict):
     def _make_span_group(self, name: str, spans: Iterable["Span"]) -> SpanGroup:
         return SpanGroup(self.doc_ref(), name=name, spans=spans)
 
+    def copy(self) -> "SpanGroups":
+        return SpanGroup(self.doc_ref()).from_bytes(self.to_bytes())
+
     def to_bytes(self) -> bytes:
         # We don't need to serialize this as a dict, because the groups
         # know their names.

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -261,11 +261,11 @@ cdef class Doc:
         cdef const LexemeC* lexeme
         for word, has_space in zip(words, spaces):
             if isinstance(word, unicode):
-                lexeme = self.vocab.get(self.mem, word)
+                lexeme = self.vocab.get(self.vocab.mem, word)
             elif isinstance(word, bytes):
                 raise ValueError(Errors.E028.format(value=word))
             else:
-                lexeme = self.vocab.get_by_orth(self.mem, word)
+                lexeme = self.vocab.get_by_orth(self.vocab.mem, word)
             self.push_back(lexeme, has_space)
 
         if heads is not None:
@@ -1185,6 +1185,7 @@ cdef class Doc:
         other.user_hooks = dict(self.user_hooks)
         other.user_token_hooks = dict(self.user_token_hooks)
         other.user_span_hooks = dict(self.user_span_hooks)
+        other.spans = self.spans.copy()
         other.length = self.length
         other.max_length = self.max_length
         buff_size = other.max_length + (PADDING*2)
@@ -1334,7 +1335,7 @@ cdef class Doc:
             end = start + attrs[i, 0]
             has_space = attrs[i, 1]
             orth_ = text[start:end]
-            lex = self.vocab.get(self.mem, orth_)
+            lex = self.vocab.get(self.vocab.mem, orth_)
             self.push_back(lex, has_space)
             start = end + has_space
         self.from_array(msg["array_head"][2:], attrs[:, 2:])

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -1180,12 +1180,12 @@ cdef class Doc:
         other.tensor = copy.deepcopy(self.tensor)
         other.cats = copy.deepcopy(self.cats)
         other.user_data = copy.deepcopy(self.user_data)
+        other.spans = self.spans.copy()
         other.sentiment = self.sentiment
         other.has_unknown_spaces = self.has_unknown_spaces
         other.user_hooks = dict(self.user_hooks)
         other.user_token_hooks = dict(self.user_token_hooks)
         other.user_span_hooks = dict(self.user_span_hooks)
-        other.spans = self.spans.copy()
         other.length = self.length
         other.max_length = self.max_length
         buff_size = other.max_length + (PADDING*2)

--- a/spacy/vocab.pyx
+++ b/spacy/vocab.pyx
@@ -161,8 +161,11 @@ cdef class Vocab:
             return self._new_lexeme(mem, self.strings[orth])
 
     cdef const LexemeC* _new_lexeme(self, Pool mem, unicode string) except NULL:
-        if len(string) < 3 or self.length < 10000:
-            mem = self.mem
+        #if len(string) < 3 or self.length < 10000:
+        #    mem = self.mem
+        # TODO: Experiment with never allowing the Doc to own lexemes, to see
+        # if it solves the Doc.copy() issue.
+        mem = self.mem
         cdef bint is_oov = mem is not self.mem
         lex = <LexemeC*>mem.alloc(1, sizeof(LexemeC))
         lex.orth = self.strings.add(string)


### PR DESCRIPTION
Fix two training bugs that were introduced by #6765 and #6767 .

1. In #6765, we're calling into `Doc.copy()`. It turns out this method had a bug. It didn't account for the fact that the `Doc` object was allowed to own the `LexemeC` struct. If the original `Doc` becomes freed before the copy, we would orphan the `LexemeC` struct. I think the idea of having the `Doc` own the `LexemeC` sometimes is just bad. I introduced this as a memory efficiency for long-running processes, but it's a weird hack that cuts against the original design, and I think the codebase is better off without it. To minimise the changes I've only made a change in the `Vocab`, but I should refactor things based on this.
2. The parser needs to be updated carefully to do the #6767 change of calling `set_annotations` in its update method. The parser plays this trick of dividing up the batch into sub-sequences, so that we can make the batch more even in length. This means we don't have a single predicted sequence for the states. I've changed it to use the oracle sequence, instead of making new predictions.
