### PR TITLE
Syntax error in Lemmatizer docs

### DIFF
--- a/website/docs/api/lemmatizer.md
+++ b/website/docs/api/lemmatizer.md
@@ -67,7 +67,7 @@ data format used by the lookup and rule-based lemmatizers, see
 > lemmatizer = nlp.add_pipe("lemmatizer")
 >
 > # Construction via add_pipe with custom settings
-> config = {"mode": "rule", overwrite=True}
+> config = {"mode": "rule", "overwrite": True}
 > lemmatizer = nlp.add_pipe("lemmatizer", config=config)
 > ```
 


### PR DESCRIPTION
## Description

The `overwrite` key in the `config` definition on line 70 was treated like a function argument – it needs quotes and should be followed by a colon.

### Types of change

Documentation change. (Typo.)

## Checklist

This is merely a documentation change.

- [ ] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.