### PR TITLE
Add capture argument to project_run

### DIFF
--- a/spacy/about.py
+++ b/spacy/about.py
@@ -1,6 +1,6 @@
 # fmt: off
 __title__ = "spacy"
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"
 __projects__ = "https://github.com/explosion/projects"

--- a/spacy/about.py
+++ b/spacy/about.py
@@ -1,6 +1,6 @@
 # fmt: off
 __title__ = "spacy"
-__version__ = "3.0.1"
+__version__ = "3.0.1.dev0"
 __download_url__ = "https://github.com/explosion/spacy-models/releases/download"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"
 __projects__ = "https://github.com/explosion/projects"

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -803,7 +803,7 @@ def run_command(
     stdin (Optional[Any]): stdin to read from or None.
     capture (bool): Whether to capture the output and errors. If False,
         the stdout and stderr will not be redirected, and if there's an error,
-        sys.exit will be called with the returncode. You should use capture=False
+        sys.exit will be called with the return code. You should use capture=False
         when you want to turn over execution to the command, and capture=True
         when you want to run the command more like a function.
     RETURNS (Optional[CompletedProcess]): The process object.


### PR DESCRIPTION

## Description
Add `capture` flag to `project_run` instead of having it default at `False`. From the unit tests of `projects` it would be good to be able to set this to `True` so we can debug cases where the CLI fails.

Bumping the version to 3.0.1. so we can potentially release it to test the projects CLI further.

### Types of change
enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
