### PR TITLE
Preserve sourced components in fill-config

### DIFF
--- a/spacy/cli/init_config.py
+++ b/spacy/cli/init_config.py
@@ -103,6 +103,10 @@ def fill_config(
     # config result is a valid config
     nlp = util.load_model_from_config(nlp.config)
     filled = nlp.config
+    # If we have sourced components in the base config, those will have been
+    # replaced with their actual config after loading, so we have to re-add them
+    sourced = util.get_sourced_components(config)
+    filled["components"].update(sourced)
     if pretraining:
         validate_config_for_pretrain(filled, msg)
         pretrain_config = util.load_config(DEFAULT_CONFIG_PRETRAIN_PATH)

--- a/spacy/tests/regression/test_issue7055.py
+++ b/spacy/tests/regression/test_issue7055.py
@@ -1,0 +1,40 @@
+from spacy.cli.init_config import fill_config
+from spacy.util import load_config
+from spacy.lang.en import English
+from thinc.api import Config
+
+from ..util import make_tempdir
+
+
+def test_issue7055():
+    """Test that fill-config doesn't turn sourced components into factories."""
+    source_cfg = {
+        "nlp": {"lang": "en", "pipeline": ["tok2vec", "tagger"]},
+        "components": {
+            "tok2vec": {"factory": "tok2vec"},
+            "tagger": {"factory": "tagger"},
+        },
+    }
+    source_nlp = English.from_config(source_cfg)
+    with make_tempdir() as dir_path:
+        # We need to create a loadable source pipeline
+        source_path = dir_path / "test_model"
+        source_nlp.to_disk(source_path)
+        base_cfg = {
+            "nlp": {"lang": "en", "pipeline": ["tok2vec", "tagger", "ner"]},
+            "components": {
+                "tok2vec": {"source": str(source_path)},
+                "tagger": {"source": str(source_path)},
+                "ner": {"factory": "ner"},
+            },
+        }
+        base_cfg = Config(base_cfg)
+        base_path = dir_path / "base.cfg"
+        base_cfg.to_disk(base_path)
+        output_path = dir_path / "config.cfg"
+        fill_config(output_path, base_path, silent=True)
+        filled_cfg = load_config(output_path)
+    assert filled_cfg["components"]["tok2vec"]["source"] == str(source_path)
+    assert filled_cfg["components"]["tagger"]["source"] == str(source_path)
+    assert filled_cfg["components"]["ner"]["factory"] == "ner"
+    assert "model" in filled_cfg["components"]["ner"]


### PR DESCRIPTION
Fixes #7055.

## Description

Under the hood, `init fill-config` creates an `nlp` object from the base config, which takes care of auto-filling and validation, and also ensures that the config is loadable. However, if the `[components]` block includes components sourced from a different pipeline, creating the `nlp` object will copy those components over, including their config (so that `nlp.config` reflects the actual component config). As a result, auto-filling a config with `init fill-config` would replace sourced component blocks, which is not the intended behaviour.

### Types of change
bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
