### PR TITLE
NEL docs & UX

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -486,6 +486,9 @@ class Errors:
     E202 = ("Unsupported alignment mode '{mode}'. Supported modes: {modes}.")
 
     # New errors added in v3.x
+
+    E885 = ("entity_linker.set_kb received an invalid 'kb_loader' argument: expected "
+            "a callable function, but got: {arg_type}")
     E886 = ("Can't replace {name} -> {tok2vec} listeners: path '{path}' not "
             "found in config for component '{name}'.")
     E887 = ("Can't replace {name} -> {tok2vec} listeners: the paths to replace "

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -146,6 +146,9 @@ class EntityLinker(TrainablePipe):
     def set_kb(self, kb_loader: Callable[[Vocab], KnowledgeBase]):
         """Define the KB of this pipe by providing a function that will
         create it using this object's vocab."""
+        if not callable(kb_loader):
+            raise ValueError(Errors.E885.format(arg_type=type(kb_loader)))
+
         self.kb = kb_loader(self.vocab)
         self.cfg["entity_vector_length"] = self.kb.entity_vector_length
 

--- a/website/docs/api/entitylinker.md
+++ b/website/docs/api/entitylinker.md
@@ -154,7 +154,7 @@ with the current vocab.
 >     kb.add_alias(...)
 >     return kb
 > entity_linker = nlp.add_pipe("entity_linker")
-> entity_linker.set_kb(lambda: [], nlp=nlp, kb_loader=create_kb)
+> entity_linker.set_kb(create_kb)
 > ```
 
 | Name        | Description                                                                                                      |


### PR DESCRIPTION
Quick fix for https://github.com/explosion/spaCy/issues/7119

## Description
- custom error when calling `set_kb` with an actual `KnowledgeBase` object instead of a function - it feels like this mistake might be common
- NEL docs fix

### Types of change
UX & docs fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
