### PR TITLE
Support building wheel in spacy package

### DIFF
--- a/website/docs/api/cli.md
+++ b/website/docs/api/cli.md
@@ -900,20 +900,21 @@ registered functions like
 copied into the package and imported in the `__init__.py`. If the path to a
 [`meta.json`](/api/data-formats#meta) is supplied, or a `meta.json` is found in
 the input directory, this file is used. Otherwise, the data can be entered
-directly from the command line. spaCy will then create a `.tar.gz` archive file
-that you can distribute and install with `pip install`. Alternatively, you can
-also set `--wheel` to build a binary `.whl` file instead.
+directly from the command line. spaCy will then create a build artifact that you
+can distribute and install with `pip install`.
 
 <Infobox title="New in v3.0" variant="warning">
 
 The `spacy package` command now also builds the `.tar.gz` archive automatically,
 so you don't have to run `python setup.py sdist` separately anymore. To disable
-this, you can set the `--no-sdist` flag.
+this, you can set `--build none`. You can also choose to build a binary wheel
+(which installs more efficiently) by setting `--build wheel`, or to build both
+the sdist and wheel by setting `--build sdist,wheel`.
 
 </Infobox>
 
 ```cli
-$ python -m spacy package [input_dir] [output_dir] [--code] [--meta-path] [--create-meta] [--no-sdist] [--name] [--version] [--force]
+$ python -m spacy package [input_dir] [output_dir] [--code] [--meta-path] [--create-meta] [--build] [--name] [--version] [--force]
 ```
 
 > #### Example
@@ -924,20 +925,19 @@ $ python -m spacy package [input_dir] [output_dir] [--code] [--meta-path] [--cre
 > $ pip install dist/en_pipeline-0.0.0.tar.gz
 > ```
 
-| Name                                             | Description                                                                                                                                                                                                                                                                                |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `input_dir`                                      | Path to directory containing pipeline data. ~~Path (positional)~~                                                                                                                                                                                                                          |
-| `output_dir`                                     | Directory to create package folder in. ~~Path (positional)~~                                                                                                                                                                                                                               |
-| `--code`, `-c` <Tag variant="new">3</Tag>        | Comma-separated paths to Python files to be included in the package and imported in its `__init__.py`. This allows including [registering functions](/usage/training#custom-functions) and [custom components](/usage/processing-pipelines#custom-components). ~~Optional[str] \(option)~~ |
-| `--meta-path`, `-m` <Tag variant="new">2</Tag>   | Path to [`meta.json`](/api/data-formats#meta) file (optional). ~~Optional[Path] \(option)~~                                                                                                                                                                                                |
-| `--create-meta`, `-C` <Tag variant="new">2</Tag> | Create a `meta.json` file on the command line, even if one already exists in the directory. If an existing file is found, its entries will be shown as the defaults in the command line prompt. ~~bool (flag)~~                                                                            |
-| `--no-sdist`, `-NS` <Tag variant="new">3</Tag>   | Don't build the `.tar.gz` sdist automatically. Can be set if you want to run this step manually. ~~bool (flag)~~                                                                                                                                                                           |
-| `--wheel`, `-W` <Tag variant="new">3</Tag>       | Build a binary wheel instead of the sdist for more efficient installation. Requires the [`wheel`](https://pypi.org/project/wheel/) extension for `setuptools` to be installed. ~~bool (flag)~~                                                                                             |
-| `--name`, `-n` <Tag variant="new">3</Tag>        | Package name to override in meta. ~~Optional[str] \(option)~~                                                                                                                                                                                                                              |
-| `--version`, `-v` <Tag variant="new">3</Tag>     | Package version to override in meta. Useful when training new versions, as it doesn't require editing the meta template. ~~Optional[str] \(option)~~                                                                                                                                       |
-| `--force`, `-f`                                  | Force overwriting of existing folder in output directory. ~~bool (flag)~~                                                                                                                                                                                                                  |
-| `--help`, `-h`                                   | Show help message and available arguments. ~~bool (flag)~~                                                                                                                                                                                                                                 |
-| **CREATES**                                      | A Python package containing the spaCy pipeline.                                                                                                                                                                                                                                            |
+| Name                                             | Description                                                                                                                                                                                                                                                                      |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `input_dir`                                      | Path to directory containing pipeline data. ~~Path (positional)~~                                                                                                                                                                                                                |
+| `output_dir`                                     | Directory to create package folder in. ~~Path (positional)~~                                                                                                                                                                                                                     |
+| `--code`, `-c` <Tag variant="new">3</Tag>        | Comma-separated paths to Python files to be included in the package and imported in its `__init__.py`. This allows including [registering functions](/usage/training#custom-functions) and [custom components](/usage/processing-pipelines#custom-components). ~~str (option)~~  |
+| `--meta-path`, `-m` <Tag variant="new">2</Tag>   | Path to [`meta.json`](/api/data-formats#meta) file (optional). ~~Optional[Path] \(option)~~                                                                                                                                                                                      |
+| `--create-meta`, `-C` <Tag variant="new">2</Tag> | Create a `meta.json` file on the command line, even if one already exists in the directory. If an existing file is found, its entries will be shown as the defaults in the command line prompt. ~~bool (flag)~~                                                                  |
+| `--build`, `-b` <Tag variant="new">3</Tag>       | Comma-separated artifact formats to build. Can be `sdist` (for a `.tar.gz` archive) and/or `wheel` (for a binary `.whl` file), or `none` if you want to run this step manually. The generated artifacts can be installed by `pip install`. Defaults to `sdist`. ~~str (option)~~ |
+| `--name`, `-n` <Tag variant="new">3</Tag>        | Package name to override in meta. ~~Optional[str] \(option)~~                                                                                                                                                                                                                    |
+| `--version`, `-v` <Tag variant="new">3</Tag>     | Package version to override in meta. Useful when training new versions, as it doesn't require editing the meta template. ~~Optional[str] \(option)~~                                                                                                                             |
+| `--force`, `-f`                                  | Force overwriting of existing folder in output directory. ~~bool (flag)~~                                                                                                                                                                                                        |
+| `--help`, `-h`                                   | Show help message and available arguments. ~~bool (flag)~~                                                                                                                                                                                                                       |
+| **CREATES**                                      | A Python package containing the spaCy pipeline.                                                                                                                                                                                                                                  |
 
 ## project {#project new="3"}
 

--- a/website/docs/api/cli.md
+++ b/website/docs/api/cli.md
@@ -901,7 +901,8 @@ copied into the package and imported in the `__init__.py`. If the path to a
 [`meta.json`](/api/data-formats#meta) is supplied, or a `meta.json` is found in
 the input directory, this file is used. Otherwise, the data can be entered
 directly from the command line. spaCy will then create a `.tar.gz` archive file
-that you can distribute and install with `pip install`.
+that you can distribute and install with `pip install`. Alternatively, you can
+also set `--wheel` to build a binary `.whl` file instead.
 
 <Infobox title="New in v3.0" variant="warning">
 
@@ -930,7 +931,8 @@ $ python -m spacy package [input_dir] [output_dir] [--code] [--meta-path] [--cre
 | `--code`, `-c` <Tag variant="new">3</Tag>        | Comma-separated paths to Python files to be included in the package and imported in its `__init__.py`. This allows including [registering functions](/usage/training#custom-functions) and [custom components](/usage/processing-pipelines#custom-components). ~~Optional[str] \(option)~~ |
 | `--meta-path`, `-m` <Tag variant="new">2</Tag>   | Path to [`meta.json`](/api/data-formats#meta) file (optional). ~~Optional[Path] \(option)~~                                                                                                                                                                                                |
 | `--create-meta`, `-C` <Tag variant="new">2</Tag> | Create a `meta.json` file on the command line, even if one already exists in the directory. If an existing file is found, its entries will be shown as the defaults in the command line prompt. ~~bool (flag)~~                                                                            |
-| `--no-sdist`, `-NS`,                             | Don't build the `.tar.gz` sdist automatically. Can be set if you want to run this step manually. ~~bool (flag)~~                                                                                                                                                                           |
+| `--no-sdist`, `-NS` <Tag variant="new">3</Tag>   | Don't build the `.tar.gz` sdist automatically. Can be set if you want to run this step manually. ~~bool (flag)~~                                                                                                                                                                           |
+| `--wheel`, `-W` <Tag variant="new">3</Tag>       | Build a binary wheel instead of the sdist for more efficient installation. Requires the [`wheel`](https://pypi.org/project/wheel/) extension for `setuptools` to be installed. ~~bool (flag)~~                                                                                             |
 | `--name`, `-n` <Tag variant="new">3</Tag>        | Package name to override in meta. ~~Optional[str] \(option)~~                                                                                                                                                                                                                              |
 | `--version`, `-v` <Tag variant="new">3</Tag>     | Package version to override in meta. Useful when training new versions, as it doesn't require editing the meta template. ~~Optional[str] \(option)~~                                                                                                                                       |
 | `--force`, `-f`                                  | Force overwriting of existing folder in output directory. ~~bool (flag)~~                                                                                                                                                                                                                  |

--- a/website/docs/usage/v3.md
+++ b/website/docs/usage/v3.md
@@ -1065,7 +1065,8 @@ setting up the label scheme.
 The [`spacy package`](/api/cli#package) command now automatically builds the
 installable `.tar.gz` sdist of the Python package, so you don't have to run this
 step manually anymore. You can disable the behavior by setting the `--no-sdist`
-flag.
+flag. You can now also specify `--wheel` to build a binary `.whl` file instead,
+which will install more efficiently.
 
 ```diff
 python -m spacy package ./output ./packages

--- a/website/docs/usage/v3.md
+++ b/website/docs/usage/v3.md
@@ -1064,9 +1064,10 @@ setting up the label scheme.
 
 The [`spacy package`](/api/cli#package) command now automatically builds the
 installable `.tar.gz` sdist of the Python package, so you don't have to run this
-step manually anymore. You can disable the behavior by setting the `--no-sdist`
-flag. You can now also specify `--wheel` to build a binary `.whl` file instead,
-which will install more efficiently.
+step manually anymore. To disable the behavior, you can set `--build none`. You
+can also choose to build a binary wheel (which installs more efficiently) by
+setting `--build wheel`, or to build both the sdist and wheel by setting
+`--build sdist,wheel`.
 
 ```diff
 python -m spacy package ./output ./packages


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Allow `spacy package` to build binary wheels by introducing a unified `--build` option that defaults to `sdist` (but can also be set to `wheel`, `sdist,wheel` or `none`). Building the wheel will then run `setup.py bdist_wheel` under the hood.

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
