### PR TITLE
Remove torino from stop words for Italian

### DIFF
--- a/spacy/lang/it/stop_words.py
+++ b/spacy/lang/it/stop_words.py
@@ -72,7 +72,7 @@ steste stesti stette stettero stetti stia stiamo stiano stiate sto su sua
 subito successivamente successivo sue sugl sugli sui sul sull sulla sulle
 sullo suo suoi
 
-tale tali talvolta tanto te tempo ti titolo torino tra tranne tre trenta
+tale tali talvolta tanto te tempo ti titolo tra tranne tre trenta
 troppo trovato tu tua tue tuo tuoi tutta tuttavia tutte tutti tutto
 
 uguali ulteriore ultimo un una uno uomo


### PR DESCRIPTION
I stumbled upon the fact that "torino" is in the list of stop words for Italian. Torino is the proper name of a city and the token has no other common meanings.
I think the inclusion is unintended since most likely people want it to not be ignored and may even want a NER tagger to detect it.

### Types of change
Bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [X] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed. (I didn't, as it's a small dataset change)
- [X] My changes don't require a change to the documentation, or if they do, I've added all required information.
