### PR TITLE
Fix linking resumed components

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1528,7 +1528,7 @@ class Language:
             for proc in procs:
                 proc.terminate()
 
-    def link_components(self) -> None:
+    def _link_components(self) -> None:
         """Register 'listeners' within pipeline components, to allow them to
         effectively share weights.
         """

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1248,7 +1248,7 @@ class Language:
                 )
                 proc.initialize(get_examples, nlp=self, **p_settings)
         if link_components:
-            self.link_components()
+            self._link_components()
         self._optimizer = sgd
         if sgd is not None:
             self._optimizer = sgd
@@ -1851,7 +1851,7 @@ class Language:
             exclude = list(exclude) + ["vocab"]
         util.from_disk(path, deserializers, exclude)
         self._path = path
-        self.link_components()
+        self._link_components()
         return self
 
     def to_bytes(self, *, exclude: Iterable[str] = SimpleFrozenList()) -> bytes:
@@ -1912,7 +1912,7 @@ class Language:
                 b, exclude=["vocab"]
             )
         util.from_bytes(bytes_data, deserializers, exclude)
-        self.link_components()
+        self._link_components()
         return self
 
 

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1190,6 +1190,7 @@ class Language:
         get_examples: Optional[Callable[[], Iterable[Example]]] = None,
         *,
         sgd: Optional[Optimizer] = None,
+        link_components: bool = True,
     ) -> Optimizer:
         """Initialize the pipe for training, using data examples if available.
 
@@ -1197,6 +1198,8 @@ class Language:
             returns gold-standard Example objects.
         sgd (Optional[Optimizer]): An optimizer to use for updates. If not
             provided, will be created using the .create_optimizer() method.
+        link_components (bool): Link listener components automatically or not
+            (default True)
         RETURNS (thinc.api.Optimizer): The optimizer.
 
         DOCS: https://nightly.spacy.io/api/language#initialize
@@ -1244,7 +1247,8 @@ class Language:
                     proc.initialize, p_settings, section="components", name=name
                 )
                 proc.initialize(get_examples, nlp=self, **p_settings)
-        self._link_components()
+        if link_components:
+            self.link_components()
         self._optimizer = sgd
         if sgd is not None:
             self._optimizer = sgd
@@ -1524,11 +1528,11 @@ class Language:
             for proc in procs:
                 proc.terminate()
 
-    def _link_components(self) -> None:
+    def link_components(self) -> None:
         """Register 'listeners' within pipeline components, to allow them to
         effectively share weights.
         """
-        # I had though, "Why do we do this inside the Language object? Shouldn't
+        # I had thought, "Why do we do this inside the Language object? Shouldn't
         # it be the tok2vec/transformer/etc's job?
         # The problem is we need to do it during deserialization...And the
         # components don't receive the pipeline then. So this does have to be
@@ -1847,7 +1851,7 @@ class Language:
             exclude = list(exclude) + ["vocab"]
         util.from_disk(path, deserializers, exclude)
         self._path = path
-        self._link_components()
+        self.link_components()
         return self
 
     def to_bytes(self, *, exclude: Iterable[str] = SimpleFrozenList()) -> bytes:
@@ -1908,7 +1912,7 @@ class Language:
                 b, exclude=["vocab"]
             )
         util.from_bytes(bytes_data, deserializers, exclude)
-        self._link_components()
+        self.link_components()
         return self
 
 

--- a/spacy/tests/pipeline/test_tok2vec.py
+++ b/spacy/tests/pipeline/test_tok2vec.py
@@ -175,7 +175,7 @@ def test_tok2vec_listener_callback():
     assert nlp.pipe_names == ["tok2vec", "tagger"]
     tagger = nlp.get_pipe("tagger")
     tok2vec = nlp.get_pipe("tok2vec")
-    nlp._link_components()
+    nlp.link_components()
     docs = [nlp.make_doc("A random sentence")]
     tok2vec.model.initialize(X=docs)
     gold_array = [[1.0 for tag in ["V", "Z"]] for word in docs]

--- a/spacy/tests/pipeline/test_tok2vec.py
+++ b/spacy/tests/pipeline/test_tok2vec.py
@@ -175,7 +175,7 @@ def test_tok2vec_listener_callback():
     assert nlp.pipe_names == ["tok2vec", "tagger"]
     tagger = nlp.get_pipe("tagger")
     tok2vec = nlp.get_pipe("tok2vec")
-    nlp.link_components()
+    nlp._link_components()
     docs = [nlp.make_doc("A random sentence")]
     tok2vec.model.initialize(X=docs)
     gold_array = [[1.0 for tag in ["V", "Z"]] for word in docs]

--- a/spacy/training/initialize.py
+++ b/spacy/training/initialize.py
@@ -64,8 +64,10 @@ def init_nlp(config: Config, *, use_gpu: int = -1) -> "Language":
         with nlp.select_pipes(enable=resume_components):
             logger.info(f"Resuming training for: {resume_components}")
             nlp.resume_training(sgd=optimizer)
+    # Make sure that listeners are defined before initializing further
+    nlp.link_components()
     with nlp.select_pipes(disable=[*frozen_components, *resume_components]):
-        nlp.initialize(lambda: train_corpus(nlp), sgd=optimizer)
+        nlp.initialize(lambda: train_corpus(nlp), sgd=optimizer, link_components=False)
         logger.info(f"Initialized pipeline components: {nlp.pipe_names}")
     # Detect components with listeners that are not frozen consistently
     for name, proc in nlp.pipeline:

--- a/spacy/training/initialize.py
+++ b/spacy/training/initialize.py
@@ -65,7 +65,7 @@ def init_nlp(config: Config, *, use_gpu: int = -1) -> "Language":
             logger.info(f"Resuming training for: {resume_components}")
             nlp.resume_training(sgd=optimizer)
     # Make sure that listeners are defined before initializing further
-    nlp.link_components()
+    nlp._link_components()
     with nlp.select_pipes(disable=[*frozen_components, *resume_components]):
         nlp.initialize(lambda: train_corpus(nlp), sgd=optimizer, link_components=False)
         logger.info(f"Initialized pipeline components: {nlp.pipe_names}")


### PR DESCRIPTION
Related to https://github.com/explosion/spaCy/discussions/6789

## Description
When linking a `TransformerListener` to a downstream component, the `nO` dimension of the listener is set according to the dimension of the `Transformer`. This linking is triggered by `nlp.initialize`, but we have to ensure that we also link resumed/frozen components. I think, in hindsight, having the linking implicitely in `nlp.initialize` is therefor probably a bad idea.

As a minimal fix, this PR adds a flag whether or not the linking should happen by `nlp.initialize`, allowing the CLI to turn it off and instead perform the linking on *all* components.

At least this fixes the bug from https://github.com/explosion/spaCy/discussions/6789, but we may want to refactor/reconsider this further at some point.

Not sure whether to add this flag to the docs, as it's mostly internals and kind of hard to explain clearly...

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.

