### PR TITLE
Optionally append lang for packaged model name

### DIFF
--- a/spacy/cli/package.py
+++ b/spacy/cli/package.py
@@ -113,7 +113,7 @@ def package(
         print("\n".join(errors))
         sys.exit(1)
     model_name = meta["name"]
-    if not model_name.startswith(meta['lang']):
+    if not model_name.startswith(meta['lang'] + "_"):
         model_name = f"{meta['lang']}_{model_name}"
     model_name_v = model_name + "-" + meta["version"]
     main_path = output_dir / model_name_v

--- a/spacy/cli/package.py
+++ b/spacy/cli/package.py
@@ -294,7 +294,8 @@ def setup_package():
 
 if __name__ == '__main__':
     setup_package()
-""".strip()
+
+"""
 
 
 TEMPLATE_MANIFEST = """
@@ -314,4 +315,5 @@ __version__ = get_model_meta(Path(__file__).parent)['version']
 
 def load(**overrides):
     return load_model_from_init_py(__file__, **overrides)
-""".strip()
+    
+"""

--- a/spacy/cli/package.py
+++ b/spacy/cli/package.py
@@ -112,7 +112,9 @@ def package(
         msg.fail("Invalid pipeline meta.json")
         print("\n".join(errors))
         sys.exit(1)
-    model_name = meta["lang"] + "_" + meta["name"]
+    model_name = meta["name"]
+    if not model_name.startswith(meta['lang']):
+        model_name = f"{meta['lang']}_{model_name}"
     model_name_v = model_name + "-" + meta["version"]
     main_path = output_dir / model_name_v
     package_path = main_path / model_name

--- a/spacy/cli/package.py
+++ b/spacy/cli/package.py
@@ -296,8 +296,7 @@ def setup_package():
 
 if __name__ == '__main__':
     setup_package()
-
-"""
+""".lstrip()
 
 
 TEMPLATE_MANIFEST = """
@@ -317,5 +316,4 @@ __version__ = get_model_meta(Path(__file__).parent)['version']
 
 def load(**overrides):
     return load_model_from_init_py(__file__, **overrides)
-    
-"""
+""".lstrip()


### PR DESCRIPTION

## Description
* Only prepend the language code if it's not there already - otherwise calling `package` with for instance `name="nl_core_my_pipeline"` would result in an `"nl_nl_core_my_pipeline"` package.
* Nitpicking: add empty newline at the end of the Python files that are written.

### Types of change
enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
