### PR TITLE
update EL training data format in docs

### DIFF
--- a/website/docs/api/data-formats.md
+++ b/website/docs/api/data-formats.md
@@ -455,7 +455,7 @@ example = Example.from_dict(doc, gold_dict)
 doc = nlp("Russ Cochran his reprints include EC Comics.")
 gold_dict = {"entities": [(0, 12, "PERSON")],
              "links": {(0, 12): {"Q7381115": 1.0, "Q2146908": 0.0}},
-             "sent_starts": [1, -1, 0, 0, 0, 0, 0, 0]})}
+             "sent_starts": [1, -1, 0, 0, 0, 0, 0, 0]}
 example = Example.from_dict(doc, gold_dict)
 ```
 

--- a/website/docs/api/data-formats.md
+++ b/website/docs/api/data-formats.md
@@ -451,9 +451,11 @@ doc = nlp("I'm pretty happy about that!")
 gold_dict = {"cats": {"POSITIVE": 1.0, "NEGATIVE": 0.0}}
 example = Example.from_dict(doc, gold_dict)
 
-# Training data for an Entity Linking component
+# Training data for an Entity Linking component (also requires entities & sentences)
 doc = nlp("Russ Cochran his reprints include EC Comics.")
-gold_dict = {"links": {(0, 12): {"Q7381115": 1.0, "Q2146908": 0.0}}}
+gold_dict = {"entities": [(0, 12, "PERSON")],
+             "links": {(0, 12): {"Q7381115": 1.0, "Q2146908": 0.0}},
+             "sent_starts": [1, -1, 0, 0, 0, 0, 0, 0]})}
 example = Example.from_dict(doc, gold_dict)
 ```
 

--- a/website/docs/api/data-formats.md
+++ b/website/docs/api/data-formats.md
@@ -455,7 +455,7 @@ example = Example.from_dict(doc, gold_dict)
 doc = nlp("Russ Cochran his reprints include EC Comics.")
 gold_dict = {"entities": [(0, 12, "PERSON")],
              "links": {(0, 12): {"Q7381115": 1.0, "Q2146908": 0.0}},
-             "sent_starts": [1, -1, 0, 0, 0, 0, 0, 0]}
+             "sent_starts": [1, -1, -1, -1, -1, -1, -1, -1]}
 example = Example.from_dict(doc, gold_dict)
 ```
 


### PR DESCRIPTION
## Description
As pointed out in https://github.com/explosion/spaCy/discussions/7817, the EL training data format from the docs was not complete and could be confusing, as the EL needs gold sentences & entities. 

### Types of change
doc fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
