### PR TITLE
Run PhraseMatcher on Spans 

### DIFF
--- a/.github/contributors/peter-exos.md
+++ b/.github/contributors/peter-exos.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI GmbH](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [ ] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [x] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           |  Peter Baumann       |
+| Company name (if applicable)   |  Exos Financial      |
+| Title or role (if applicable)  |  data scientist      |
+| Date                           |  Feb 1st, 2021       |
+| GitHub username                |  peter-exos          |
+| Website (optional)             |                      |

--- a/spacy/matcher/phrasematcher.pxd
+++ b/spacy/matcher/phrasematcher.pxd
@@ -18,4 +18,4 @@ cdef class PhraseMatcher:
     cdef Pool mem
     cdef key_t _terminal_hash
 
-    cdef void find_matches(self, Doc doc, vector[SpanC] *matches) nogil
+    cdef void find_matches(self, Doc doc, int start_idx, int end_idx, vector[SpanC] *matches) nogil

--- a/spacy/tests/matcher/test_phrase_matcher.py
+++ b/spacy/tests/matcher/test_phrase_matcher.py
@@ -337,3 +337,19 @@ def test_span_in_phrasematcher(en_vocab):
     matches_span = matcher(span)
     assert len(matches_doc) == 1
     assert len(matches_span) == 1
+
+
+def test_span_v_doc_in_phrasematcher(en_vocab):
+    """Ensure that PhraseMatcher only returns matches in input Span and not in entire Doc"""
+    doc = Doc(en_vocab,
+              words=["I", "like", "Spans", "and", "Docs", "in", "my", "input", ",", 
+                    "Spans", "and", "Docs", "in", "my", "matchers", ","
+                    "and", "Spans", "and", "Docs", "everywhere" "."])
+    span = doc[9:15]  # second clause
+    pattern = Doc(en_vocab, words=["Spans", "and", "Docs"])
+    matcher = PhraseMatcher(en_vocab)
+    matcher.add("SPACY", [pattern])
+    matches_doc = matcher(doc)
+    matches_span = matcher(span)
+    assert len(matches_doc) == 3
+    assert len(matches_span) == 1

--- a/spacy/tests/matcher/test_phrase_matcher.py
+++ b/spacy/tests/matcher/test_phrase_matcher.py
@@ -323,3 +323,17 @@ def test_phrase_matcher_deprecated(en_vocab):
 @pytest.mark.parametrize("attr", ["SENT_START", "IS_SENT_START"])
 def test_phrase_matcher_sent_start(en_vocab, attr):
     _ = PhraseMatcher(en_vocab, attr=attr)  # noqa: F841
+
+
+def test_span_in_phrasematcher(en_vocab):
+    """Ensure that PhraseMatcher accepts Span and Doc as input"""
+    doc = Doc(en_vocab,
+              words=["I", "like", "Spans", "and", "Docs", "in", "my", "input", ",", "and", "nothing", "else", "."])
+    span = doc[:8]
+    pattern = Doc(en_vocab, words=["Spans", "and", "Docs"])
+    matcher = PhraseMatcher(en_vocab)
+    matcher.add("SPACY", [pattern])
+    matches_doc = matcher(doc)
+    matches_span = matcher(span)
+    assert len(matches_doc) == 1
+    assert len(matches_span) == 1

--- a/spacy/tests/regression/test_issue6839.py
+++ b/spacy/tests/regression/test_issue6839.py
@@ -1,0 +1,15 @@
+from spacy.tokens import Doc
+from spacy.matcher import PhraseMatcher
+
+
+def test_span_in_phrasematcher(en_vocab):
+    """Ensure that PhraseMatcher accepts Span as input"""
+    doc = Doc(en_vocab,
+              words=["I", "like", "Spans", "and", "Docs", "in", "my", "input", ",", "and", "nothing", "else", "."])
+    span = doc[:8]
+    pattern = Doc(en_vocab, words=["Spans", "and", "Docs"])
+    matcher = PhraseMatcher(en_vocab)
+    matcher.add("SPACY", [pattern])
+    matches = matcher(span)
+    assert matches
+

--- a/spacy/tokenizer.pyx
+++ b/spacy/tokenizer.pyx
@@ -245,7 +245,9 @@ cdef class Tokenizer:
         cdef int offset
         cdef int modified_doc_length
         # Find matches for special cases
-        self._special_matcher.find_matches(doc, &c_matches)
+        start_idx = 0
+        end_idx = len(doc)
+        self._special_matcher.find_matches(doc, start_idx, end_idx, &c_matches)
         # Skip processing if no matches
         if c_matches.size() == 0:
             return True

--- a/spacy/tokenizer.pyx
+++ b/spacy/tokenizer.pyx
@@ -245,9 +245,7 @@ cdef class Tokenizer:
         cdef int offset
         cdef int modified_doc_length
         # Find matches for special cases
-        start_idx = 0
-        end_idx = len(doc)
-        self._special_matcher.find_matches(doc, start_idx, end_idx, &c_matches)
+        self._special_matcher.find_matches(doc, 0, doc.length, &c_matches)
         # Skip processing if no matches
         if c_matches.size() == 0:
             return True

--- a/website/docs/api/phrasematcher.md
+++ b/website/docs/api/phrasematcher.md
@@ -44,7 +44,7 @@ be shown.
 
 ## PhraseMatcher.\_\_call\_\_ {#call tag="method"}
 
-Find all token sequences matching the supplied patterns on the `Doc`.
+Find all token sequences matching the supplied patterns on the `Doc` or `Span`.
 
 > #### Example
 >
@@ -59,7 +59,7 @@ Find all token sequences matching the supplied patterns on the `Doc`.
 
 | Name                                  | Description                                                                                                                                                                                                                                                                                              |
 | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `doc`                                 | The document to match over. ~~Doc~~                                                                                                                                                                                                                                                                      |
+| `doclike`                             | The `Doc` or `Span` to match over. ~~Union[Doc, Span]~~                                                                                                                                                                                                                                                                      |
 | _keyword-only_                        |                                                                                                                                                                                                                                                                                                          |
 | `as_spans` <Tag variant="new">3</Tag> | Instead of tuples, return a list of [`Span`](/api/span) objects of the matches, with the `match_id` assigned as the span label. Defaults to `False`. ~~bool~~                                                                                                                                            |
 | **RETURNS**                           | A list of `(match_id, start, end)` tuples, describing the matches. A match tuple describes a span `doc[start:end`]. The `match_id` is the ID of the added match pattern. If `as_spans` is set to `True`, a list of `Span` objects is returned instead. ~~Union[List[Tuple[int, int, int]], List[Span]]~~ |


### PR DESCRIPTION
## Description
Addresses https://github.com/explosion/spaCy/issues/6839

Since you may be busy with the spacy 3 release (thank you and congrats!), I went ahead and tried to implement the requested feature myself. It was easier than I thought: 
I extended PhraseMatcher to run on Spans and Docs (like Matcher) by adding start and end index arguments to `PhraseMatcher.find_matches` and using them to constrain the loops. 
Created a regression test and a functional test. All tests passed.

I adjusted the relevant doc strings, but the website docs may need to be updated as well. I have not done that.

This is my first contribution to this repo. 
Please let me know if I am missing anything, or if I can improve something in this PR.

### Types of change
enhancement, matcher/feat

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
