### PR TITLE
ensure 'spacy ray' works

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ install_requires =
 
 [options.entry_points]
 console_scripts =
-    spacy = spacy.cli:app
+    spacy = spacy.cli:setup_cli
 
 [options.extras_require]
 lookups =

--- a/spacy/cli/__init__.py
+++ b/spacy/cli/__init__.py
@@ -26,12 +26,6 @@ from .project.push import project_push  # noqa: F401
 from .project.pull import project_pull  # noqa: F401
 from .project.document import project_document  # noqa: F401
 
-# ensure 'spacy ray' is available (otherwise only 'python -m spacy ray' works)
-try:
-    from spacy_ray.train_cli import ray_train_cli
-except ImportError:
-    pass
-
 
 @app.command("link", no_args_is_help=True, deprecated=True, hidden=True)
 def link(*args, **kwargs):

--- a/spacy/cli/__init__.py
+++ b/spacy/cli/__init__.py
@@ -26,6 +26,12 @@ from .project.push import project_push  # noqa: F401
 from .project.pull import project_pull  # noqa: F401
 from .project.document import project_document  # noqa: F401
 
+# ensure 'spacy ray' is available (otherwise only 'python -m spacy ray' works)
+try:
+    from spacy_ray.train_cli import ray_train_cli
+except ImportError:
+    pass
+
 
 @app.command("link", no_args_is_help=True, deprecated=True, hidden=True)
 def link(*args, **kwargs):


### PR DESCRIPTION
Fixes https://github.com/explosion/spaCy/issues/7732

## Description
If `spacy-ray` is installed, it only works when calling `python -m spacy ray`. With this fix, it also works with just `spacy ray` - cf https://github.com/explosion/spaCy/issues/7732 for details.

### Types of change
fix/enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
