### PR TITLE
import wandb failure - UX

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -487,6 +487,9 @@ class Errors:
 
     # New errors added in v3.x
 
+    E880 = ("The 'wandb' library could not be found - did you install it? "
+            "Alternatively, specify the 'ConsoleLogger' in the 'training.logger' "
+            "config section, instead of the 'WandbLogger'.")
     E885 = ("entity_linker.set_kb received an invalid 'kb_loader' argument: expected "
             "a callable function, but got: {arg_type}")
     E886 = ("Can't replace {name} -> {tok2vec} listeners: path '{path}' not "

--- a/spacy/training/loggers.py
+++ b/spacy/training/loggers.py
@@ -103,7 +103,11 @@ def console_logger(progress_bar: bool = False):
 
 @registry.loggers("spacy.WandbLogger.v1")
 def wandb_logger(project_name: str, remove_config_values: List[str] = []):
-    import wandb
+    try:
+        import wandb
+        from wandb import init, log, join  # test that these are available
+    except ImportError:
+        raise ImportError(Errors.E880)
 
     console = console_logger(progress_bar=False)
 


### PR DESCRIPTION
## Description
I was testing a config with `WandbLogger` in, without having `wandb` installed in that specific venv. It gave a confusing error because Python seemed to import some other "wandb" folder that got written during previous experiments. 
So instead of failing directly on the `import wandb` statement, it only failed when calling `wandb.init`, which is confusing:
```
AttributeError: module 'wandb' has no attribute 'init'
```
It feels like this may happen to others as well - so I added a quick check & custom error to address this case:
```
ImportError: [E880] The 'wandb' library could not be found - did you install it? Alternatively, specify the 'ConsoleLogger' in the 'training.logger' config section, instead of the 'WandbLogger'.
```

### Types of change
UX enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
