### PR TITLE
Fix Doc.copy bugs

### DIFF
--- a/spacy/tokens/_dict_proxies.py
+++ b/spacy/tokens/_dict_proxies.py
@@ -33,6 +33,9 @@ class SpanGroups(UserDict):
     def _make_span_group(self, name: str, spans: Iterable["Span"]) -> SpanGroup:
         return SpanGroup(self.doc_ref(), name=name, spans=spans)
 
+    def copy(self) -> "SpanGroups":
+        return SpanGroups(self.doc_ref()).from_bytes(self.to_bytes())
+
     def to_bytes(self) -> bytes:
         # We don't need to serialize this as a dict, because the groups
         # know their names.

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -1187,6 +1187,7 @@ cdef class Doc:
         other.user_span_hooks = dict(self.user_span_hooks)
         other.length = self.length
         other.max_length = self.max_length
+        other.spans = self.spans.copy()
         buff_size = other.max_length + (PADDING*2)
         assert buff_size > 0
         tokens = <TokenC*>other.mem.alloc(buff_size, sizeof(TokenC))


### PR DESCRIPTION
* Avoid letting the `Doc` object own `LexemeC` data. Instead all lexemes should be owned by the `Vocab`. Also avoids weird heuristics.
* Copy `doc.spans` attribute.
