### PR TITLE
Fix issue #6950: allow pickling Tok2Vec with listeners

### DIFF
--- a/spacy/pipeline/tok2vec.py
+++ b/spacy/pipeline/tok2vec.py
@@ -121,7 +121,7 @@ class Tok2Vec(TrainablePipe):
         tokvecs = self.model.predict(docs)
         batch_id = Tok2VecListener.get_batch_id(docs)
         for listener in self.listeners:
-            listener.receive(batch_id, tokvecs, lambda dX: [])
+            listener.receive(batch_id, tokvecs, _empty_backprop)
         return tokvecs
 
     def set_annotations(self, docs: Sequence[Doc], tokvecses) -> None:
@@ -300,3 +300,7 @@ def forward(model: Tok2VecListener, inputs, is_train: bool):
         else:
             outputs = [doc.tensor for doc in inputs]
         return outputs, lambda dX: []
+
+
+def _empty_backprop(dX):  # for pickling
+    return []

--- a/spacy/tests/regression/test_issue6950.py
+++ b/spacy/tests/regression/test_issue6950.py
@@ -1,0 +1,59 @@
+from spacy.lang.en import English
+from spacy.training import Example
+from spacy.util import load_config_from_str
+import pickle
+
+
+CONFIG = """
+[nlp]
+lang = "en"
+pipeline = ["tok2vec", "tagger"]
+
+[components]
+
+[components.tok2vec]
+factory = "tok2vec"
+
+[components.tok2vec.model]
+@architectures = "spacy.Tok2Vec.v1"
+
+[components.tok2vec.model.embed]
+@architectures = "spacy.MultiHashEmbed.v1"
+width = ${components.tok2vec.model.encode:width}
+attrs = ["NORM","PREFIX","SUFFIX","SHAPE"]
+rows = [5000,2500,2500,2500]
+include_static_vectors = false
+
+[components.tok2vec.model.encode]
+@architectures = "spacy.MaxoutWindowEncoder.v1"
+width = 96
+depth = 4
+window_size = 1
+maxout_pieces = 3
+
+[components.ner]
+factory = "ner"
+
+[components.tagger]
+factory = "tagger"
+
+[components.tagger.model]
+@architectures = "spacy.Tagger.v1"
+nO = null
+
+[components.tagger.model.tok2vec]
+@architectures = "spacy.Tok2VecListener.v1"
+width = ${components.tok2vec.model.encode:width}
+upstream = "*"
+"""
+
+
+def test_issue6950():
+    """Test that the nlp object with initialized tok2vec with listeners pickles
+    correctly (and doesn't have lambdas).
+    """
+    nlp = English.from_config(load_config_from_str(CONFIG))
+    nlp.initialize(lambda: [Example.from_dict(nlp.make_doc("hello"), {"tags": ["V"]})])
+    pickle.dumps(nlp)
+    nlp("hello")
+    pickle.dumps(nlp)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

The `lambda` in `Tok2Vec.predict` would result in the `nlp` object not being picklable if the pipeline is initialized and has tok2vec listeners.

Open question: Could we simplify this and just use `None` here, like we do in `spacy-transformers`? https://github.com/explosion/spacy-transformers/blob/392b442eb39e2cbf1f6d6152690a7547f48877ff/spacy_transformers/pipeline_component.py#L220-L221

### Types of change
bug fix, serialization

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
