### PR TITLE
The test spacy/tests/vocab_vectors/test_lexeme.py::test_vocab_lexeme_add_flag_auto_id seems to fail occasionally when the test suite is run in a random order.

### DIFF
--- a/spacy/tests/vocab_vectors/test_lexeme.py
+++ b/spacy/tests/vocab_vectors/test_lexeme.py
@@ -55,7 +55,7 @@ def test_vocab_lexeme_add_flag_provided_id(en_vocab):
     assert en_vocab["199"].check_flag(IS_DIGIT) is False
     assert en_vocab["the"].check_flag(is_len4) is False
     assert en_vocab["dogs"].check_flag(is_len4) is True
-
+    en_vocab.add_flag(lambda string: string.isdigit(), flag_id=IS_DIGIT)
 
 def test_vocab_lexeme_oov_rank(en_vocab):
     """Test that default rank is OOV_RANK."""


### PR DESCRIPTION
The test `spacy/tests/vocab_vectors/test_lexeme.py::test_vocab_lexeme_add_flag_auto_id` seems to fail occasionally when the test suite is run in a random order.

### Error Message
```python
    def test_vocab_lexeme_add_flag_auto_id(en_vocab):
        is_len4 = en_vocab.add_flag(lambda string: len(string) == 4)
        assert en_vocab["1999"].check_flag(is_len4) is True
        assert en_vocab["1999"].check_flag(IS_DIGIT) is True
        assert en_vocab["199"].check_flag(is_len4) is False
>       assert en_vocab["199"].check_flag(IS_DIGIT) is True
E       assert False is True
E        +  where False = <built-in method check_flag of spacy.lexeme.Lexeme object at 0x7fa155c36840>(3)
E        +    where <built-in method check_flag of spacy.lexeme.Lexeme object at 0x7fa155c36840> = <spacy.lexeme.Lexeme object at 0x7fa155c36840>.check_flag

spacy/tests/vocab_vectors/test_lexeme.py:49: AssertionError
```

### Environment
>  `pytest==6.1.1`
>
>  `numpy==1.19.2`
>
> `Python version: 3.8.3`

### Reproducing Error
To reproduce the error, run `pytest --random-order-bucket=global --random-order-seed=170158 -v spacy/tests`

### Reasoning
If `test_vocab_lexeme_add_flag_auto_id` is run after `test_vocab_lexeme_add_flag_provided_id`, it fails.
It seems like `test_vocab_lexeme_add_flag_provided_id` uses the `IS_DIGIT` bit for testing purposes but does not reset the bit.

This solution seems to work but if anyone has a better fix, please let me know and I will integrate it.