### PR TITLE
added spacy-dbpedia-spotlight

### DIFF
--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -1,6 +1,34 @@
 {
     "resources": [
-    	{
+        {
+            "id": "spacy-dbpedia-spotlight",
+            "title": "DBpedia Spotlight for SpaCy",
+            "slogan": "Use DBpedia Spotlight to link entities inside SpaCy",
+            "description": "This library links SpaCy with [DBpedia Spotlight](https://www.dbpedia-spotlight.org/). You can easily get the DBpedia entities from your documents, using the public web service or by using your own instance of DBpedia Spotlight. The `doc.ents` are populated with the entities and all their details (URI, type, ...).",
+            "github": "MartinoMensio/spacy-dbpedia-spotlight",
+            "pip": "spacy-dbpedia-spotlight",
+            "code_example": [
+                "import spacy_dbpedia_spotlight",
+                "# load your model as usual",
+                "nlp = spacy.load('en_core_web_lg')",
+                "# add the pipeline stage",
+                "nlp.add_pipe('dbpedia_spotlight')",
+                "# get the document",
+                "doc = nlp('The president of USA is calling Boris Johnson to decide what to do about coronavirus')",
+                "# see the entities",
+                "print('Entities', [(ent.text, ent.label_, ent.kb_id_) for ent in doc.ents])",
+                "# inspect the raw data from DBpedia spotlight",
+                "print(doc.ents[0]._.dbpedia_raw_result)"
+            ],
+            "category": ["models", "pipeline"],
+            "author": "Martino Mensio",
+            "author_links": {
+                "twitter": "MartinoMensio",
+                "github": "MartinoMensio",
+                "website": "https://martinomensio.github.io"
+            }
+        },
+        {
             "id": "spacy-textblob",
             "title": "spaCyTextBlob",
             "slogan": "Easy sentiment analysis for spaCy using TextBlob",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
This pull request adds a project to the SpaCy Universe.

[spacy-dbpedia-spotlight](https://github.com/MartinoMensio/spacy-dbpedia-spotlight) allows to get annotations from DBpedia Spotlight within SpaCy. The `doc.ents` are populated with the linked entities.

### Types of change
It is a change to the documentation, since it is only an addition to Universe.


## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
