### PR TITLE
Fix __add__ method of PRFScore

### DIFF
--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -20,10 +20,16 @@ MISSING_VALUES = frozenset([None, 0, ""])
 class PRFScore:
     """A precision / recall / F score."""
 
-    def __init__(self) -> None:
-        self.tp = 0
-        self.fp = 0
-        self.fn = 0
+    def __init__(
+        self,
+        *,
+        tp: Optional[int] = None,
+        fp: Optional[int] = None,
+        fn: Optional[int] = None,
+    ) -> None:
+        self.tp = 0 if tp is None else tp
+        self.fp = 0 if fp is None else fp
+        self.fn = 0 if fn is None else fn
 
     def __len__(self) -> int:
         return self.tp + self.fp + self.fn

--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -23,13 +23,13 @@ class PRFScore:
     def __init__(
         self,
         *,
-        tp: Optional[int] = None,
-        fp: Optional[int] = None,
-        fn: Optional[int] = None,
+        tp: int = 0,
+        fp: int = 0,
+        fn: int = 0,
     ) -> None:
-        self.tp = 0 if tp is None else tp
-        self.fp = 0 if fp is None else fp
-        self.fn = 0 if fn is None else fn
+        self.tp = tp
+        self.fp = fp
+        self.fn = fn
 
     def __len__(self) -> int:
         return self.tp + self.fp + self.fn

--- a/spacy/tests/test_scorer.py
+++ b/spacy/tests/test_scorer.py
@@ -3,7 +3,7 @@ import pytest
 from pytest import approx
 from spacy.training import Example
 from spacy.training.iob_utils import offsets_to_biluo_tags
-from spacy.scorer import Scorer, ROCAUCScore
+from spacy.scorer import Scorer, ROCAUCScore, PRFScore
 from spacy.scorer import _roc_auc_score, _roc_curve
 from spacy.lang.en import English
 from spacy.tokens import Doc
@@ -403,3 +403,23 @@ def test_roc_auc_score():
     score.score_set(0.75, 1)
     with pytest.raises(ValueError):
         _ = score.score  # noqa: F841
+
+
+def test_prf_score():
+    cand = {"hi", "ho"}
+    gold1 = {"yo", "hi"}
+    gold2 = set()
+
+    a = PRFScore()
+    a.score_set(cand=cand, gold=gold1)
+    assert (a.precision, a.recall, a.fscore) == approx((0.5, 0.5, 0.5))
+
+    b = PRFScore()
+    b.score_set(cand=cand, gold=gold2)
+    assert (b.precision, b.recall, b.fscore) == approx((0.0, 0.0, 0.0))
+
+    c = a + b
+    assert (c.precision, c.recall, c.fscore) == approx((0.25, 0.5, 0.33333333))
+
+    a += b
+    assert (a.precision, a.recall, a.fscore) == approx((c.precision, c.recall, c.fscore))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
The `__add__` method of `PRFScore` can't be run because of incorrect constructor usage. It isn't used anywhere in the code. Because it would be weird to have `__iadd__` without `__add__`, I decided to fix it instead of removing it.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
