### PR TITLE
Terminology: deprecated vs obsolete

### DIFF
--- a/spacy/cli/__init__.py
+++ b/spacy/cli/__init__.py
@@ -29,9 +29,9 @@ from .project.document import project_document  # noqa: F401
 
 @app.command("link", no_args_is_help=True, deprecated=True, hidden=True)
 def link(*args, **kwargs):
-    """As of spaCy v3.0, symlinks like "en" are deprecated. You can load trained
+    """As of spaCy v3.0, symlinks like "en" are not supported anymore. You can load trained
     pipeline packages using their full names or from a directory path."""
     msg.warn(
-        "As of spaCy v3.0, model symlinks are deprecated. You can load trained "
+        "As of spaCy v3.0, model symlinks are not supported anymore. You can load trained "
         "pipeline packages using their full names or from a directory path."
     )

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -634,7 +634,7 @@ class Errors:
             "method, make sure it's overwritten on the subclass.")
     E940 = ("Found NaN values in scores.")
     E941 = ("Can't find model '{name}'. It looks like you're trying to load a "
-            "model from a shortcut, which is deprecated as of spaCy v3.0. To "
+            "model from a shortcut, which is obsolete as of spaCy v3.0. To "
             "load the model, use its full name instead:\n\n"
             "nlp = spacy.load(\"{full}\")\n\nFor more details on the available "
             "models, see the models directory: https://spacy.io/models. If you "

--- a/website/docs/usage/v3.md
+++ b/website/docs/usage/v3.md
@@ -616,11 +616,11 @@ Note that spaCy v3.0 now requires **Python 3.6+**.
 | `spacy profile`                                                                              | [`spacy debug profile`](/api/cli#debug-profile)                                                                                                                                                                          |
 | `spacy link`, `util.set_data_path`, `util.get_data_path`                                     | not needed, symlinks are deprecated                                                                                                                                                                                      |
 
-The following deprecated methods, attributes and arguments were removed in v3.0.
-Most of them have been **deprecated for a while** and many would previously
-raise errors. Many of them were also mostly internals. If you've been working
-with more recent versions of spaCy v2.x, it's **unlikely** that your code relied
-on them.
+The following methods, attributes and arguments were removed in v3.0. Most of
+them have been **deprecated for a while** and many would previously raise
+errors. Many of them were also mostly internals. If you've been working with
+more recent versions of spaCy v2.x, it's **unlikely** that your code relied on
+them.
 
 | Removed                                                                                                                 | Replacement                                                                                                                                                |
 | ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -637,10 +637,10 @@ on them.
 
 ### Downloading and loading trained pipelines {#migrating-downloading-models}
 
-Symlinks and shortcuts like `en` are now officially deprecated. There are
-[many different trained pipelines](/models) with different capabilities and not
-just one "English model". In order to download and load a package, you should
-always use its full name – for instance,
+Symlinks and shortcuts like `en` have been deprecated for a while, and are now
+not supported anymore. There are [many different trained pipelines](/models)
+with different capabilities and not just one "English model". In order to
+download and load a package, you should always use its full name – for instance,
 [`en_core_web_sm`](/models/en#en_core_web_sm).
 
 ```diff
@@ -1185,9 +1185,10 @@ package isn't imported.
 In Jupyter notebooks, run [`prefer_gpu`](/api/top-level#spacy.prefer_gpu),
 [`require_gpu`](/api/top-level#spacy.require_gpu) or
 [`require_cpu`](/api/top-level#spacy.require_cpu) in the same cell as
-[`spacy.load`](/api/top-level#spacy.load) to ensure that the model is loaded on the correct device.
+[`spacy.load`](/api/top-level#spacy.load) to ensure that the model is loaded on
+the correct device.
 
-Due to a bug related to `contextvars` (see the [bug
-report](https://github.com/ipython/ipython/issues/11565)), the GPU settings may
-not be preserved correctly across cells, resulting in models being loaded on
+Due to a bug related to `contextvars` (see the
+[bug report](https://github.com/ipython/ipython/issues/11565)), the GPU settings
+may not be preserved correctly across cells, resulting in models being loaded on
 the wrong device or only partially on GPU.


### PR DESCRIPTION
Typically, deprecated is used for functionality that is bound to become unavailable but that can still be used. Obsolete is used for features that have been removed. In E941, I think what is meant is "obsolete" since loading a model by a shortcut simply does not work anymore (and throws an error). This is different from downloading a model with a shortcut, which is deprecated but still works.

In light of this, perhaps all other error codes should be checked as well.

### Types of change
Change in error code

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
