### PR TITLE
fix pretraining initialization

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1222,10 +1222,6 @@ class Language:
         init_vocab(
             self, data=I["vocab_data"], lookups=I["lookups"], vectors=I["vectors"]
         )
-        pretrain_cfg = config.get("pretraining")
-        if pretrain_cfg:
-            P = registry.resolve(pretrain_cfg, schema=ConfigSchemaPretrain)
-            init_tok2vec(self, P, I)
         if self.vocab.vectors.data.shape[1] >= 1:
             ops = get_current_ops()
             self.vocab.vectors.data = ops.asarray(self.vocab.vectors.data)
@@ -1244,6 +1240,10 @@ class Language:
                     proc.initialize, p_settings, section="components", name=name
                 )
                 proc.initialize(get_examples, nlp=self, **p_settings)
+        pretrain_cfg = config.get("pretraining")
+        if pretrain_cfg:
+            P = registry.resolve(pretrain_cfg, schema=ConfigSchemaPretrain)
+            init_tok2vec(self, P, I)
         self._link_components()
         self._optimizer = sgd
         if sgd is not None:

--- a/spacy/ml/models/multi_task.py
+++ b/spacy/ml/models/multi_task.py
@@ -134,7 +134,7 @@ def build_cloze_characters_multi_task_model(
 ) -> Model:
     output_layer = chain(
         list2array(),
-        Maxout(hidden_size, nP=maxout_pieces),
+        Maxout(nO=hidden_size, nP=maxout_pieces),
         LayerNorm(nI=hidden_size),
         MultiSoftmax([256] * nr_char, nI=hidden_size),
     )

--- a/spacy/ml/models/multi_task.py
+++ b/spacy/ml/models/multi_task.py
@@ -21,6 +21,10 @@ def create_pretrain_vectors(
     maxout_pieces: int, hidden_size: int, loss: str
 ) -> Callable[["Vocab", Model], Model]:
     def create_vectors_objective(vocab: "Vocab", tok2vec: Model) -> Model:
+        if vocab.vectors.data.shape[1] == 0:
+            raise ValueError("To use the PretrainVectors objective, make sure that "
+                             "static vectors are loaded. In the config, these are "
+                             "defined by the initialize.vectors setting.")
         model = build_cloze_multi_task_model(
             vocab, tok2vec, hidden_size=hidden_size, maxout_pieces=maxout_pieces
         )

--- a/spacy/tests/training/test_pretraining.py
+++ b/spacy/tests/training/test_pretraining.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+
+import srsly
+from thinc.api import Config
+from spacy.language import DEFAULT_CONFIG_PRETRAIN_PATH
+
+
+from ..util import make_tempdir
+from ... import util
+from ...training.pretrain import pretrain
+
+pretrain_string = """
+[paths]
+train = null
+dev = null
+
+[corpora]
+
+[corpora.train]
+@readers = "spacy.Corpus.v1"
+path = ${paths.train}
+
+[corpora.dev]
+@readers = "spacy.Corpus.v1"
+path = ${paths.dev}
+
+[training]
+
+[training.batcher]
+@batchers = "spacy.batch_by_words.v1"
+size = 666
+
+[nlp]
+lang = "en"
+pipeline = ["tok2vec", "tagger"]
+
+[components]
+
+[components.tok2vec]
+factory = "tok2vec"
+
+[components.tok2vec.model]
+@architectures = "spacy.HashEmbedCNN.v1"
+pretrained_vectors = null
+width = 342
+depth = 4
+window_size = 1
+embed_size = 2000
+maxout_pieces = 3
+subword_features = true
+
+[components.tagger]
+factory = "tagger"
+
+[components.tagger.model]
+@architectures = "spacy.Tagger.v1"
+
+[components.tagger.model.tok2vec]
+@architectures = "spacy.Tok2VecListener.v1"
+width = ${components.tok2vec.model.width}
+
+[pretraining]
+max_epochs = 10
+"""
+
+
+def test_pretraining_tok2vec_layer():
+    """Test that pretraining works for the tok2vec component"""
+    config = Config().from_str(pretrain_string)
+    nlp = util.load_model_from_config(config, auto_fill=True, validate=False)
+    filled = nlp.config
+    pretrain_config = util.load_config(DEFAULT_CONFIG_PRETRAIN_PATH)
+    filled = pretrain_config.merge(filled)
+    with make_tempdir() as tmp_dir:
+        file_path = write_sample_jsonl(tmp_dir)
+        filled["paths"]["raw_text"] = file_path
+        filled = filled.interpolate()
+        assert filled["pretraining"]["component"] == "tok2vec"
+        pretrain(filled, tmp_dir)
+        assert Path(tmp_dir / "model0.bin").exists()
+        assert Path(tmp_dir / "model9.bin").exists()
+        assert not Path(tmp_dir / "model10.bin").exists()
+
+
+def test_pretraining_tagger_tok2vec():
+    """Test that the pretraining works when referring to the tagger's tok2vec layer"""
+    config = Config().from_str(pretrain_string)
+    nlp = util.load_model_from_config(config, auto_fill=True, validate=False)
+    filled = nlp.config
+    pretrain_config = util.load_config(DEFAULT_CONFIG_PRETRAIN_PATH)
+    filled = pretrain_config.merge(filled)
+    with make_tempdir() as tmp_dir:
+        file_path = write_sample_jsonl(tmp_dir)
+        filled["paths"]["raw_text"] = file_path
+        filled["pretraining"]["component"] = "tagger"
+        filled = filled.interpolate()
+        pretrain(filled, tmp_dir)
+        assert Path(tmp_dir / "model0.bin").exists()
+        assert Path(tmp_dir / "model9.bin").exists()
+        assert not Path(tmp_dir / "model10.bin").exists()
+
+
+def write_sample_jsonl(tmp_dir):
+    data = [
+        {
+            "meta": {"id": "1"},
+            "text": "This is the best TV you'll ever buy!",
+            "cats": {"pos": 1, "neg": 0},
+        },
+        {
+            "meta": {"id": "2"},
+            "text": "I wouldn't buy this again.",
+            "cats": {"pos": 0, "neg": 1},
+        },
+    ]
+    file_path = f"{tmp_dir}/text.jsonl"
+    srsly.write_jsonl(file_path, data)
+    return file_path

--- a/spacy/training/initialize.py
+++ b/spacy/training/initialize.py
@@ -148,10 +148,6 @@ def init_tok2vec(
     weights_data = None
     init_tok2vec = ensure_path(I["init_tok2vec"])
     if init_tok2vec is not None:
-        if P["objective"].get("type") == "vectors" and not I["vectors"]:
-            err = 'need initialize.vectors if pretraining.objective.type is "vectors"'
-            errors = [{"loc": ["initialize"], "msg": err}]
-            raise ConfigValidationError(config=nlp.config, errors=errors)
         if not init_tok2vec.exists():
             err = f"can't find pretrained tok2vec: {init_tok2vec}"
             errors = [{"loc": ["initialize", "init_tok2vec"], "msg": err}]

--- a/spacy/training/initialize.py
+++ b/spacy/training/initialize.py
@@ -157,6 +157,7 @@ def init_tok2vec(
     if weights_data is not None:
         layer = get_tok2vec_ref(nlp, P)
         layer.from_bytes(weights_data)
+        logger.info(f"Loaded pretrained weights from {init_tok2vec}")
         return True
     return False
 

--- a/spacy/training/initialize.py
+++ b/spacy/training/initialize.py
@@ -9,6 +9,7 @@ import gzip
 import zipfile
 import tqdm
 
+from .pretrain import get_tok2vec_ref
 from ..lookups import Lookups
 from ..vectors import Vectors
 from ..errors import Errors, Warnings
@@ -158,20 +159,7 @@ def init_tok2vec(
         with init_tok2vec.open("rb") as file_:
             weights_data = file_.read()
     if weights_data is not None:
-        tok2vec_component = P["component"]
-        if tok2vec_component is None:
-            desc = (
-                f"To use pretrained tok2vec weights, [pretraining.component] "
-                f"needs to specify the component that should load them."
-            )
-            err = "component can't be null"
-            errors = [{"loc": ["pretraining", "component"], "msg": err}]
-            raise ConfigValidationError(
-                config=nlp.config["pretraining"], errors=errors, desc=desc
-            )
-        layer = nlp.get_pipe(tok2vec_component).model
-        if P["layer"]:
-            layer = layer.get_ref(P["layer"])
+        layer = get_tok2vec_ref(nlp, P)
         layer.from_bytes(weights_data)
         return True
     return False

--- a/spacy/training/pretrain.py
+++ b/spacy/training/pretrain.py
@@ -135,8 +135,10 @@ def create_pretraining_model(nlp, pretrain_config):
     The actual tok2vec layer is stored as a reference, and only this bit will be
     serialized to file and read back in when calling the 'train' command.
     """
+    with nlp.select_pipes(enable=[]):
+        nlp.initialize()
     tok2vec = get_tok2vec_ref(nlp, pretrain_config)
-    # If the config refered to a Tok2VecListener, grab the original model instead
+    # If the config referred to a Tok2VecListener, grab the original model instead
     if type(tok2vec).__name__ == "Tok2VecListener":
         original_tok2vec = (
             tok2vec.upstream_name if tok2vec.upstream_name is not "*" else "tok2vec"

--- a/spacy/training/pretrain.py
+++ b/spacy/training/pretrain.py
@@ -138,15 +138,19 @@ def create_pretraining_model(nlp, pretrain_config):
     tok2vec = get_tok2vec_ref(nlp, pretrain_config)
     # If the config refered to a Tok2VecListener, grab the original model instead
     if type(tok2vec).__name__ == "Tok2VecListener":
-        original_tok2vec = tok2vec.upstream_name if tok2vec.upstream_name is not "*" else "tok2vec"
+        original_tok2vec = (
+            tok2vec.upstream_name if tok2vec.upstream_name is not "*" else "tok2vec"
+        )
         tok2vec = nlp.get_pipe(original_tok2vec).model
     try:
         tok2vec.initialize(X=[nlp.make_doc("Give it a doc to infer shapes")])
     except ValueError:
         component = pretrain_config["component"]
         layer = pretrain_config["layer"]
-        raise ValueError(f"Could not initialize the tok2vec model from component "
-                         f"'{component}' and layer '{layer}'.")
+        raise ValueError(
+            f"Could not initialize the tok2vec model from component "
+            f"'{component}' and layer '{layer}'."
+        )
 
     create_function = pretrain_config["objective"]
     model = create_function(nlp.vocab, tok2vec)
@@ -171,7 +175,6 @@ def get_tok2vec_ref(nlp, pretrain_config):
     if pretrain_config["layer"]:
         layer = layer.get_ref(pretrain_config["layer"])
     return layer
-
 
 
 class ProgressTracker:

--- a/spacy/training/pretrain.py
+++ b/spacy/training/pretrain.py
@@ -6,6 +6,8 @@ from collections import Counter
 import srsly
 import time
 import re
+
+from thinc.config import ConfigValidationError
 from wasabi import Printer
 
 from .example import Example
@@ -30,13 +32,10 @@ def pretrain(
         set_gpu_allocator(allocator)
     nlp = load_model_from_config(config)
     _config = nlp.config.interpolate()
-    T = registry.resolve(config["training"], schema=ConfigSchemaTraining)
-    train_corpus = resolve_dot_names(config, [T["train_corpus"]])[0]
     P = registry.resolve(_config["pretraining"], schema=ConfigSchemaPretrain)
     corpus = dot_to_object(_config, P["corpus"])
     corpus = registry.resolve({"corpus": corpus})["corpus"]
     batcher = P["batcher"]
-    nlp.initialize(lambda: train_corpus(nlp))
     model = create_pretraining_model(nlp, P)
     optimizer = P["optimizer"]
     # Load in pretrained weights to resume from
@@ -136,17 +135,43 @@ def create_pretraining_model(nlp, pretrain_config):
     The actual tok2vec layer is stored as a reference, and only this bit will be
     serialized to file and read back in when calling the 'train' command.
     """
-    component = nlp.get_pipe(pretrain_config["component"])
-    if pretrain_config.get("layer"):
-        tok2vec = component.model.get_ref(pretrain_config["layer"])
-    else:
-        tok2vec = component.model
+    tok2vec = get_tok2vec_ref(nlp, pretrain_config)
+    # If the config refered to a Tok2VecListener, grab the original model instead
+    if type(tok2vec).__name__ == "Tok2VecListener":
+        original_tok2vec = tok2vec.upstream_name if tok2vec.upstream_name is not "*" else "tok2vec"
+        tok2vec = nlp.get_pipe(original_tok2vec).model
+    try:
+        tok2vec.initialize(X=[nlp.make_doc("Give it a doc to infer shapes")])
+    except ValueError:
+        component = pretrain_config["component"]
+        layer = pretrain_config["layer"]
+        raise ValueError(f"Could not initialize the tok2vec model from component "
+                         f"'{component}' and layer '{layer}'.")
 
     create_function = pretrain_config["objective"]
     model = create_function(nlp.vocab, tok2vec)
     model.initialize(X=[nlp.make_doc("Give it a doc to infer shapes")])
     set_dropout_rate(model, pretrain_config["dropout"])
     return model
+
+
+def get_tok2vec_ref(nlp, pretrain_config):
+    tok2vec_component = pretrain_config["component"]
+    if tok2vec_component is None:
+        desc = (
+            f"To use pretrained tok2vec weights, [pretraining.component] "
+            f"needs to specify the component that should load them."
+        )
+        err = "component can't be null"
+        errors = [{"loc": ["pretraining", "component"], "msg": err}]
+        raise ConfigValidationError(
+            config=nlp.config["pretraining"], errors=errors, desc=desc
+        )
+    layer = nlp.get_pipe(tok2vec_component).model
+    if pretrain_config["layer"]:
+        layer = layer.get_ref(pretrain_config["layer"])
+    return layer
+
 
 
 class ProgressTracker:

--- a/website/docs/api/architectures.md
+++ b/website/docs/api/architectures.md
@@ -447,6 +447,9 @@ For more information, see the section on
 > ```ini
 > [pretraining]
 > component = "tok2vec"
+> 
+> [initialize]
+> vectors = "en_core_web_lg"
 > ...
 >
 > [pretraining.objective]
@@ -457,7 +460,9 @@ For more information, see the section on
 > ```
 
 Predict the word's vector from a static embeddings table as pretraining
-objective for a Tok2Vec layer.
+objective for a Tok2Vec layer. To use this objective, make sure that the 
+`initialize.vectors` section in the config refers to a model with static 
+vectors.
 
 | Name            | Description                                                                                                                                               |
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION

## Description
When running `pretrain`, the `nlp` object should be initialized with the relevant train corpus to ensure the initialization of components happens correctly. Otherwise, the tagger for instance may complain about not having any labels.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
