### PR TITLE
Small fix for EL

### DIFF
--- a/spacy/ml/models/entity_linker.py
+++ b/spacy/ml/models/entity_linker.py
@@ -11,7 +11,7 @@ from ...vocab import Vocab
 @registry.architectures("spacy.EntityLinker.v1")
 def build_nel_encoder(tok2vec: Model, nO: Optional[int] = None) -> Model:
     with Model.define_operators({">>": chain, "**": clone}):
-        token_width = tok2vec.get_dim("nO")
+        token_width = tok2vec.maybe_get_dim("nO")
         output_layer = Linear(nO=nO, nI=token_width)
         model = (
             tok2vec


### PR DESCRIPTION

## Description
If the `entity_linker` model is created with `nO=None`, that should still work through shape inference. To accomodate this use-case, use `maybe_get_dim` instead of `get_dim` when deciding on the token width.

I don't think we need to bump the `EntityLinker`'s version number, as this is a bug fix for use-cases that would have otherwise not worked, and won't affect existing, working use-cases.

This came up in https://github.com/explosion/spaCy/discussions/7884.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
