### PR TITLE
fix fn name: tokenizer.infixes_finditer -> tokenizer.infix_finditer

### DIFF
--- a/website/docs/usage/linguistic-features.md
+++ b/website/docs/usage/linguistic-features.md
@@ -962,7 +962,7 @@ domain. There are six things you may need to define:
    quotes, open brackets, etc.
 3. A function `suffix_search`, to handle **succeeding punctuation**, such as
    commas, periods, close quotes, etc.
-4. A function `infixes_finditer`, to handle non-whitespace separators, such as
+4. A function `infix_finditer`, to handle non-whitespace separators, such as
    hyphens etc.
 5. An optional boolean function `token_match` matching strings that should never
    be split, overriding the infix rules. Useful for things like numbers.


### PR DESCRIPTION
## Description
Fix a wrong function name in the documentation. `tokenizer.infixes_finditer`, as mentioned [here](https://spacy.io/usage/linguistic-features#native-tokenizers), should instead be `tokenizer.infix_finditer`, as shown in the API [here](https://spacy.io/api/tokenizer#init).

### Types of change
Change in the documentation.

## Checklist

- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
