### PR TITLE
return custom error in nlp.initialize

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -486,6 +486,10 @@ class Errors:
     E202 = ("Unsupported alignment mode '{mode}'. Supported modes: {modes}.")
 
     # New errors added in v3.x
+    E885 = ("The pipeline could not be initialized because the vectors "
+            "could not be found at '{vectors}'. If your pipeline was already "
+            "initialized/trained before, call 'resume_training' instead of 'initialize', "
+            "or initialize only the components that are new.")
     E886 = ("Can't replace {name} -> {tok2vec} listeners: path '{path}' not "
             "found in config for component '{name}'.")
     E887 = ("Can't replace {name} -> {tok2vec} listeners: the paths to replace "

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1219,9 +1219,12 @@ class Language:
         before_init = I["before_init"]
         if before_init is not None:
             before_init(self)
-        init_vocab(
-            self, data=I["vocab_data"], lookups=I["lookups"], vectors=I["vectors"]
-        )
+        try:
+            init_vocab(
+                self, data=I["vocab_data"], lookups=I["lookups"], vectors=I["vectors"]
+            )
+        except IOError:
+            raise IOError(Errors.E885.format(vectors=I["vectors"]))
         pretrain_cfg = config.get("pretraining")
         if pretrain_cfg:
             P = registry.resolve(pretrain_cfg, schema=ConfigSchemaPretrain)


### PR DESCRIPTION
Inspired by discussions https://github.com/explosion/spaCy/discussions/6972 and https://github.com/explosion/spaCy/discussions/7093

## Description
When a previously trained pipeline refers to vectors, and you try to call `nlp.initialize` on this pipeline, it will attempt to load those vectors again. The `E050` error by itself is not very informative for the user, who probably didn't even define these vectors in the config themselves. Instead, the error should hint towards the fact that the pipeline really shouldn't be initialized again.

### Types of change
UX enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
