### PR TITLE
Removed Languages that were listed twice on Docs

### DIFF
--- a/website/meta/languages.json
+++ b/website/meta/languages.json
@@ -1,84 +1,201 @@
 {
     "languages": [
-        { "code": "af", "name": "Afrikaans" },
-        { "code": "ar", "name": "Arabic", "example": "هذه جملة", "has_examples": true },
-        { "code": "bg", "name": "Bulgarian", "example": "Това е изречение", "has_examples": true },
-        { "code": "bn", "name": "Bengali", "has_examples": true },
-        { "code": "ca", "name": "Catalan", "example": "Això és una frase.", "has_examples": true },
-        { "code": "cs", "name": "Czech", "has_examples": true },
+        {
+            "code": "af",
+            "name": "Afrikaans"
+        },
+        {
+            "code": "ar",
+            "name": "Arabic",
+            "example": "هذه جملة",
+            "has_examples": true
+        },
+        {
+            "code": "bg",
+            "name": "Bulgarian",
+            "example": "Това е изречение",
+            "has_examples": true
+        },
+        {
+            "code": "bn",
+            "name": "Bengali",
+            "has_examples": true
+        },
+        {
+            "code": "ca",
+            "name": "Catalan",
+            "example": "Això és una frase.",
+            "has_examples": true
+        },
+        {
+            "code": "cs",
+            "name": "Czech",
+            "has_examples": true
+        },
         {
             "code": "da",
             "name": "Danish",
             "example": "Dette er en sætning.",
             "has_examples": true,
-            "models": ["da_core_news_sm", "da_core_news_md", "da_core_news_lg"]
+            "models": [
+                "da_core_news_sm",
+                "da_core_news_md",
+                "da_core_news_lg"
+            ]
         },
         {
             "code": "de",
             "name": "German",
-            "models": ["de_core_news_sm", "de_core_news_md", "de_core_news_lg", "de_dep_news_trf"],
+            "models": [
+                "de_core_news_sm",
+                "de_core_news_md",
+                "de_core_news_lg",
+                "de_dep_news_trf"
+            ],
             "example": "Dies ist ein Satz.",
             "has_examples": true
         },
         {
             "code": "el",
             "name": "Greek",
-            "models": ["el_core_news_sm", "el_core_news_md", "el_core_news_lg"],
+            "models": [
+                "el_core_news_sm",
+                "el_core_news_md",
+                "el_core_news_lg"
+            ],
             "example": "Αυτή είναι μια πρόταση.",
             "has_examples": true
         },
         {
             "code": "en",
             "name": "English",
-            "models": ["en_core_web_sm", "en_core_web_md", "en_core_web_lg", "en_core_web_trf"],
+            "models": [
+                "en_core_web_sm",
+                "en_core_web_md",
+                "en_core_web_lg",
+                "en_core_web_trf"
+            ],
             "example": "This is a sentence.",
             "has_examples": true
         },
         {
             "code": "es",
             "name": "Spanish",
-            "models": ["es_core_news_sm", "es_core_news_md", "es_core_news_lg", "es_dep_news_trf"],
+            "models": [
+                "es_core_news_sm",
+                "es_core_news_md",
+                "es_core_news_lg",
+                "es_dep_news_trf"
+            ],
             "example": "Esto es una frase.",
             "has_examples": true
         },
-        { "code": "et", "name": "Estonian" },
-        { "code": "eu", "name": "Basque", "has_examples": true },
-        { "code": "fa", "name": "Persian", "has_examples": true },
-        { "code": "fi", "name": "Finnish", "has_examples": true },
+        {
+            "code": "et",
+            "name": "Estonian"
+        },
+        {
+            "code": "eu",
+            "name": "Basque",
+            "has_examples": true
+        },
+        {
+            "code": "fa",
+            "name": "Persian",
+            "has_examples": true
+        },
+        {
+            "code": "fi",
+            "name": "Finnish",
+            "has_examples": true
+        },
         {
             "code": "fr",
             "name": "French",
-            "models": ["fr_core_news_sm", "fr_core_news_md", "fr_core_news_lg", "fr_dep_news_trf"],
+            "models": [
+                "fr_core_news_sm",
+                "fr_core_news_md",
+                "fr_core_news_lg",
+                "fr_dep_news_trf"
+            ],
             "example": "C'est une phrase.",
             "has_examples": true
         },
-        { "code": "ga", "name": "Irish" },
-        { "code": "he", "name": "Hebrew", "example": "זהו משפט.", "has_examples": true },
-        { "code": "hi", "name": "Hindi", "example": "यह एक वाक्य है।", "has_examples": true },
-        { "code": "hr", "name": "Croatian", "has_examples": true },
-        { "code": "hu", "name": "Hungarian", "example": "Ez egy mondat.", "has_examples": true },
-        { "code": "hy", "name": "Armenian", "has_examples": true },
+        {
+            "code": "ga",
+            "name": "Irish"
+        },
+        {
+            "code": "gu",
+            "name": "Gujarati",
+            "has_examples": true
+        },
+        {
+            "code": "he",
+            "name": "Hebrew",
+            "example": "זהו משפט.",
+            "has_examples": true
+        },
+        {
+            "code": "hi",
+            "name": "Hindi",
+            "example": "यह एक वाक्य है।",
+            "has_examples": true
+        },
+        {
+            "code": "hr",
+            "name": "Croatian",
+            "has_examples": true
+        },
+        {
+            "code": "hu",
+            "name": "Hungarian",
+            "example": "Ez egy mondat.",
+            "has_examples": true
+        },
+        {
+            "code": "hy",
+            "name": "Armenian",
+            "has_examples": true
+        },
         {
             "code": "id",
             "name": "Indonesian",
             "example": "Ini adalah sebuah kalimat.",
             "has_examples": true
         },
-        { "code": "is", "name": "Icelandic" },
+        {
+            "code": "is",
+            "name": "Icelandic"
+        },
         {
             "code": "it",
             "name": "Italian",
-            "models": ["it_core_news_sm", "it_core_news_md", "it_core_news_lg"],
+            "models": [
+                "it_core_news_sm",
+                "it_core_news_md",
+                "it_core_news_lg"
+            ],
             "example": "Questa è una frase.",
             "has_examples": true
         },
         {
             "code": "ja",
             "name": "Japanese",
-            "models": ["ja_core_news_sm", "ja_core_news_md", "ja_core_news_lg"],
+            "models": [
+                "ja_core_news_sm",
+                "ja_core_news_md",
+                "ja_core_news_lg"
+            ],
             "dependencies": [
-                { "name": "Unidic", "url": "http://unidic.ninjal.ac.jp/back_number#unidic_cwj" },
-                { "name": "Mecab", "url": "https://github.com/taku910/mecab" },
+                {
+                    "name": "Unidic",
+                    "url": "http://unidic.ninjal.ac.jp/back_number#unidic_cwj"
+                },
+                {
+                    "name": "Mecab",
+                    "url": "https://github.com/taku910/mecab"
+                },
                 {
                     "name": "SudachiPy",
                     "url": "https://github.com/WorksApplications/SudachiPy"
@@ -87,7 +204,11 @@
             "example": "これは文章です。",
             "has_examples": true
         },
-        { "code": "kn", "name": "Kannada", "has_examples": true },
+        {
+            "code": "kn",
+            "name": "Kannada",
+            "has_examples": true
+        },
         {
             "code": "ko",
             "name": "Korean",
@@ -96,8 +217,14 @@
                     "name": "mecab-ko",
                     "url": "https://bitbucket.org/eunjeon/mecab-ko/src/master/README.md"
                 },
-                { "name": "mecab-ko-dic", "url": "https://bitbucket.org/eunjeon/mecab-ko-dic" },
-                { "name": "natto-py", "url": "https://github.com/buruzaemon/natto-py" }
+                {
+                    "name": "mecab-ko-dic",
+                    "url": "https://bitbucket.org/eunjeon/mecab-ko-dic"
+                },
+                {
+                    "name": "natto-py",
+                    "url": "https://github.com/buruzaemon/natto-py"
+                }
             ],
             "example": "이것은 문장입니다.",
             "has_examples": true
@@ -108,103 +235,10 @@
             "example": "Адамга эң кыйыны — күн сайын адам болуу",
             "has_examples": true
         },
-        { "code": "lb", "name": "Luxembourgish", "has_examples": true },
         {
-            "code": "lt",
-            "name": "Lithuanian",
-            "has_examples": true,
-            "models": ["lt_core_news_sm", "lt_core_news_md", "lt_core_news_lg"]
-        },
-        { "code": "lv", "name": "Latvian" },
-        {
-            "code": "mk",
-            "name": "Macedonian",
-            "has_examples": false,
-            "models": ["mk_core_news_sm", "mk_core_news_md", "mk_core_news_lg"]
-        },
-        { "code": "ml", "name": "Malayalam", "has_examples": true },
-        { "code": "mr", "name": "Marathi" },
-        {
-            "code": "nb",
-            "name": "Norwegian Bokmål",
-            "example": "Dette er en setning.",
-            "has_examples": true,
-            "models": ["nb_core_news_sm", "nb_core_news_md", "nb_core_news_lg"]
-        },
-        { "code": "ne", "name": "Nepali", "has_examples": true },
-        {
-            "code": "nl",
-            "name": "Dutch",
-            "models": ["nl_core_news_sm", "nl_core_news_md", "nl_core_news_lg"],
-            "example": "Dit is een zin.",
+            "code": "lb",
+            "name": "Luxembourgish",
             "has_examples": true
-        },
-        {
-            "code": "pl",
-            "name": "Polish",
-            "example": "To jest zdanie.",
-            "has_examples": true,
-            "models": ["pl_core_news_sm", "pl_core_news_md", "pl_core_news_lg"]
-        },
-        {
-            "code": "pt",
-            "name": "Portuguese",
-            "models": ["pt_core_news_sm", "pt_core_news_md", "pt_core_news_lg"],
-            "example": "Esta é uma frase.",
-            "has_examples": true
-        },
-        {
-            "code": "ro",
-            "name": "Romanian",
-            "example": "Aceasta este o propoziție.",
-            "has_examples": true,
-            "models": ["ro_core_news_sm", "ro_core_news_md", "ro_core_news_lg"]
-        },
-        {
-            "code": "ru",
-            "name": "Russian",
-            "has_examples": true,
-            "dependencies": [{ "name": "pymorphy2", "url": "https://github.com/kmike/pymorphy2" }],
-            "models": ["ru_core_news_sm", "ru_core_news_md", "ru_core_news_lg"]
-        },
-        { "code": "sa", "name": "Sanskrit", "has_examples": true },
-        { "code": "si", "name": "Sinhala", "example": "මෙය වාක්‍යයකි.", "has_examples": true },
-        { "code": "sk", "name": "Slovak", "has_examples": true },
-        { "code": "sl", "name": "Slovenian" },
-        {
-            "code": "sq",
-            "name": "Albanian",
-            "example": "Kjo është një fjali.",
-            "has_examples": true
-        },
-        { "code": "sr", "name": "Serbian", "has_examples": true },
-        { "code": "sv", "name": "Swedish", "has_examples": true },
-        { "code": "ta", "name": "Tamil", "has_examples": true },
-        { "code": "te", "name": "Telugu", "example": "ఇది ఒక వాక్యం.", "has_examples": true },
-        {
-            "code": "th",
-            "name": "Thai",
-            "dependencies": [
-                { "name": "pythainlp", "url": "https://github.com/wannaphongcom/pythainlp" }
-            ],
-            "example": "นี่คือประโยค",
-            "has_examples": true
-        },
-        { "code": "tl", "name": "Tagalog" },
-        { "code": "tn", "name": "Setswana", "has_examples": true },
-        { "code": "tr", "name": "Turkish", "example": "Bu bir cümledir.", "has_examples": true },
-        { "code": "tt", "name": "Tatar", "has_examples": true },
-        {
-            "code": "uk",
-            "name": "Ukrainian",
-            "has_examples": true,
-            "dependencies": [{ "name": "pymorphy2", "url": "https://github.com/kmike/pymorphy2" }]
-        },
-        { "code": "ur", "name": "Urdu", "example": "یہ ایک جملہ ہے", "has_examples": true },
-        {
-            "code": "vi",
-            "name": "Vietnamese",
-            "dependencies": [{ "name": "Pyvi", "url": "https://github.com/trungtv/pyvi" }]
         },
         {
             "code": "lij",
@@ -213,8 +247,56 @@
             "has_examples": true
         },
         {
-            "code": "gu",
-            "name": "Gujarati",
+            "code": "lt",
+            "name": "Lithuanian",
+            "has_examples": true,
+            "models": [
+                "lt_core_news_sm",
+                "lt_core_news_md",
+                "lt_core_news_lg"
+            ]
+        },
+        {
+            "code": "lv",
+            "name": "Latvian"
+        },
+        {
+            "code": "mk",
+            "name": "Macedonian",
+            "has_examples": false,
+            "models": [
+                "mk_core_news_sm",
+                "mk_core_news_md",
+                "mk_core_news_lg"
+            ]
+        },
+        {
+            "code": "mk",
+            "name": "Macedonian"
+        },
+        {
+            "code": "ml",
+            "name": "Malayalam",
+            "has_examples": true
+        },
+        {
+            "code": "mr",
+            "name": "Marathi"
+        },
+        {
+            "code": "nb",
+            "name": "Norwegian Bokmål",
+            "example": "Dette er en setning.",
+            "has_examples": true,
+            "models": [
+                "nb_core_news_sm",
+                "nb_core_news_md",
+                "nb_core_news_lg"
+            ]
+        },
+        {
+            "code": "ne",
+            "name": "Nepali",
             "has_examples": true
         },
         {
@@ -223,20 +305,194 @@
             "has_examples": true
         },
         {
-            "code": "mk",
-            "name": "Macedonian"
+            "code": "nl",
+            "name": "Dutch",
+            "models": [
+                "nl_core_news_sm",
+                "nl_core_news_md",
+                "nl_core_news_lg"
+            ],
+            "example": "Dit is een zin.",
+            "has_examples": true
+        },
+        {
+            "code": "pl",
+            "name": "Polish",
+            "example": "To jest zdanie.",
+            "has_examples": true,
+            "models": [
+                "pl_core_news_sm",
+                "pl_core_news_md",
+                "pl_core_news_lg"
+            ]
+        },
+        {
+            "code": "pt",
+            "name": "Portuguese",
+            "models": [
+                "pt_core_news_sm",
+                "pt_core_news_md",
+                "pt_core_news_lg"
+            ],
+            "example": "Esta é uma frase.",
+            "has_examples": true
+        },
+        {
+            "code": "ro",
+            "name": "Romanian",
+            "example": "Aceasta este o propoziție.",
+            "has_examples": true,
+            "models": [
+                "ro_core_news_sm",
+                "ro_core_news_md",
+                "ro_core_news_lg"
+            ]
+        },
+        {
+            "code": "ru",
+            "name": "Russian",
+            "has_examples": true,
+            "dependencies": [
+                {
+                    "name": "pymorphy2",
+                    "url": "https://github.com/kmike/pymorphy2"
+                }
+            ],
+            "models": [
+                "ru_core_news_sm",
+                "ru_core_news_md",
+                "ru_core_news_lg"
+            ]
+        },
+        {
+            "code": "sa",
+            "name": "Sanskrit",
+            "has_examples": true
+        },
+        {
+            "code": "si",
+            "name": "Sinhala",
+            "example": "මෙය වාක්‍යයකි.",
+            "has_examples": true
+        },
+        {
+            "code": "sk",
+            "name": "Slovak",
+            "has_examples": true
+        },
+        {
+            "code": "sl",
+            "name": "Slovenian"
+        },
+        {
+            "code": "sq",
+            "name": "Albanian",
+            "example": "Kjo është një fjali.",
+            "has_examples": true
+        },
+        {
+            "code": "sr",
+            "name": "Serbian",
+            "has_examples": true
+        },
+        {
+            "code": "sv",
+            "name": "Swedish",
+            "has_examples": true
+        },
+        {
+            "code": "ta",
+            "name": "Tamil",
+            "has_examples": true
+        },
+        {
+            "code": "te",
+            "name": "Telugu",
+            "example": "ఇది ఒక వాక్యం.",
+            "has_examples": true
+        },
+        {
+            "code": "th",
+            "name": "Thai",
+            "dependencies": [
+                {
+                    "name": "pythainlp",
+                    "url": "https://github.com/wannaphongcom/pythainlp"
+                }
+            ],
+            "example": "นี่คือประโยค",
+            "has_examples": true
+        },
+        {
+            "code": "tl",
+            "name": "Tagalog"
+        },
+        {
+            "code": "tn",
+            "name": "Setswana",
+            "has_examples": true
+        },
+        {
+            "code": "tr",
+            "name": "Turkish",
+            "example": "Bu bir cümledir.",
+            "has_examples": true
+        },
+        {
+            "code": "tt",
+            "name": "Tatar",
+            "has_examples": true
+        },
+        {
+            "code": "uk",
+            "name": "Ukrainian",
+            "has_examples": true,
+            "dependencies": [
+                {
+                    "name": "pymorphy2",
+                    "url": "https://github.com/kmike/pymorphy2"
+                }
+            ]
+        },
+        {
+            "code": "ur",
+            "name": "Urdu",
+            "example": "یہ ایک جملہ ہے",
+            "has_examples": true
+        },
+        {
+            "code": "vi",
+            "name": "Vietnamese",
+            "dependencies": [
+                {
+                    "name": "Pyvi",
+                    "url": "https://github.com/trungtv/pyvi"
+                }
+            ]
         },
         {
             "code": "xx",
             "name": "Multi-language",
-            "models": ["xx_ent_wiki_sm", "xx_sent_ud_sm"],
+            "models": [
+                "xx_ent_wiki_sm",
+                "xx_sent_ud_sm"
+            ],
             "example": "This is a sentence about Facebook."
         },
-        { "code": "yo", "name": "Yoruba", "has_examples": true },
+        {
+            "code": "yo",
+            "name": "Yoruba",
+            "has_examples": true
+        },
         {
             "code": "zh",
             "name": "Chinese",
-            "models": ["zh_core_web_sm", "zh_core_web_md", "zh_core_web_lg", "zh_core_web_trf"],
+            "models": [
+                "zh_core_web_sm",
+                "zh_core_web_md",
+                "zh_core_web_lg",
+                "zh_core_web_trf"
+            ],
             "dependencies": [
                 {
                     "name": "Jieba",
@@ -251,18 +507,54 @@
         }
     ],
     "licenses": [
-        { "id": "CC BY 4.0", "url": "https://creativecommons.org/licenses/by/4.0/" },
-        { "id": "CC BY-SA", "url": "https://creativecommons.org/licenses/by-sa/3.0/" },
-        { "id": "CC BY-SA 3.0", "url": "https://creativecommons.org/licenses/by-sa/3.0/" },
-        { "id": "CC BY-SA 4.0", "url": "https://creativecommons.org/licenses/by-sa/4.0/" },
-        { "id": "CC BY-NC", "url": "https://creativecommons.org/licenses/by-nc/3.0/" },
-        { "id": "CC BY-NC 3.0", "url": "https://creativecommons.org/licenses/by-nc/3.0/" },
-        { "id": "CC BY-NC 4.0", "url": "https://creativecommons.org/licenses/by-nc/4.0/" },
-        { "id": "CC-BY-NC-SA 3.0", "url": "https://creativecommons.org/licenses/by-nc-sa/3.0/" },
-        { "id": "GPL", "url": "https://www.gnu.org/licenses/gpl.html" },
-        { "id": "GPU GPL 3.0", "url": "https://www.gnu.org/licenses/gpl-3.0.en.html" },
-        { "id": "LGPL", "url": "https://www.gnu.org/licenses/lgpl.html" },
-        { "id": "MIT", "url": "https://opensource.org/licenses/MIT" },
+        {
+            "id": "CC BY 4.0",
+            "url": "https://creativecommons.org/licenses/by/4.0/"
+        },
+        {
+            "id": "CC BY-SA",
+            "url": "https://creativecommons.org/licenses/by-sa/3.0/"
+        },
+        {
+            "id": "CC BY-SA 3.0",
+            "url": "https://creativecommons.org/licenses/by-sa/3.0/"
+        },
+        {
+            "id": "CC BY-SA 4.0",
+            "url": "https://creativecommons.org/licenses/by-sa/4.0/"
+        },
+        {
+            "id": "CC BY-NC",
+            "url": "https://creativecommons.org/licenses/by-nc/3.0/"
+        },
+        {
+            "id": "CC BY-NC 3.0",
+            "url": "https://creativecommons.org/licenses/by-nc/3.0/"
+        },
+        {
+            "id": "CC BY-NC 4.0",
+            "url": "https://creativecommons.org/licenses/by-nc/4.0/"
+        },
+        {
+            "id": "CC-BY-NC-SA 3.0",
+            "url": "https://creativecommons.org/licenses/by-nc-sa/3.0/"
+        },
+        {
+            "id": "GPL",
+            "url": "https://www.gnu.org/licenses/gpl.html"
+        },
+        {
+            "id": "GPU GPL 3.0",
+            "url": "https://www.gnu.org/licenses/gpl-3.0.en.html"
+        },
+        {
+            "id": "LGPL",
+            "url": "https://www.gnu.org/licenses/lgpl.html"
+        },
+        {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+        },
         {
             "id": "LGPL-LR",
             "url": "https://github.com/UniversalDependencies/UD_French-Sequoia/blob/master/LICENSE.txt"

--- a/website/meta/languages.json
+++ b/website/meta/languages.json
@@ -53,7 +53,6 @@
             "has_examples": true
         },
         { "code": "ga", "name": "Irish" },
-        { "code": "gu", "name": "Gujarati", "has_examples": true },
         { "code": "he", "name": "Hebrew", "example": "זהו משפט.", "has_examples": true },
         { "code": "hi", "name": "Hindi", "example": "यह एक वाक्य है।", "has_examples": true },
         { "code": "hr", "name": "Croatian", "has_examples": true },
@@ -110,12 +109,6 @@
             "has_examples": true
         },
         { "code": "lb", "name": "Luxembourgish", "has_examples": true },
-        {
-            "code": "lij",
-            "name": "Ligurian",
-            "example": "Sta chì a l'é unna fraxe.",
-            "has_examples": true
-        },
         {
             "code": "lt",
             "name": "Lithuanian",
@@ -220,18 +213,8 @@
             "has_examples": true
         },
         {
-            "code": "hy",
-            "name": "Armenian",
-            "has_examples": true
-        },
-        {
             "code": "gu",
             "name": "Gujarati",
-            "has_examples": true
-        },
-        {
-            "code": "ml",
-            "name": "Malayalam",
             "has_examples": true
         },
         {

--- a/website/meta/languages.json
+++ b/website/meta/languages.json
@@ -290,11 +290,6 @@
             "has_examples": true
         },
         {
-            "code": "ne",
-            "name": "Nepali",
-            "has_examples": true
-        },
-        {
             "code": "nl",
             "name": "Dutch",
             "models": [

--- a/website/meta/languages.json
+++ b/website/meta/languages.json
@@ -262,16 +262,6 @@
         },
         {
             "code": "mk",
-            "name": "Macedonian",
-            "has_examples": false,
-            "models": [
-                "mk_core_news_sm",
-                "mk_core_news_md",
-                "mk_core_news_lg"
-            ]
-        },
-        {
-            "code": "mk",
             "name": "Macedonian"
         },
         {


### PR DESCRIPTION
## Description

I was looking at the [model list on the docs](https://spacy.io/usage/models) and I noticed a few languages were listed twice. 

![image](https://user-images.githubusercontent.com/1019791/109956732-4c55a100-7ce4-11eb-9b2f-66b5a924af5e.png)

So I figured I'd remove the ones that were listed twice. 

### Types of change
Minor documentation fix. 

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
