### PR TITLE
Ensure the loss value is cast as float

### DIFF
--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -273,7 +273,7 @@ class EntityLinker(TrainablePipe):
         gradients = self.distance.get_grad(sentence_encodings, entity_encodings)
         loss = self.distance.get_loss(sentence_encodings, entity_encodings)
         loss = loss / len(entity_encodings)
-        return loss, gradients
+        return float(loss), gradients
 
     def predict(self, docs: Iterable[Doc]) -> List[str]:
         """Apply the pipeline's model to a batch of docs, without modifying them.

--- a/spacy/pipeline/multitask.pyx
+++ b/spacy/pipeline/multitask.pyx
@@ -197,7 +197,7 @@ class ClozeMultitask(TrainablePipe):
         target = vectors[ids]
         gradient = self.distance.get_grad(prediction, target)
         loss = self.distance.get_loss(prediction, target)
-        return loss, gradient
+        return float(loss), gradient
 
     def update(self, examples, *, drop=0., sgd=None, losses=None):
         pass


### PR DESCRIPTION
Fixes #6826

## Description
Ensure that the loss value is cast as float. Otherwise on GPU, the `cupy.core.core.ndarray` object will create trouble during IO as it is not JSON serializable.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
