### PR TITLE
Forbid OP matching 2+ tokens in DependencyMatcher

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -132,6 +132,11 @@ class Warnings:
             "'morphologizer'.")
     W109 = ("Unable to save user hooks while serializing the doc. Re-add any "
             "required user hooks to the doc after processing.")
+    W110 = ("The DependencyMatcher token pattern {pattern} matched a span "
+            "{tokens} that is 2+ tokens long. Only the first token in the span "
+            "will be included in the results. For better results, token "
+            "patterns should return matches that are each exactly one token "
+            "long.")
 
 
 @add_codes
@@ -747,6 +752,10 @@ class Errors:
              "file.json .`.")
     E1015 = ("Can't initialize model from config: no {value} found. For more "
              "information, run: python -m spacy debug config config.cfg")
+    E1016 = ("The operators 'OP': '?', '*', and '+' are not supported in "
+             "DependencyMatcher token patterns. The token pattern in "
+             "RIGHT_ATTR should return matches that are each exactly one token "
+             "long. Invalid pattern:\n{node}")
 
 
 # Deprecated model shortcuts, only used in errors and warnings

--- a/spacy/tests/matcher/test_dependency_matcher.py
+++ b/spacy/tests/matcher/test_dependency_matcher.py
@@ -2,6 +2,7 @@ import pytest
 import pickle
 import re
 import copy
+import logging
 from mock import Mock
 from spacy.matcher import DependencyMatcher
 from spacy.tokens import Doc
@@ -334,3 +335,14 @@ def test_dependency_matcher_ops(en_vocab, doc, left, right, op, num_matches):
     matcher.add("pattern", [pattern])
     matches = matcher(doc)
     assert len(matches) == num_matches
+
+
+def test_dependency_matcher_long_matches(en_vocab, doc):
+    pattern = [
+        {"RIGHT_ID": "quick", "RIGHT_ATTRS": {"DEP": "amod", "OP": "+"}},
+    ]
+
+    matcher = DependencyMatcher(en_vocab)
+    logger = logging.getLogger("spacy")
+    with pytest.raises(ValueError):
+        matcher.add("pattern", [pattern])


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Instead of silently using only the first token in each matched span:

* Forbid `OP: ?/*/+` through `DependencyMatcher` validation
* As a fail-safe, add warning if a token match that's not exactly one token long is found by a token pattern.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

?

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
