### PR TITLE
Add open and closed exclamation and question marks to is_left_punct and is_right_punct

### DIFF
--- a/spacy/lang/lex_attrs.py
+++ b/spacy/lang/lex_attrs.py
@@ -64,13 +64,13 @@ def is_quote(text: str) -> bool:
 
 def is_left_punct(text: str) -> bool:
     # fmt: off
-    left_punct = ("(", "[", "{", "<", '"', "'", "«", "‘", "‚", "‛", "“", "„", "‟", "‹", "❮", "``")
+    left_punct = ("(", "[", "{", "<", '"', "'", "«", "‘", "‚", "‛", "“", "„", "‟", "‹", "❮", "``", "¿", "¡")
     # fmt: on
     return text in left_punct
 
 
 def is_right_punct(text: str) -> bool:
-    right_punct = (")", "]", "}", ">", '"', "'", "»", "’", "”", "›", "❯", "''")
+    right_punct = (")", "]", "}", ">", '"', "'", "»", "’", "”", "›", "❯", "''", "?", "!")
     return text in right_punct
 
 


### PR DESCRIPTION
## Description
Add open and closed exclamation and question marks to is_left_punct and is_right_punct

[Spanish](https://en.wikipedia.org/wiki/Inverted_question_and_exclamation_marks) and some of its co-official languages use open and closed question and exclamation marks. I think that it would be really useful to include them on the `is_left_punct` and `is_right_punct` functions, given that they're similar to any other opening/closing symbol pair.

### Types of change
This change is both an enhancement and a bug fix, if we consider the previous behavior as a bug.

## Checklist
- [X] I have submitted the spaCy Contributor Agreement 👉  #6916 👈 
- [X] I ran the tests, and all new and existing tests ***either*** passed ***or were skipped***.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
