### PR TITLE
Restore implicit label addition for NER

### DIFF
--- a/spacy/pipeline/_parser_internals/arc_eager.pyx
+++ b/spacy/pipeline/_parser_internals/arc_eager.pyx
@@ -615,8 +615,20 @@ cdef class ArcEager(TransitionSystem):
         return actions
 
     @property
+    def builtin_labels(self):
+        return ["ROOT", "dep"]
+
+    @property
     def action_types(self):
         return (SHIFT, REDUCE, LEFT, RIGHT, BREAK)
+
+    def get_doc_labels(self, doc):
+        """Get the labels required for a given Doc."""
+        labels = set(self.builtin_labels)
+        for token in doc:
+            if token.dep_:
+                labels.add(token.dep_)
+        return labels
 
     def transition(self, StateClass state, action):
         cdef Transition t = self.lookup_transition(action)

--- a/spacy/pipeline/_parser_internals/ner.pyx
+++ b/spacy/pipeline/_parser_internals/ner.pyx
@@ -126,6 +126,13 @@ cdef class BiluoPushDown(TransitionSystem):
     def action_types(self):
         return (BEGIN, IN, LAST, UNIT, OUT)
 
+    def get_doc_labels(self, doc):
+        labels = set()
+        for token in doc:
+            if token.ent_type:
+                labels.add(token.ent_type_)
+        return labels
+    
     def move_name(self, int move, attr_t label):
         if move == OUT:
             return 'O'

--- a/spacy/pipeline/dep_parser.pyx
+++ b/spacy/pipeline/dep_parser.pyx
@@ -277,3 +277,10 @@ cdef class DependencyParser(Parser):
             head_scores.append(score_head_dict)
             label_scores.append(score_label_dict)
         return head_scores, label_scores
+
+    def _ensure_labels_are_added(self, docs):
+        # This gives the parser a chance to add labels it's missing for a batch
+        # of documents. However, this isn't desirable for the dependency parser,
+        # because we instead have a label frequency cut-off and back off rare
+        # labels to 'dep'.
+        pass


### PR DESCRIPTION
Addresses #6681 

In v2 (and maybe older?), labels are added to the NER if they're present in the batch of data but aren't in the model yet. The `EntityRecognizer` support dynamically resizing their output arrays, and a lot of applications have found success in sticking a new entity type into an exisiting NER model. The implicit label adding makes this easier. The labels need to be there for prediction too, or the imitation learning can't work.

I've implemented this a bit more cleanly than it was, in that the labels come in at a more consistent time, and they're added all at once for the batch before we resize the model once.

For the parser, it's a bit different. We have a label frequency cut-off for the parser, and the parser won't fail to find a parse just because a label is missing. Instead it will back-off the rare label to `dep`. So I've disabled this mechanism for the parser.
