### PR TITLE
Add warning about GPU selection in Jupyter notebooks

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -147,6 +147,11 @@ class Warnings:
             "will be included in the results. For better results, token "
             "patterns should return matches that are each exactly one token "
             "long.")
+    W111 = ("Jupyter notebook detected: if using `prefer_gpu()` or "
+            "`require_gpu()`, include it in the same cell right before "
+            "`spacy.load()` to ensure that the model is loaded on the correct "
+            "device. More information: "
+            "http://spacy.io/usage/v3#jupyter-notebook-gpu")
 
 
 @add_codes

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1615,11 +1615,15 @@ class Language:
                 or lang_cls is not cls
             ):
                 raise ValueError(Errors.E943.format(value=type(lang_cls)))
-        # Warn about require_gpu if a jupyter notebook + cupy is detected
+        # Warn about require_gpu if a jupyter notebook + cupy + mismatched
+        # contextvars vs. thread ops are detected
         if is_in_jupyter():
             from thinc.backends.cupy_ops import CupyOps
             if CupyOps.xp is not None:
-                warnings.warn(Warnings.W111)
+                from thinc.backends import contextvars_eq_thread_ops
+                if not contextvars_eq_thread_ops():
+                    warnings.warn(Warnings.W111)
+
         # Note that we don't load vectors here, instead they get loaded explicitly
         # inside stuff like the spacy train function. If we loaded them here,
         # then we would load them twice at runtime: once when we make from config,

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -20,8 +20,9 @@ from .pipe_analysis import validate_attrs, analyze_pipes, print_pipe_analysis
 from .training import Example, validate_examples
 from .training.initialize import init_vocab, init_tok2vec
 from .scorer import Scorer
-from .util import registry, SimpleFrozenList, _pipe, raise_error, is_in_jupyter
+from .util import registry, SimpleFrozenList, _pipe, raise_error
 from .util import SimpleFrozenDict, combine_score_weights, CONFIG_SECTION_ORDER
+from .util import warn_if_jupyter_cupy
 from .lang.tokenizer_exceptions import URL_MATCH, BASE_EXCEPTIONS
 from .lang.punctuation import TOKENIZER_PREFIXES, TOKENIZER_SUFFIXES
 from .lang.punctuation import TOKENIZER_INFIXES
@@ -1615,14 +1616,9 @@ class Language:
                 or lang_cls is not cls
             ):
                 raise ValueError(Errors.E943.format(value=type(lang_cls)))
-        # Warn about require_gpu if a jupyter notebook + cupy + mismatched
-        # contextvars vs. thread ops are detected
-        if is_in_jupyter():
-            from thinc.backends.cupy_ops import CupyOps
-            if CupyOps.xp is not None:
-                from thinc.backends import contextvars_eq_thread_ops
-                if not contextvars_eq_thread_ops():
-                    warnings.warn(Warnings.W111)
+
+        # Warn about require_gpu usage in jupyter notebook
+        warn_if_jupyter_cupy()
 
         # Note that we don't load vectors here, instead they get loaded explicitly
         # inside stuff like the spacy train function. If we loaded them here,

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -20,7 +20,7 @@ from .pipe_analysis import validate_attrs, analyze_pipes, print_pipe_analysis
 from .training import Example, validate_examples
 from .training.initialize import init_vocab, init_tok2vec
 from .scorer import Scorer
-from .util import registry, SimpleFrozenList, _pipe, raise_error
+from .util import registry, SimpleFrozenList, _pipe, raise_error, is_in_jupyter
 from .util import SimpleFrozenDict, combine_score_weights, CONFIG_SECTION_ORDER
 from .lang.tokenizer_exceptions import URL_MATCH, BASE_EXCEPTIONS
 from .lang.punctuation import TOKENIZER_PREFIXES, TOKENIZER_SUFFIXES
@@ -1615,6 +1615,11 @@ class Language:
                 or lang_cls is not cls
             ):
                 raise ValueError(Errors.E943.format(value=type(lang_cls)))
+        # Warn about require_gpu if a jupyter notebook + cupy is detected
+        if is_in_jupyter():
+            from thinc.backends.cupy_ops import CupyOps
+            if CupyOps.xp is not None:
+                warnings.warn(Warnings.W111)
         # Note that we don't load vectors here, instead they get loaded explicitly
         # inside stuff like the spacy train function. If we loaded them here,
         # then we would load them twice at runtime: once when we make from config,

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -1499,3 +1499,15 @@ def raise_error(proc_name, proc, docs, e):
 
 def ignore_error(proc_name, proc, docs, e):
     pass
+
+
+def warn_if_jupyter_cupy():
+    """Warn about require_gpu if a jupyter notebook + cupy + mismatched
+    contextvars vs. thread ops are detected
+    """
+    if is_in_jupyter():
+        from thinc.backends.cupy_ops import CupyOps
+        if CupyOps.xp is not None:
+            from thinc.backends import contextvars_eq_thread_ops
+            if not contextvars_eq_thread_ops():
+                warnings.warn(Warnings.W111)

--- a/website/docs/api/top-level.md
+++ b/website/docs/api/top-level.md
@@ -141,7 +141,8 @@ pipelines.
 <Infobox variant="warning" title="Jupyter notebook usage">
 
 In a Jupyter notebook, run `prefer_gpu()` in the same cell as `spacy.load()`
-to ensure that the model is loaded on the correct device.
+to ensure that the model is loaded on the correct device. See [more
+details](/usage/v3#jupyter-notebook-gpu).
 
 </Infobox>
 
@@ -168,7 +169,8 @@ and _before_ loading any pipelines.
 <Infobox variant="warning" title="Jupyter notebook usage">
 
 In a Jupyter notebook, run `require_gpu()` in the same cell as `spacy.load()`
-to ensure that the model is loaded on the correct device.
+to ensure that the model is loaded on the correct device. See [more
+details](/usage/v3#jupyter-notebook-gpu).
 
 </Infobox>
 
@@ -194,7 +196,8 @@ after importing spaCy and _before_ loading any pipelines.
 <Infobox variant="warning" title="Jupyter notebook usage">
 
 In a Jupyter notebook, run `require_cpu()` in the same cell as `spacy.load()`
-to ensure that the model is loaded on the correct device.
+to ensure that the model is loaded on the correct device. See [more
+details](/usage/v3#jupyter-notebook-gpu).
 
 </Infobox>
 

--- a/website/docs/api/top-level.md
+++ b/website/docs/api/top-level.md
@@ -138,6 +138,13 @@ data has already been allocated on CPU, it will not be moved. Ideally, this
 function should be called right after importing spaCy and _before_ loading any
 pipelines.
 
+<Infobox variant="warning" title="Jupyter notebook usage">
+
+In a Jupyter notebook, run `prefer_gpu()` in the same cell as `spacy.load()`
+to ensure that the model is loaded on the correct device.
+
+</Infobox>
+
 > #### Example
 >
 > ```python
@@ -158,6 +165,13 @@ if no GPU is available. If data has already been allocated on CPU, it will not
 be moved. Ideally, this function should be called right after importing spaCy
 and _before_ loading any pipelines.
 
+<Infobox variant="warning" title="Jupyter notebook usage">
+
+In a Jupyter notebook, run `require_gpu()` in the same cell as `spacy.load()`
+to ensure that the model is loaded on the correct device.
+
+</Infobox>
+
 > #### Example
 >
 > ```python
@@ -176,6 +190,13 @@ and _before_ loading any pipelines.
 Allocate data and perform operations on CPU. If data has already been allocated
 on GPU, it will not be moved. Ideally, this function should be called right
 after importing spaCy and _before_ loading any pipelines.
+
+<Infobox variant="warning" title="Jupyter notebook usage">
+
+In a Jupyter notebook, run `require_cpu()` in the same cell as `spacy.load()`
+to ensure that the model is loaded on the correct device.
+
+</Infobox>
 
 > #### Example
 >

--- a/website/docs/usage/v3.md
+++ b/website/docs/usage/v3.md
@@ -1179,4 +1179,4 @@ In Jupyter notebooks, run [`prefer_gpu`](/api/top-level#spacy.prefer_gpu),
 Due to a bug related to `contextvars` (see the [bug
 report](https://github.com/ipython/ipython/issues/11565)), the GPU settings may
 not be preserved correctly across cells, resulting in models being loaded on
-on the wrong device or only partially on GPU.
+the wrong device or only partially on GPU.

--- a/website/docs/usage/v3.md
+++ b/website/docs/usage/v3.md
@@ -1168,3 +1168,15 @@ This means that spaCy knows how to initialize `my_component`, even if your
 package isn't imported.
 
 </Infobox>
+
+#### Using GPUs in Jupyter notebooks {#jupyter-notebook-gpu}
+
+In Jupyter notebooks, run [`prefer_gpu`](/api/top-level#spacy.prefer_gpu),
+[`require_gpu`](/api/top-level#spacy.require_gpu) or
+[`require_cpu`](/api/top-level#spacy.require_cpu) in the same cell as
+[`spacy.load`](/api/top-level#spacy.load) to ensure that the model is loaded on the correct device.
+
+Due to a bug related to `contextvars` (see the [bug
+report](https://github.com/ipython/ipython/issues/11565)), the GPU settings may
+not be preserved correctly across cells, resulting in models being loaded on
+on the wrong device or only partially on GPU.


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Due to the bug reported in #6990, warn users with `cupy` available who are working in a Jupyter notebook that they need to run `require_gpu` or `prefer_gpu` in the same cell as `spacy.load` for the model to be loaded on the correct device.

`thinc` uses `contextvars` to store the GPU selection and there is a bug in IPython (https://github.com/ipython/ipython/issues/11565) that does not preserve `contextvars` settings across cells.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Enhancement?

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
