### PR TITLE
Fix spans weak ref in doc copy

### DIFF
--- a/spacy/tests/doc/test_doc_api.py
+++ b/spacy/tests/doc/test_doc_api.py
@@ -1,3 +1,5 @@
+import weakref
+
 import pytest
 import numpy
 import logging
@@ -663,3 +665,10 @@ def test_span_groups(en_tokenizer):
     assert doc.spans["hi"].has_overlap
     del doc.spans["hi"]
     assert "hi" not in doc.spans
+
+
+def test_doc_spans_copy(en_tokenizer):
+    doc1 = en_tokenizer("Some text about Colombia and the Czech Republic")
+    assert weakref.ref(doc1) == doc1.spans.doc_ref
+    doc2 = doc1.copy()
+    assert weakref.ref(doc2) == doc2.spans.doc_ref

--- a/spacy/tokens/_dict_proxies.py
+++ b/spacy/tokens/_dict_proxies.py
@@ -33,7 +33,7 @@ class SpanGroups(UserDict):
     def _make_span_group(self, name: str, spans: Iterable["Span"]) -> SpanGroup:
         return SpanGroup(self.doc_ref(), name=name, spans=spans)
 
-    def copy(self, doc=None) -> "SpanGroups":
+    def copy(self, doc: "Doc" = None) -> "SpanGroups":
         if doc is None:
             doc = self.doc_ref()
         return SpanGroups(doc).from_bytes(self.to_bytes())

--- a/spacy/tokens/_dict_proxies.py
+++ b/spacy/tokens/_dict_proxies.py
@@ -33,8 +33,10 @@ class SpanGroups(UserDict):
     def _make_span_group(self, name: str, spans: Iterable["Span"]) -> SpanGroup:
         return SpanGroup(self.doc_ref(), name=name, spans=spans)
 
-    def copy(self) -> "SpanGroups":
-        return SpanGroups(self.doc_ref()).from_bytes(self.to_bytes())
+    def copy(self, doc=None) -> "SpanGroups":
+        if doc is None:
+            doc = self.doc_ref()
+        return SpanGroups(doc).from_bytes(self.to_bytes())
 
     def to_bytes(self) -> bytes:
         # We don't need to serialize this as a dict, because the groups

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -1188,7 +1188,7 @@ cdef class Doc:
         other.user_span_hooks = dict(self.user_span_hooks)
         other.length = self.length
         other.max_length = self.max_length
-        other.spans = self.spans.copy()
+        other.spans = self.spans.copy(doc=other)
         buff_size = other.max_length + (PADDING*2)
         assert buff_size > 0
         tokens = <TokenC*>other.mem.alloc(buff_size, sizeof(TokenC))


### PR DESCRIPTION

## Description
`Doc.copy()` would corrupt the doc reference stored in `doc.spans`, because the copied `spans` would keep pointing to the old doc, which would get garbage-collected at some point, eventually leading to dead references.

Proposed solution: allow `Spangroups.copy()` to optionally define a new `Doc` object, so that `Doc.copy()` sets the correct new `Doc`.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
