### PR TITLE
Several callable objects do not have __qualname__

### DIFF
--- a/spacy/util.py
+++ b/spacy/util.py
@@ -930,6 +930,8 @@ def is_same_func(func1: Callable, func2: Callable) -> bool:
     """
     if not callable(func1) or not callable(func2):
         return False
+    if not hasattr(func1,"__qualname__") or not hasattr(func2,"__qualname__"):
+        return False
     same_name = func1.__qualname__ == func2.__qualname__
     same_file = inspect.getfile(func1) == inspect.getfile(func2)
     same_code = inspect.getsourcelines(func1) == inspect.getsourcelines(func2)

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -930,7 +930,7 @@ def is_same_func(func1: Callable, func2: Callable) -> bool:
     """
     if not callable(func1) or not callable(func2):
         return False
-    if not hasattr(func1,"__qualname__") or not hasattr(func2,"__qualname__"):
+    if not hasattr(func1, "__qualname__") or not hasattr(func2, "__qualname__"):
         return False
     same_name = func1.__qualname__ == func2.__qualname__
     same_file = inspect.getfile(func1) == inspect.getfile(func2)


### PR DESCRIPTION
Check of `__qualname__` attribute existance.

## Description
When making some components with class objects, they do not have `__qualname__` before they are included in `__pycache__`.

### Types of change
Bug fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
