### PR TITLE
remove link_components flag again

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1190,7 +1190,6 @@ class Language:
         get_examples: Optional[Callable[[], Iterable[Example]]] = None,
         *,
         sgd: Optional[Optimizer] = None,
-        link_components: bool = True,
     ) -> Optimizer:
         """Initialize the pipe for training, using data examples if available.
 
@@ -1198,8 +1197,6 @@ class Language:
             returns gold-standard Example objects.
         sgd (Optional[Optimizer]): An optimizer to use for updates. If not
             provided, will be created using the .create_optimizer() method.
-        link_components (bool): Link listener components automatically or not
-            (default True)
         RETURNS (thinc.api.Optimizer): The optimizer.
 
         DOCS: https://spacy.io/api/language#initialize
@@ -1247,8 +1244,7 @@ class Language:
                     proc.initialize, p_settings, section="components", name=name
                 )
                 proc.initialize(get_examples, nlp=self, **p_settings)
-        if link_components:
-            self._link_components()
+        self._link_components()
         self._optimizer = sgd
         if sgd is not None:
             self._optimizer = sgd

--- a/spacy/pipeline/tok2vec.py
+++ b/spacy/pipeline/tok2vec.py
@@ -80,7 +80,8 @@ class Tok2Vec(TrainablePipe):
     def add_listener(self, listener: "Tok2VecListener", component_name: str) -> None:
         """Add a listener for a downstream component. Usually internals."""
         self.listener_map.setdefault(component_name, [])
-        self.listener_map[component_name].append(listener)
+        if listener not in self.listener_map[component_name]:
+            self.listener_map[component_name].append(listener)
 
     def remove_listener(self, listener: "Tok2VecListener", component_name: str) -> bool:
         """Remove a listener for a downstream component. Usually internals."""

--- a/spacy/training/initialize.py
+++ b/spacy/training/initialize.py
@@ -67,7 +67,7 @@ def init_nlp(config: Config, *, use_gpu: int = -1) -> "Language":
     # Make sure that listeners are defined before initializing further
     nlp._link_components()
     with nlp.select_pipes(disable=[*frozen_components, *resume_components]):
-        nlp.initialize(lambda: train_corpus(nlp), sgd=optimizer, link_components=False)
+        nlp.initialize(lambda: train_corpus(nlp), sgd=optimizer)
         logger.info(f"Initialized pipeline components: {nlp.pipe_names}")
     # Detect components with listeners that are not frozen consistently
     for name, proc in nlp.pipeline:


### PR DESCRIPTION
Follow-up to https://github.com/explosion/spaCy/pull/6859

## Description
Removing the flag `link_components` again in favour of a more general solution. Depending on what components need initialization and which don't (e.g. because they are frozen), the required order changes: sometimes we need to link first, sometimes we need to initialize first. To resolve this, I think for now it makes more sense to ensure that it's not harmful if the linking happens twice. This generically catches all use-cases.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
