### PR TITLE
Fix percent unk display in debug data

### DIFF
--- a/spacy/cli/debug_data.py
+++ b/spacy/cli/debug_data.py
@@ -171,7 +171,7 @@ def debug_data(
         )
         n_missing_vectors = sum(gold_train_data["words_missing_vectors"].values())
         msg.warn(
-            "{} words in training data without vectors ({:0.2f}%)".format(
+            "{} words in training data without vectors ({:.0f}%)".format(
                 n_missing_vectors, 100 * (n_missing_vectors / gold_train_data["n_words"])
             ),
         )

--- a/spacy/cli/debug_data.py
+++ b/spacy/cli/debug_data.py
@@ -172,7 +172,7 @@ def debug_data(
         n_missing_vectors = sum(gold_train_data["words_missing_vectors"].values())
         msg.warn(
             "{} words in training data without vectors ({:0.2f}%)".format(
-                n_missing_vectors, n_missing_vectors / gold_train_data["n_words"]
+                n_missing_vectors, 100 * (n_missing_vectors / gold_train_data["n_words"])
             ),
         )
         msg.text(


### PR DESCRIPTION
This was showing (ratio %), so 10% would show as 0.10%. Fix by
multiplying ratio by 100.

Might want to add a warning if this is over a threshold.

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

### Types of change

Minor fix to display output of debug data.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
