### PR TITLE
Update sentencizer documentation example with sentencizer pipe name

### DIFF
--- a/website/docs/api/sentencizer.md
+++ b/website/docs/api/sentencizer.md
@@ -24,7 +24,7 @@ how the component should be configured. You can override its settings via the
 >
 > ```python
 > config = {"punct_chars": None}
-> nlp.add_pipe("entity_ruler", config=config)
+> nlp.add_pipe("sentencizer", config=config)
 > ```
 
 | Setting       | Description                                                                                                                                            |


### PR DESCRIPTION
Update sentencizer documentation example with sentencizer pipe name

## Description
One of the examples is using `entity_ruler` as a pipe name, so just changed it to `sentencizer`

### Types of change
Documentation

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
