### PR TITLE
reduce memory load when reading all vectors from file

### DIFF
--- a/spacy/lexeme.pyx
+++ b/spacy/lexeme.pyx
@@ -451,7 +451,7 @@ cdef class Lexeme:
             Lexeme.c_set_flag(self.c, IS_QUOTE, x)
 
     property is_left_punct:
-        """RETURNS (bool): Whether the lexeme is left punctuation, e.g. )."""
+        """RETURNS (bool): Whether the lexeme is left punctuation, e.g. (."""
         def __get__(self):
             return Lexeme.c_check_flag(self.c, IS_LEFT_PUNCT)
 

--- a/website/docs/api/top-level.md
+++ b/website/docs/api/top-level.md
@@ -727,7 +727,7 @@ capitalization by including a mix of capitalized and lowercase examples. See the
 
 Create a data augmentation callback that uses orth-variant replacement. The
 callback can be added to a corpus or other data iterator during training. It's
-is especially useful for punctuation and case replacement, to help generalize
+especially useful for punctuation and case replacement, to help generalize
 beyond corpora that don't have smart quotes, or only have smart quotes etc.
 
 | Name            | Description                                                                                                                                                                                                                                                                                               |


### PR DESCRIPTION

## Description
Rewrote an internal function `ensure_shape` used by `init vectors`. When the file does not contain the number of vectors as the first line, this function goes through the file and counts them. Previously, the lines were cached in a list but this may blow up your memory/pc. Instead, I think it's actually a better idea to just iterate through the file twice. It takes slightly longer but seems to work more smoothly at least on my end.

Also fixed a typo in an unrelated docstring.

### Types of change
memory-speed trade-off

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
