### PR TITLE
Default code for Setting Entity annotations on the website errors

### DIFF
--- a/.github/contributors/armsp.md
+++ b/.github/contributors/armsp.md
@@ -98,9 +98,9 @@ mark both statements:
 
 | Field                          | Entry                |
 |------------------------------- | -------------------- |
-| Name                           |  Shantam             |
+| Name                           |  Shantam Raj         |
 | Company name (if applicable)   |                      |
 | Title or role (if applicable)  |                      |
-| Date                           |   21/5/2018          |
+| Date                           |   10/4/2021          |
 | GitHub username                |     armsp            |
-| Website (optional)             |                      |
+| Website (optional)             |https://shantamraj.com|

--- a/website/docs/usage/linguistic-features.md
+++ b/website/docs/usage/linguistic-features.md
@@ -601,12 +601,13 @@ print('Before', ents)
 
 # Create a span for the new entity
 fb_ent = Span(doc, 0, 1, label="ORG")
+orig_ents = list(doc.ents)
 
 # Option 1: Modify the provided entity spans, leaving the rest unmodified
 doc.set_ents([fb_ent], default="unmodified")
 
 # Option 2: Assign a complete list of ents to doc.ents
-# doc.ents = list(doc.ents) + [fb_ent]    # Comment Option 1 before uncommenting this
+doc.ents = orig_ents + [fb_ent]
 
 ents = [(e.text, e.start, e.end, e.label_) for e in doc.ents]
 print('After', ents)

--- a/website/docs/usage/linguistic-features.md
+++ b/website/docs/usage/linguistic-features.md
@@ -606,7 +606,7 @@ fb_ent = Span(doc, 0, 1, label="ORG")
 doc.set_ents([fb_ent], default="unmodified")
 
 # Option 2: Assign a complete list of ents to doc.ents
-doc.ents = list(doc.ents) + [fb_ent]
+# doc.ents = list(doc.ents) + [fb_ent]    # Comment Option 1 before uncommenting this
 
 ents = [(e.text, e.start, e.end, e.label_) for e in doc.ents]
 print('After', ents)


### PR DESCRIPTION
## Description
To the uninitiated, the example at https://spacy.io/usage/linguistic-features#setting-entities errors on Binder because the code tries to set the entity for "fb" twice.
The exact error as reported is -
```
ValueError                                Traceback (most recent call last)
<ipython-input-1-73c2a9e8d913> in <module>
     15
     16 # Option 2: Assign a complete list of ents to doc.ents
---> 17 doc.ents = list(doc.ents) + [fb_ent]
     18
     19 ents = [(e.text, e.start, e.end, e.label_) for e in doc.ents]

/srv/conda/envs/notebook/lib/python3.7/site-packages/spacy/tokens/doc.pyx in spacy.tokens.doc.Doc.ents.__set__()

/srv/conda/envs/notebook/lib/python3.7/site-packages/spacy/tokens/doc.pyx in spacy.tokens.doc.Doc.set_ents()

ValueError: [E1010] Unable to set entity information for token 0 which is included in more than one span in entities, blocked, missing or outside.
```

People short on time or coming here the first time or just beginners may assume that this is
a shortcoming of the library when they are supposed to actually try one of the two options.

So I have commented Option 2 by default, and added a comment adjacent to it stating that
comment option 1 before running option 2.



### Types of change
Very basic change to the documentation

## Checklist

- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

The changes are so basic that they do not require any tests to be run.

Feel free to ignore this PR if you think it is not important.