### PR TITLE
Error handling in nlp.pipe

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1293,7 +1293,7 @@ class Language:
             Function that deals with a failing batch of documents. This callable function should take in
             the component's name, the component itself, the offending batch of documents, and the exception
             that was thrown.
-        DOCS: https://nightly.spacy.io/api/language#set_error_handler (TODO)
+        DOCS: https://nightly.spacy.io/api/language#set_error_handler
         """
         self.default_error_handler = error_handler
         for name, pipe in self.pipeline:

--- a/spacy/pipeline/attributeruler.py
+++ b/spacy/pipeline/attributeruler.py
@@ -96,32 +96,36 @@ class AttributeRuler(Pipe):
 
         DOCS: https://nightly.spacy.io/api/attributeruler#call
         """
-        matches = self.matcher(doc, allow_missing=True)
-        # Sort by the attribute ID, so that later rules have precendence
-        matches = [
-            (int(self.vocab.strings[m_id]), m_id, s, e) for m_id, s, e in matches
-        ]
-        matches.sort()
-        for attr_id, match_id, start, end in matches:
-            span = Span(doc, start, end, label=match_id)
-            attrs = self.attrs[attr_id]
-            index = self.indices[attr_id]
-            try:
-                # The index can be negative, which makes it annoying to do
-                # the boundscheck. Let Span do it instead.
-                token = span[index]  # noqa: F841
-            except IndexError:
-                # The original exception is just our conditional logic, so we
-                # raise from.
-                raise ValueError(
-                    Errors.E1001.format(
-                        patterns=self.matcher.get(span.label),
-                        span=[t.text for t in span],
-                        index=index,
-                    )
-                ) from None
-            set_token_attrs(span[index], attrs)
-        return doc
+        error_handler = self.get_error_handler()
+        try:
+            matches = self.matcher(doc, allow_missing=True)
+            # Sort by the attribute ID, so that later rules have precendence
+            matches = [
+                (int(self.vocab.strings[m_id]), m_id, s, e) for m_id, s, e in matches
+            ]
+            matches.sort()
+            for attr_id, match_id, start, end in matches:
+                span = Span(doc, start, end, label=match_id)
+                attrs = self.attrs[attr_id]
+                index = self.indices[attr_id]
+                try:
+                    # The index can be negative, which makes it annoying to do
+                    # the boundscheck. Let Span do it instead.
+                    token = span[index]  # noqa: F841
+                except IndexError:
+                    # The original exception is just our conditional logic, so we
+                    # raise from.
+                    raise ValueError(
+                        Errors.E1001.format(
+                            patterns=self.matcher.get(span.label),
+                            span=[t.text for t in span],
+                            index=index,
+                        )
+                    ) from None
+                set_token_attrs(span[index], attrs)
+            return doc
+        except Exception as e:
+            error_handler(self.name, self, [doc], e)
 
     def load_from_tag_map(
         self, tag_map: Dict[str, Dict[Union[int, str], Union[int, str]]]

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -276,18 +276,6 @@ class EntityLinker(TrainablePipe):
         loss = loss / len(entity_encodings)
         return loss, gradients
 
-    def __call__(self, doc: Doc) -> Doc:
-        """Apply the pipe to a Doc.
-
-        doc (Doc): The document to process.
-        RETURNS (Doc): The processed Doc.
-
-        DOCS: https://nightly.spacy.io/api/entitylinker#call
-        """
-        kb_ids = self.predict([doc])
-        self.set_annotations([doc], kb_ids)
-        return doc
-
     def predict(self, docs: Iterable[Doc]) -> List[str]:
         """Apply the pipeline's model to a batch of docs, without modifying them.
         Returns the KB IDs for each entity in each doc, including NIL if there is

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -288,34 +288,6 @@ class EntityLinker(TrainablePipe):
         self.set_annotations([doc], kb_ids)
         return doc
 
-    def pipe(
-        self,
-        stream: Iterable[Doc],
-        *,
-        batch_size: int = 128,
-        error_handler: Callable[[str, List[Doc], Exception], Any] = raise_error,
-    ) -> Iterator[Doc]:
-        """Apply the pipe to a stream of documents. This usually happens under
-        the hood when the nlp object is called on a text and all components are
-        applied to the Doc.
-
-        stream (Iterable[Doc]): A stream of documents.
-        batch_size (int): The number of documents to buffer.
-        error_handler (Callable[[str, List[Doc], Exception], Any]): Function that
-            deals with a failing batch of documents. The default function just reraises
-            the exception.
-        YIELDS (Doc): Processed documents in order.
-
-        DOCS: https://nightly.spacy.io/api/entitylinker#pipe
-        """
-        for docs in util.minibatch(stream, size=batch_size):
-            try:
-                kb_ids = self.predict(docs)
-                self.set_annotations(docs, kb_ids)
-                yield from docs
-            except Exception as e:
-                error_handler(self.name, docs, e)
-
     def predict(self, docs: Iterable[Doc]) -> List[str]:
         """Apply the pipeline's model to a batch of docs, without modifying them.
         Returns the KB IDs for each entity in each doc, including NIL if there is

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -1,4 +1,4 @@
-from typing import Optional, Iterable, Callable, Dict, Iterator, Union, List, Any
+from typing import Optional, Iterable, Callable, Dict, Union, List
 from pathlib import Path
 from itertools import islice
 import srsly
@@ -16,7 +16,7 @@ from ..language import Language
 from ..vocab import Vocab
 from ..training import Example, validate_examples, validate_get_examples
 from ..errors import Errors, Warnings
-from ..util import SimpleFrozenList, raise_error
+from ..util import SimpleFrozenList
 from .. import util
 from ..scorer import Scorer
 

--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -135,35 +135,39 @@ class EntityRuler(Pipe):
 
         DOCS: https://nightly.spacy.io/api/entityruler#call
         """
-        matches = list(self.matcher(doc)) + list(self.phrase_matcher(doc))
-        matches = set(
-            [(m_id, start, end) for m_id, start, end in matches if start != end]
-        )
-        get_sort_key = lambda m: (m[2] - m[1], -m[1])
-        matches = sorted(matches, key=get_sort_key, reverse=True)
-        entities = list(doc.ents)
-        new_entities = []
-        seen_tokens = set()
-        for match_id, start, end in matches:
-            if any(t.ent_type for t in doc[start:end]) and not self.overwrite:
-                continue
-            # check for end - 1 here because boundaries are inclusive
-            if start not in seen_tokens and end - 1 not in seen_tokens:
-                if match_id in self._ent_ids:
-                    label, ent_id = self._ent_ids[match_id]
-                    span = Span(doc, start, end, label=label)
-                    if ent_id:
-                        for token in span:
-                            token.ent_id_ = ent_id
-                else:
-                    span = Span(doc, start, end, label=match_id)
-                new_entities.append(span)
-                entities = [
-                    e for e in entities if not (e.start < end and e.end > start)
-                ]
-                seen_tokens.update(range(start, end))
-        doc.ents = entities + new_entities
-        return doc
+        error_handler = self.get_error_handler()
+        try:
+            matches = list(self.matcher(doc)) + list(self.phrase_matcher(doc))
+            matches = set(
+                [(m_id, start, end) for m_id, start, end in matches if start != end]
+            )
+            get_sort_key = lambda m: (m[2] - m[1], -m[1])
+            matches = sorted(matches, key=get_sort_key, reverse=True)
+            entities = list(doc.ents)
+            new_entities = []
+            seen_tokens = set()
+            for match_id, start, end in matches:
+                if any(t.ent_type for t in doc[start:end]) and not self.overwrite:
+                    continue
+                # check for end - 1 here because boundaries are inclusive
+                if start not in seen_tokens and end - 1 not in seen_tokens:
+                    if match_id in self._ent_ids:
+                        label, ent_id = self._ent_ids[match_id]
+                        span = Span(doc, start, end, label=label)
+                        if ent_id:
+                            for token in span:
+                                token.ent_id_ = ent_id
+                    else:
+                        span = Span(doc, start, end, label=match_id)
+                    new_entities.append(span)
+                    entities = [
+                        e for e in entities if not (e.start < end and e.end > start)
+                    ]
+                    seen_tokens.update(range(start, end))
+            doc.ents = entities + new_entities
+            return doc
+        except Exception as e:
+            error_handler(self.name, self, [doc], e)
 
     @property
     def labels(self) -> Tuple[str, ...]:

--- a/spacy/pipeline/lemmatizer.py
+++ b/spacy/pipeline/lemmatizer.py
@@ -103,10 +103,14 @@ class Lemmatizer(Pipe):
         """
         if not self._validated:
             self._validate_tables(Errors.E1004)
-        for token in doc:
-            if self.overwrite or token.lemma == 0:
-                token.lemma_ = self.lemmatize(token)[0]
-        return doc
+        error_handler = self.get_error_handler()
+        try:
+            for token in doc:
+                if self.overwrite or token.lemma == 0:
+                    token.lemma_ = self.lemmatize(token)[0]
+            return doc
+        except Exception as e:
+            error_handler(self.name, self, [doc], e)
 
     def initialize(
         self,

--- a/spacy/pipeline/lemmatizer.py
+++ b/spacy/pipeline/lemmatizer.py
@@ -150,33 +150,6 @@ class Lemmatizer(Pipe):
                 )
         self._validated = True
 
-    def pipe(
-        self,
-        stream: Iterable[Doc],
-        *,
-        batch_size: int = 128,
-        error_handler: Callable[[str, List[Doc], Exception], Any] = raise_error,
-    ) -> Iterator[Doc]:
-        """Apply the pipe to a stream of documents. This usually happens under
-        the hood when the nlp object is called on a text and all components are
-        applied to the Doc.
-
-        stream (Iterable[Doc]): A stream of documents.
-        batch_size (int): The number of documents to buffer.
-        error_handler (Callable[[str, List[Doc], Exception], Any]): Function that
-            deals with a failing batch of documents. The default function just reraises
-            the exception.
-        YIELDS (Doc): Processed documents in order.
-
-        DOCS: https://nightly.spacy.io/api/lemmatizer#pipe
-        """
-        for doc in stream:
-            try:
-                doc = self(doc)
-                yield doc
-            except Exception as e:
-                error_handler(self.name, [doc], e)
-
     def lookup_lemmatize(self, token: Token) -> List[str]:
         """Lemmatize using a lookup-based approach.
 

--- a/spacy/pipeline/lemmatizer.py
+++ b/spacy/pipeline/lemmatizer.py
@@ -12,7 +12,7 @@ from ..scorer import Scorer
 from ..tokens import Doc, Token
 from ..vocab import Vocab
 from ..training import validate_examples
-from ..util import logger, SimpleFrozenList, raise_error
+from ..util import logger, SimpleFrozenList
 from .. import util
 
 

--- a/spacy/pipeline/pipe.pyx
+++ b/spacy/pipeline/pipe.pyx
@@ -111,7 +111,7 @@ cdef class Pipe:
             the component's name, the component itself, the offending batch of documents, and the exception
             that was thrown.
 
-        DOCS: https://nightly.spacy.io/api/pipe#set_error_handler (TODO)
+        DOCS: https://nightly.spacy.io/api/pipe#set_error_handler
         """
         self.error_handler = error_handler
 
@@ -120,7 +120,7 @@ cdef class Pipe:
 
         RETURNS (Callable): The error handler, or if it's not set a default function that just reraises.
 
-        DOCS: https://nightly.spacy.io/api/pipe#get_error_handler (TODO)
+        DOCS: https://nightly.spacy.io/api/pipe#get_error_handler
         """
         if hasattr(self, "error_handler"):
             return self.error_handler

--- a/spacy/pipeline/pipe.pyx
+++ b/spacy/pipeline/pipe.pyx
@@ -38,12 +38,7 @@ cdef class Pipe:
         """
         raise NotImplementedError(Errors.E931.format(parent="Pipe", method="__call__", name=self.name))
 
-    def pipe(
-        self,
-        stream: Iterable[Doc],
-        *,
-        batch_size: int = 128,
-    ) -> Iterator[Doc]:
+    def pipe(self, stream: Iterable[Doc], *, batch_size: int=128) -> Iterator[Doc]:
         """Apply the pipe to a stream of documents. This usually happens under
         the hood when the nlp object is called on a text and all components are
         applied to the Doc.

--- a/spacy/pipeline/pipe.pyx
+++ b/spacy/pipeline/pipe.pyx
@@ -1,5 +1,5 @@
 # cython: infer_types=True, profile=True
-from typing import Optional, Tuple, Iterable, Iterator, Callable, Union, Dict, List, Any
+from typing import Optional, Tuple, Iterable, Iterator, Callable, Union, Dict
 import srsly
 import warnings
 

--- a/spacy/pipeline/sentencizer.pyx
+++ b/spacy/pipeline/sentencizer.pyx
@@ -1,5 +1,5 @@
 # cython: infer_types=True, profile=True, binding=True
-from typing import Optional, List, Callable, Any
+from typing import Optional, List
 import srsly
 
 from ..tokens.doc cimport Doc
@@ -8,7 +8,6 @@ from ..language import Language
 from ..scorer import Scorer
 from ..training import validate_examples
 from .. import util
-from ..util import raise_error
 
 @Language.factory(
     "sentencizer",

--- a/spacy/pipeline/sentencizer.pyx
+++ b/spacy/pipeline/sentencizer.pyx
@@ -65,20 +65,24 @@ class Sentencizer(Pipe):
 
         DOCS: https://nightly.spacy.io/api/sentencizer#call
         """
-        start = 0
-        seen_period = False
-        for i, token in enumerate(doc):
-            is_in_punct_chars = token.text in self.punct_chars
-            token.is_sent_start = i == 0
-            if seen_period and not token.is_punct and not is_in_punct_chars:
+        error_handler = self.get_error_handler()
+        try:
+            start = 0
+            seen_period = False
+            for i, token in enumerate(doc):
+                is_in_punct_chars = token.text in self.punct_chars
+                token.is_sent_start = i == 0
+                if seen_period and not token.is_punct and not is_in_punct_chars:
+                    doc[start].is_sent_start = True
+                    start = token.i
+                    seen_period = False
+                elif is_in_punct_chars:
+                    seen_period = True
+            if start < len(doc):
                 doc[start].is_sent_start = True
-                start = token.i
-                seen_period = False
-            elif is_in_punct_chars:
-                seen_period = True
-        if start < len(doc):
-            doc[start].is_sent_start = True
-        return doc
+            return doc
+        except Exception as e:
+            error_handler(self.name, self, [doc], e)
 
     def predict(self, docs):
         """Apply the pipe to a batch of docs, without modifying them.

--- a/spacy/pipeline/sentencizer.pyx
+++ b/spacy/pipeline/sentencizer.pyx
@@ -80,33 +80,6 @@ class Sentencizer(Pipe):
             doc[start].is_sent_start = True
         return doc
 
-    def pipe(
-        self,
-        stream,
-        batch_size = 128,
-        error_handler: Callable[[str, List[Doc], Exception], Any] = raise_error,
-    ):
-        """Apply the pipe to a stream of documents. This usually happens under
-        the hood when the nlp object is called on a text and all components are
-        applied to the Doc.
-
-        stream (Iterable[Doc]): A stream of documents.
-        batch_size (int): The number of documents to buffer.
-        error_handler (Callable[[str, List[Doc], Exception], Any]): Function that
-            deals with a failing batch of documents. The default function just reraises
-            the exception.
-        YIELDS (Doc): Processed documents in order.
-
-        DOCS: https://nightly.spacy.io/api/sentencizer#pipe
-        """
-        for docs in util.minibatch(stream, size=batch_size):
-            try:
-                predictions = self.predict(docs)
-                self.set_annotations(docs, predictions)
-                yield from docs
-            except Exception as e:
-                error_handler(self.name, docs, e)
-
     def predict(self, docs):
         """Apply the pipe to a batch of docs, without modifying them.
 

--- a/spacy/pipeline/sentencizer.pyx
+++ b/spacy/pipeline/sentencizer.pyx
@@ -66,22 +66,25 @@ class Sentencizer(Pipe):
         """
         error_handler = self.get_error_handler()
         try:
-            start = 0
-            seen_period = False
-            for i, token in enumerate(doc):
-                is_in_punct_chars = token.text in self.punct_chars
-                token.is_sent_start = i == 0
-                if seen_period and not token.is_punct and not is_in_punct_chars:
-                    doc[start].is_sent_start = True
-                    start = token.i
-                    seen_period = False
-                elif is_in_punct_chars:
-                    seen_period = True
-            if start < len(doc):
-                doc[start].is_sent_start = True
+            self._call(doc)
             return doc
         except Exception as e:
             error_handler(self.name, self, [doc], e)
+
+    def _call(self, doc):
+        start = 0
+        seen_period = False
+        for i, token in enumerate(doc):
+            is_in_punct_chars = token.text in self.punct_chars
+            token.is_sent_start = i == 0
+            if seen_period and not token.is_punct and not is_in_punct_chars:
+                doc[start].is_sent_start = True
+                start = token.i
+                seen_period = False
+            elif is_in_punct_chars:
+                seen_period = True
+        if start < len(doc):
+            doc[start].is_sent_start = True
 
     def predict(self, docs):
         """Apply the pipe to a batch of docs, without modifying them.

--- a/spacy/pipeline/sentencizer.pyx
+++ b/spacy/pipeline/sentencizer.pyx
@@ -1,15 +1,14 @@
 # cython: infer_types=True, profile=True, binding=True
+from typing import Optional, List, Callable, Any
 import srsly
-from typing import Optional, List
 
 from ..tokens.doc cimport Doc
-
 from .pipe import Pipe
 from ..language import Language
 from ..scorer import Scorer
 from ..training import validate_examples
 from .. import util
-
+from ..util import raise_error
 
 @Language.factory(
     "sentencizer",
@@ -81,21 +80,32 @@ class Sentencizer(Pipe):
             doc[start].is_sent_start = True
         return doc
 
-    def pipe(self, stream, batch_size=128):
+    def pipe(
+        self,
+        stream,
+        batch_size = 128,
+        error_handler: Callable[[str, List[Doc], Exception], Any] = raise_error,
+    ):
         """Apply the pipe to a stream of documents. This usually happens under
         the hood when the nlp object is called on a text and all components are
         applied to the Doc.
 
         stream (Iterable[Doc]): A stream of documents.
         batch_size (int): The number of documents to buffer.
+        error_handler (Callable[[str, List[Doc], Exception], Any]): Function that
+            deals with a failing batch of documents. The default function just reraises
+            the exception.
         YIELDS (Doc): Processed documents in order.
 
         DOCS: https://nightly.spacy.io/api/sentencizer#pipe
         """
         for docs in util.minibatch(stream, size=batch_size):
-            predictions = self.predict(docs)
-            self.set_annotations(docs, predictions)
-            yield from docs
+            try:
+                predictions = self.predict(docs)
+                self.set_annotations(docs, predictions)
+                yield from docs
+            except Exception as e:
+                error_handler(self.name, docs, e)
 
     def predict(self, docs):
         """Apply the pipe to a batch of docs, without modifying them.

--- a/spacy/pipeline/tagger.pyx
+++ b/spacy/pipeline/tagger.pyx
@@ -108,34 +108,6 @@ class Tagger(TrainablePipe):
         self.set_annotations([doc], tags)
         return doc
 
-    def pipe(
-        self,
-        stream,
-        *,
-        batch_size = 128,
-        error_handler: Callable[[str, List[Doc], Exception], Any] = raise_error,
-    ):
-        """Apply the pipe to a stream of documents. This usually happens under
-        the hood when the nlp object is called on a text and all components are
-        applied to the Doc.
-
-        stream (Iterable[Doc]): A stream of documents.
-        batch_size (int): The number of documents to buffer.
-        error_handler (Callable[[str, List[Doc], Exception], Any]): Function that
-            deals with a failing batch of documents. The default function just reraises
-            the exception.
-        YIELDS (Doc): Processed documents in order.
-
-        DOCS: https://nightly.spacy.io/api/tagger#pipe
-        """
-        for docs in util.minibatch(stream, size=batch_size):
-            try:
-                tag_ids = self.predict(docs)
-                self.set_annotations(docs, tag_ids)
-                yield from docs
-            except Exception as e:
-                error_handler(self.name, docs, e)
-
     def predict(self, docs):
         """Apply the pipeline's model to a batch of docs, without modifying them.
 

--- a/spacy/pipeline/tagger.pyx
+++ b/spacy/pipeline/tagger.pyx
@@ -96,18 +96,6 @@ class Tagger(TrainablePipe):
         """Data about the labels currently added to the component."""
         return tuple(self.cfg["labels"])
 
-    def __call__(self, doc):
-        """Apply the pipe to a Doc.
-
-        doc (Doc): The document to process.
-        RETURNS (Doc): The processed Doc.
-
-        DOCS: https://nightly.spacy.io/api/tagger#call
-        """
-        tags = self.predict([doc])
-        self.set_annotations([doc], tags)
-        return doc
-
     def predict(self, docs):
         """Apply the pipeline's model to a batch of docs, without modifying them.
 

--- a/spacy/pipeline/tagger.pyx
+++ b/spacy/pipeline/tagger.pyx
@@ -1,5 +1,4 @@
 # cython: infer_types=True, profile=True, binding=True
-from typing import List, Callable, Any
 import numpy
 import srsly
 from thinc.api import Model, set_dropout_rate, SequenceCategoricalCrossentropy, Config
@@ -9,7 +8,6 @@ from itertools import islice
 
 from ..tokens.doc cimport Doc
 from ..morphology cimport Morphology
-from ..util import raise_error
 from ..vocab cimport Vocab
 
 from .trainable_pipe import TrainablePipe

--- a/spacy/pipeline/textcat.py
+++ b/spacy/pipeline/textcat.py
@@ -145,34 +145,6 @@ class TextCategorizer(TrainablePipe):
         """
         return self.labels
 
-    def pipe(
-        self,
-        stream: Iterable[Doc],
-        *,
-        batch_size: int = 128,
-        error_handler: Callable[[str, List[Doc], Exception], Any] = raise_error,
-    ) -> Iterator[Doc]:
-        """Apply the pipe to a stream of documents. This usually happens under
-        the hood when the nlp object is called on a text and all components are
-        applied to the Doc.
-
-        stream (Iterable[Doc]): A stream of documents.
-        batch_size (int): The number of documents to buffer.
-        error_handler (Callable[[str, List[Doc], Exception], Any]): Function that
-            deals with a failing batch of documents. The default function just reraises
-            the exception.
-        YIELDS (Doc): Processed documents in order.
-
-        DOCS: https://nightly.spacy.io/api/textcategorizer#pipe
-        """
-        for docs in util.minibatch(stream, size=batch_size):
-            try:
-                scores = self.predict(docs)
-                self.set_annotations(docs, scores)
-                yield from docs
-            except Exception as e:
-                error_handler(self.name, docs, e)
-
     def predict(self, docs: Iterable[Doc]):
         """Apply the pipeline's model to a batch of docs, without modifying them.
 

--- a/spacy/pipeline/textcat.py
+++ b/spacy/pipeline/textcat.py
@@ -11,6 +11,7 @@ from ..errors import Errors
 from ..scorer import Scorer
 from .. import util
 from ..tokens import Doc
+from ..util import raise_error
 from ..vocab import Vocab
 
 
@@ -144,21 +145,33 @@ class TextCategorizer(TrainablePipe):
         """
         return self.labels
 
-    def pipe(self, stream: Iterable[Doc], *, batch_size: int = 128) -> Iterator[Doc]:
+    def pipe(
+        self,
+        stream: Iterable[Doc],
+        *,
+        batch_size: int = 128,
+        error_handler: Callable[[str, List[Doc], Exception], Any] = raise_error,
+    ) -> Iterator[Doc]:
         """Apply the pipe to a stream of documents. This usually happens under
         the hood when the nlp object is called on a text and all components are
         applied to the Doc.
 
         stream (Iterable[Doc]): A stream of documents.
         batch_size (int): The number of documents to buffer.
+        error_handler (Callable[[str, List[Doc], Exception], Any]): Function that
+            deals with a failing batch of documents. The default function just reraises
+            the exception.
         YIELDS (Doc): Processed documents in order.
 
         DOCS: https://nightly.spacy.io/api/textcategorizer#pipe
         """
         for docs in util.minibatch(stream, size=batch_size):
-            scores = self.predict(docs)
-            self.set_annotations(docs, scores)
-            yield from docs
+            try:
+                scores = self.predict(docs)
+                self.set_annotations(docs, scores)
+                yield from docs
+            except Exception as e:
+                error_handler(self.name, docs, e)
 
     def predict(self, docs: Iterable[Doc]):
         """Apply the pipeline's model to a batch of docs, without modifying them.

--- a/spacy/pipeline/textcat.py
+++ b/spacy/pipeline/textcat.py
@@ -1,5 +1,5 @@
 from itertools import islice
-from typing import Iterable, Tuple, Optional, Dict, List, Callable, Iterator, Any
+from typing import Iterable, Tuple, Optional, Dict, List, Callable, Any
 from thinc.api import get_array_module, Model, Optimizer, set_dropout_rate, Config
 from thinc.types import Floats2d
 import numpy
@@ -9,9 +9,7 @@ from ..language import Language
 from ..training import Example, validate_examples, validate_get_examples
 from ..errors import Errors
 from ..scorer import Scorer
-from .. import util
 from ..tokens import Doc
-from ..util import raise_error
 from ..vocab import Vocab
 
 

--- a/spacy/pipeline/tok2vec.py
+++ b/spacy/pipeline/tok2vec.py
@@ -1,4 +1,4 @@
-from typing import Iterator, Sequence, Iterable, Optional, Dict, Callable, List, Any
+from typing import Sequence, Iterable, Optional, Dict, Callable, List
 from thinc.api import Model, set_dropout_rate, Optimizer, Config
 from itertools import islice
 
@@ -8,7 +8,6 @@ from ..tokens import Doc
 from ..vocab import Vocab
 from ..language import Language
 from ..errors import Errors
-from ..util import minibatch, raise_error
 
 default_model_config = """
 [model]

--- a/spacy/pipeline/tok2vec.py
+++ b/spacy/pipeline/tok2vec.py
@@ -111,35 +111,6 @@ class Tok2Vec(TrainablePipe):
         self.set_annotations([doc], tokvecses)
         return doc
 
-    def pipe(
-        self,
-        stream: Iterator[Doc],
-        *,
-        batch_size: int = 128,
-        error_handler: Callable[[str, List[Doc], Exception], Any] = raise_error,
-    ) -> Iterator[Doc]:
-        """Apply the pipe to a stream of documents. This usually happens under
-        the hood when the nlp object is called on a text and all components are
-        applied to the Doc.
-
-        stream (Iterable[Doc]): A stream of documents.
-        batch_size (int): The number of documents to buffer.
-        error_handler (Callable[[str, List[Doc], Exception], Any]): Function that
-            deals with a failing batch of documents. The default function just reraises
-            the exception.
-        YIELDS (Doc): Processed documents in order.
-
-        DOCS: https://nightly.spacy.io/api/tok2vec#pipe
-        """
-        for docs in minibatch(stream, batch_size):
-            try:
-                docs = list(docs)
-                tokvecses = self.predict(docs)
-                self.set_annotations(docs, tokvecses)
-                yield from docs
-            except Exception as e:
-                error_handler(self.name, docs, e)
-
     def predict(self, docs: Iterable[Doc]):
         """Apply the pipeline's model to a batch of docs, without modifying them.
         Returns a single tensor for a batch of documents.

--- a/spacy/pipeline/tok2vec.py
+++ b/spacy/pipeline/tok2vec.py
@@ -98,19 +98,6 @@ class Tok2Vec(TrainablePipe):
                 if isinstance(node, Tok2VecListener) and node.upstream_name in names:
                     self.add_listener(node, component.name)
 
-    def __call__(self, doc: Doc) -> Doc:
-        """Add context-sensitive embeddings to the Doc.tensor attribute, allowing
-        them to be used as features by downstream components.
-
-        docs (Doc): The Doc to process.
-        RETURNS (Doc): The processed Doc.
-
-        DOCS: https://nightly.spacy.io/api/tok2vec#call
-        """
-        tokvecses = self.predict([doc])
-        self.set_annotations([doc], tokvecses)
-        return doc
-
     def predict(self, docs: Iterable[Doc]):
         """Apply the pipeline's model to a batch of docs, without modifying them.
         Returns a single tensor for a batch of documents.

--- a/spacy/pipeline/trainable_pipe.pyx
+++ b/spacy/pipeline/trainable_pipe.pyx
@@ -55,12 +55,7 @@ cdef class TrainablePipe(Pipe):
         except Exception as e:
             error_handler(self.name, self, [doc], e)
 
-    def pipe(
-        self,
-        stream: Iterable[Doc],
-        *,
-        batch_size: int = 128,
-    ) -> Iterator[Doc]:
+    def pipe(self, stream: Iterable[Doc], *, batch_size: int=128) -> Iterator[Doc]:
         """Apply the pipe to a stream of documents. This usually happens under
         the hood when the nlp object is called on a text and all components are
         applied to the Doc.

--- a/spacy/pipeline/trainable_pipe.pyx
+++ b/spacy/pipeline/trainable_pipe.pyx
@@ -1,5 +1,5 @@
 # cython: infer_types=True, profile=True
-from typing import Iterable, Iterator, Optional, Dict, Tuple, Callable, List, Any
+from typing import Iterable, Iterator, Optional, Dict, Tuple, Callable
 import srsly
 from thinc.api import set_dropout_rate, Model, Optimizer
 
@@ -9,7 +9,6 @@ from ..training import validate_examples
 from ..errors import Errors
 from .pipe import Pipe, deserialize_config
 from .. import util
-from ..util import raise_error
 from ..vocab import Vocab
 from ..language import Language
 from ..training import Example

--- a/spacy/pipeline/trainable_pipe.pyx
+++ b/spacy/pipeline/trainable_pipe.pyx
@@ -1,5 +1,5 @@
 # cython: infer_types=True, profile=True
-from typing import Iterable, Iterator, Optional, Dict, Tuple, Callable
+from typing import Iterable, Iterator, Optional, Dict, Tuple, Callable, List, Any
 import srsly
 from thinc.api import set_dropout_rate, Model, Optimizer
 
@@ -9,6 +9,7 @@ from ..training import validate_examples
 from ..errors import Errors
 from .pipe import Pipe, deserialize_config
 from .. import util
+from ..util import raise_error
 from ..vocab import Vocab
 from ..language import Language
 from ..training import Example
@@ -51,21 +52,33 @@ cdef class TrainablePipe(Pipe):
         self.set_annotations([doc], scores)
         return doc
 
-    def pipe(self, stream: Iterable[Doc], *, batch_size: int=128) -> Iterator[Doc]:
+    def pipe(
+        self,
+        stream: Iterable[Doc],
+        *,
+        batch_size: int = 128,
+        error_handler: Callable[[str, List[Doc], Exception], Any] = raise_error,
+    ) -> Iterator[Doc]:
         """Apply the pipe to a stream of documents. This usually happens under
         the hood when the nlp object is called on a text and all components are
         applied to the Doc.
 
         stream (Iterable[Doc]): A stream of documents.
         batch_size (int): The number of documents to buffer.
+        error_handler (Callable[[str, List[Doc], Exception], Any]): Function that
+            deals with a failing batch of documents. The default function just reraises
+            the exception.
         YIELDS (Doc): Processed documents in order.
 
         DOCS: https://nightly.spacy.io/api/pipe#pipe
         """
         for docs in util.minibatch(stream, size=batch_size):
-            scores = self.predict(docs)
-            self.set_annotations(docs, scores)
-            yield from docs
+            try:
+                scores = self.predict(docs)
+                self.set_annotations(docs, scores)
+                yield from docs
+            except Exception as e:
+                error_handler(self.name, docs, e)
 
     def predict(self, docs: Iterable[Doc]):
         """Apply the pipeline's model to a batch of docs, without modifying them.

--- a/spacy/pipeline/transition_parser.pyx
+++ b/spacy/pipeline/transition_parser.pyx
@@ -1,6 +1,5 @@
 # cython: infer_types=True, cdivision=True, boundscheck=False, binding=True
 from __future__ import print_function
-from typing import Optional, Callable, List, Any
 from cymem.cymem cimport Pool
 cimport numpy as np
 from itertools import islice
@@ -29,7 +28,6 @@ from ._parser_internals import _beam_utils
 from ..training import validate_examples, validate_get_examples
 from ..errors import Errors, Warnings
 from .. import util
-from ..util import raise_error
 
 cdef class Parser(TrainablePipe):
     """
@@ -175,9 +173,7 @@ cdef class Parser(TrainablePipe):
         YIELDS (Doc): Documents, in order.
         """
         cdef Doc doc
-        error_handler = raise_error
-        if hasattr(self, "get_error_handler"):
-            error_handler = self.get_error_handler()
+        error_handler = self.get_error_handler()
         for batch in util.minibatch(docs, size=batch_size):
             batch_in_order = list(batch)
             try:

--- a/spacy/pipeline/transition_parser.pyx
+++ b/spacy/pipeline/transition_parser.pyx
@@ -156,12 +156,7 @@ cdef class Parser(TrainablePipe):
         with self.model.use_params(params):
             yield
 
-    def pipe(
-        self,
-        docs,
-        *,
-        int batch_size = 256,
-    ):
+    def pipe(self, docs, *, int batch_size=256):
         """Process a stream of documents.
 
         stream: The sequence of documents to process.

--- a/spacy/tests/test_language.py
+++ b/spacy/tests/test_language.py
@@ -1,4 +1,6 @@
 import itertools
+import logging
+from unittest import mock
 import pytest
 from spacy.language import Language
 from spacy.tokens import Doc, Span
@@ -6,7 +8,7 @@ from spacy.vocab import Vocab
 from spacy.training import Example
 from spacy.lang.en import English
 from spacy.lang.de import German
-from spacy.util import registry
+from spacy.util import registry, ignore_error, raise_error
 import spacy
 
 from .util import add_vecs_to_vocab, assert_docs_equal
@@ -159,6 +161,75 @@ def test_language_pipe_stream(nlp2, n_process, texts):
     n_fetch = 20
     for doc, expected_doc in itertools.islice(zip(docs, expecteds), n_fetch):
         assert_docs_equal(doc, expected_doc)
+
+
+def test_language_pipe_error_handler():
+    """Test that the error handling of nlp.pipe works well"""
+    nlp = English()
+    nlp.add_pipe("merge_subtokens")
+    nlp.initialize()
+    texts = ["Curious to see what will happen to this text.", "And this one."]
+    # the pipeline fails because there's no parser
+    with pytest.raises(ValueError):
+        nlp(texts[0])
+    with pytest.raises(ValueError):
+        list(nlp.pipe(texts))
+    with pytest.raises(ValueError):
+        list(nlp.pipe(texts, error_handler=raise_error))
+    docs = list(nlp.pipe(texts, error_handler=ignore_error))
+    assert len(docs) == 0
+
+
+def test_language_pipe_error_handler_custom(en_vocab):
+    """Test the error handling of a custom component that has no pipe method"""
+    @Language.component("my_evil_component")
+    def evil_component(doc):
+        if "2" in doc.text:
+            raise ValueError("no dice")
+        return doc
+
+    def warn_error(proc_name, docs, e):
+        from spacy.util import logger
+        logger.warning(f"Trouble with component {proc_name}.")
+
+    nlp = English()
+    nlp.add_pipe("my_evil_component")
+    nlp.initialize()
+    texts = ["TEXT 111", "TEXT 222", "TEXT 333", "TEXT 342", "TEXT 666"]
+    with pytest.raises(ValueError):
+        # the evil custom component throws an error
+        list(nlp.pipe(texts))
+
+    logger = logging.getLogger("spacy")
+    with mock.patch.object(logger, "warning") as mock_warning:
+        # the errors by the evil custom component raise a warning for each bad batch
+        docs = list(nlp.pipe(texts, error_handler=warn_error))
+        mock_warning.assert_called()
+        assert mock_warning.call_count == 2
+        assert len(docs) + mock_warning.call_count == len(texts)
+        assert [doc.text for doc in docs] == ["TEXT 111", "TEXT 333", "TEXT 666"]
+
+
+def test_language_pipe_error_handler_pipe(en_vocab):
+    """Test the error handling of a component's pipe method"""
+    @Language.component("my_sentences")
+    def perhaps_set_sentences(doc):
+        if not doc.text.startswith("4"):
+            doc[-1].is_sent_start = True
+        return doc
+
+    texts = [f"{str(i)} is enough. Done" for i in range(100)]
+    nlp = English()
+    nlp.add_pipe("my_sentences")
+    entity_linker = nlp.add_pipe("entity_linker", config={"entity_vector_length": 3})
+    entity_linker.kb.add_entity(entity="Q1", freq=12, entity_vector=[1, 2, 3])
+    nlp.initialize()
+    with pytest.raises(ValueError):
+        # the entity linker requires sentence boundaries, will throw an error otherwise
+        docs = list(nlp.pipe(texts, batch_size=10))
+    docs = list(nlp.pipe(texts, batch_size=10, error_handler=ignore_error))
+    # we lose/ignore the failing 0-9 and 40-49 batches
+    assert len(docs) == 80
 
 
 def test_language_from_config_before_after_init():

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -1435,10 +1435,13 @@ def _pipe(docs, proc, name, kwargs):
         for doc in docs:
             try:
                 doc = proc(doc, **kwargs)
+                yield doc
             except Exception as e:
                 error_handler(name, [doc], e)
-            yield doc
 
 
 def raise_error(proc_name, docs, e):
     raise e
+
+def ignore_error(proc_name, docs, e):
+    pass

--- a/website/docs/api/language.md
+++ b/website/docs/api/language.md
@@ -203,6 +203,28 @@ more efficient than processing texts one-by-one.
 | `n_process` <Tag variant="new">2.2.2</Tag> | Number of processors to use. Defaults to `1`. ~~int~~                                                                                                               |
 | **YIELDS**                                 | Documents in the order of the original text. ~~Doc~~                                                                                                                |
 
+## Language.set_error_handler {#set_error_handler tag="method"}
+
+Define a callback that will be invoked when an error is thrown during processing
+of one or more documents. Specifically, this function will call
+[`set_error_handler`](/api/pipe#set_error_handler) on all the pipeline
+components that define that function. The error handler will be invoked with the
+original component's name, the component itself, the list of documents that was
+being processed, and the original error.
+
+> #### Example
+>
+> ```python
+> def warn_error(proc_name, proc, docs, e):
+>     print(f"An error occurred when applying component {proc_name}.")
+>
+> nlp.set_error_handler(warn_error)
+> ```
+
+| Name            | Description                                                                                                    |
+| --------------- | -------------------------------------------------------------------------------------------------------------- |
+| `error_handler` | A function that performs custom error handling. ~~Callable[[str, Callable[[Doc], Doc], List[Doc], Exception]~~ |
+
 ## Language.initialize {#initialize tag="method" new="3"}
 
 Initialize the pipeline for training and return an

--- a/website/docs/api/pipe.md
+++ b/website/docs/api/pipe.md
@@ -100,6 +100,47 @@ applied to the `Doc` in order. Both [`__call__`](/api/pipe#call) and
 | `batch_size`   | The number of documents to buffer. Defaults to `128`. ~~int~~ |
 | **YIELDS**     | The processed documents in order. ~~Doc~~                     |
 
+## TrainablePipe.set_error_handler {#set_error_handler tag="method"}
+
+Define a callback that will be invoked when an error is thrown during processing
+of one or more documents with either [`__call__`](/api/pipe#call) or
+[`pipe`](/api/pipe#pipe). The error handler will be invoked with the original
+component's name, the component itself, the list of documents that was being
+processed, and the original error.
+
+> #### Example
+>
+> ```python
+> def warn_error(proc_name, proc, docs, e):
+>     print(f"An error occurred when applying component {proc_name}.")
+>
+> pipe = nlp.add_pipe("ner")
+> pipe.set_error_handler(warn_error)
+> ```
+
+| Name            | Description                                                                                                    |
+| --------------- | -------------------------------------------------------------------------------------------------------------- |
+| `error_handler` | A function that performs custom error handling. ~~Callable[[str, Callable[[Doc], Doc], List[Doc], Exception]~~ |
+
+## TrainablePipe.get_error_handler {#get_error_handler tag="method"}
+
+Retrieve the callback that performs error handling for this component's
+[`__call__`](/api/pipe#call) and [`pipe`](/api/pipe#pipe) methods. If no custom
+function was previously defined with
+[`set_error_handler`](/api/pipe#set_error_handler), a default function is
+returned that simply reraises the exception.
+
+> #### Example
+>
+> ```python
+> pipe = nlp.add_pipe("ner")
+> error_handler = pipe.get_error_handler()
+> ```
+
+| Name        | Description                                                                                                      |
+| ----------- | ---------------------------------------------------------------------------------------------------------------- |
+| **RETURNS** | The function that performs custom error handling. ~~Callable[[str, Callable[[Doc], Doc], List[Doc], Exception]~~ |
+
 ## TrainablePipe.initialize {#initialize tag="method" new="3"}
 
 Initialize the component for training. `get_examples` should be a function that
@@ -190,14 +231,14 @@ predictions and gold-standard annotations, and update the component's model.
 > losses = pipe.update(examples, sgd=optimizer)
 > ```
 
-| Name              | Description                                                                                                                        |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `examples`        | A batch of [`Example`](/api/example) objects to learn from. ~~Iterable[Example]~~                                                  |
-| _keyword-only_    |                                                                                                                                    |
-| `drop`            | The dropout rate. ~~float~~                                                                                                        |
-| `sgd`             | An optimizer. Will be created via [`create_optimizer`](#create_optimizer) if not set. ~~Optional[Optimizer]~~                      |
-| `losses`          | Optional record of the loss during training. Updated using the component name as the key. ~~Optional[Dict[str, float]]~~           |
-| **RETURNS**       | The updated `losses` dictionary. ~~Dict[str, float]~~                                                                              |
+| Name           | Description                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `examples`     | A batch of [`Example`](/api/example) objects to learn from. ~~Iterable[Example]~~                                        |
+| _keyword-only_ |                                                                                                                          |
+| `drop`         | The dropout rate. ~~float~~                                                                                              |
+| `sgd`          | An optimizer. Will be created via [`create_optimizer`](#create_optimizer) if not set. ~~Optional[Optimizer]~~            |
+| `losses`       | Optional record of the loss during training. Updated using the component name as the key. ~~Optional[Dict[str, float]]~~ |
+| **RETURNS**    | The updated `losses` dictionary. ~~Dict[str, float]~~                                                                    |
 
 ## TrainablePipe.rehearse {#rehearse tag="method,experimental" new="3"}
 


### PR DESCRIPTION
This seems a frequently asked feature - e.g. https://github.com/explosion/spaCy/issues/6630 and https://github.com/explosion/spaCy/issues/4847, and I've been wanting it myself too ;-)

## Description
With the `Pipe` / `TrainablePipe` API revamped for spaCy 3, I thought it would make sense to also add an error handler to `nlp.pipe` and the `pipe` methods of trainable pipeline components.

The default error handler changes nothing: it just reraises the same exception. But the user has an option of specifying its own error handling function that can ignore the batch, inspect the batch, warn, ... 

## Open question
Which arguments should the error handler function take? Currently it takes the component's name, the offending batch of documents, and the original error that was thrown.

### Types of change
enhancement, UX

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

## TODO
- [ ] In multi-processing context 