### PR TITLE
Remove mention of -1 for early stopping (fix #7535)

### DIFF
--- a/spacy/default_config.cfg
+++ b/spacy/default_config.cfg
@@ -68,7 +68,7 @@ seed = ${system.seed}
 gpu_allocator = ${system.gpu_allocator}
 dropout = 0.1
 accumulate_gradient = 1
-# Controls early-stopping. 0 or -1 mean unlimited.
+# Controls early-stopping. 0 disables early stopping.
 patience = 1600
 max_epochs = 0
 max_steps = 20000


### PR DESCRIPTION
Maybe this used to work differently, but currently a negative patience
just causes immediate termination.

<!--- Provide a general summary of your changes in the title. -->

### Types of change

Doc fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
