### PR TITLE
replace "is not" with !=

### DIFF
--- a/spacy/training/pretrain.py
+++ b/spacy/training/pretrain.py
@@ -142,7 +142,7 @@ def create_pretraining_model(nlp, pretrain_config):
     # If the config referred to a Tok2VecListener, grab the original model instead
     if type(tok2vec).__name__ == "Tok2VecListener":
         original_tok2vec = (
-            tok2vec.upstream_name if tok2vec.upstream_name is not "*" else "tok2vec"
+            tok2vec.upstream_name if tok2vec.upstream_name != "*" else "tok2vec"
         )
         tok2vec = nlp.get_pipe(original_tok2vec).model
     try:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

When running spacy with python3.9 I get the following warning
```text
/srv/venv/venvname/lib/python3.9/site-packages/spacy/training/pretrain.py:145: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  tok2vec.upstream_name if tok2vec.upstream_name is not "*" else "tok2vec"
```


### Types of change
replace "is not" with `!=` as we are comparing with a string

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ ] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
