### PR TITLE
Adds support for logging training loop metrics, models, datasets to M…

### DIFF
--- a/.github/contributors/narayanacharya6.md
+++ b/.github/contributors/narayanacharya6.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI GmbH](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           | Narayan Acharya      |
+| Company name (if applicable)   |                      |
+| Title or role (if applicable)  |                      |
+| Date                           | 29 APR 2021          |
+| GitHub username                | narayanacharya6      |
+| Website (optional)             | narayanacharya.com   |

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -517,6 +517,9 @@ class Errors:
     E880 = ("The 'wandb' library could not be found - did you install it? "
             "Alternatively, specify the 'ConsoleLogger' in the 'training.logger' "
             "config section, instead of the 'WandbLogger'.")
+    E881 = ("The 'mlflow' library could not be found - did you install it? "
+            "Alternatively, specify the 'ConsoleLogger' in the 'training.logger' "
+            "config section, instead of the 'MLflowLogger'.")
     E884 = ("The pipeline could not be initialized because the vectors "
             "could not be found at '{vectors}'. If your pipeline was already "
             "initialized/trained before, call 'resume_training' instead of 'initialize', "

--- a/spacy/training/__init__.py
+++ b/spacy/training/__init__.py
@@ -7,5 +7,5 @@ from .iob_utils import offsets_to_biluo_tags, biluo_tags_to_offsets  # noqa: F40
 from .iob_utils import biluo_tags_to_spans, tags_to_entities  # noqa: F401
 from .gold_io import docs_to_json, read_json_file  # noqa: F401
 from .batchers import minibatch_by_padded_size, minibatch_by_words  # noqa: F401
-from .loggers import console_logger, wandb_logger  # noqa: F401
+from .loggers import console_logger, wandb_logger, mlflow_logger  # noqa: F401
 from .callbacks import create_copy_from_base_model  # noqa: F401

--- a/spacy/training/loggers.py
+++ b/spacy/training/loggers.py
@@ -225,7 +225,7 @@ def mlflow_logger(
                 if log_other_scores and isinstance(other_scores, dict):
                     log_dict(other_scores, artifact_file='scores_{}.json'.format(step))
 
-                if model_artifact_path:
+                if model_artifact_path and info.get("output_path"):
                     from spacy import load
                     model_path = info["output_path"]
                     model = load(model_path)

--- a/spacy/training/loop.py
+++ b/spacy/training/loop.py
@@ -122,9 +122,9 @@ def train(
             )
         raise e
     finally:
-        finalize_logger()
         if output_path is not None:
             save_checkpoint(False)
+        finalize_logger()
     # This will only run if we did't hit an error
     if optimizer.averages:
         nlp.use_params(optimizer.averages)

--- a/website/docs/api/top-level.md
+++ b/website/docs/api/top-level.md
@@ -410,9 +410,10 @@ finished. To log each training step, a
 [`spacy train`](/api/cli#train), including information such as the training loss
 and the accuracy scores on the development set.
 
-There are two built-in logging functions: a logger printing results to the
-console in tabular format (which is the default), and one that also sends the
-results to a [Weights & Biases](https://www.wandb.com/) dashboard. Instead of
+There are three built-in logging functions: a logger printing results to the
+console in tabular format (which is the default), one that also sends the
+results to a [Weights & Biases](https://www.wandb.com/) dashboard, and one that
+sends results to a [MLflow](https://www.mlflow.org/) tracking server. Instead of
 using one of the built-in loggers listed here, you can also
 [implement your own](/usage/training#custom-logging).
 
@@ -517,6 +518,46 @@ creating variants of the config for a simple hyperparameter grid search and
 logging the results.
 
 </Project>
+
+#### spacy.MLflowLogger.v1 {#MLflowLogger tag="registered function"}
+
+> #### Installation
+>
+> ```bash
+> $ pip install mlflow
+> $ export MLFLOW_TRACKING_URI=<URL_TO_YOUR_TRACKING_SERVER>
+> ```
+
+Built-in logger that sends the results of each training step to the 
+[MLflow](https://www.mlflow.org/) tracking server. To use this logger, MLflow
+should be installed, and you should know MLflow tracking server URL. The logger
+will send the losses, other scores, model artifacts, datasets (optional) 
+to the tracking server.
+
+> #### Example config
+>
+> ```ini
+> [training.logger]
+> @loggers = "spacy.MLflowLogger.v1"
+> experiment_name = "monitor_spacy_training"
+> log_scores = true
+> log_losses = true
+> log_other_scores = true
+> model_artifact_path = "spacy.models"
+> dataset_source_path = "corpus"
+> dataset_artifact_path = "corpus"
+> ```
+
+| Name                   | Description                                                                                                                           |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `experiment_name`      | The name of the experiment against which you wish to track runs. ~~str~~                                                              |
+| `log_scores`           | Flag indicating whether you wish to log scores (default: True). ~~Optional[bool]~~                                                    |
+| `log_losses`           | Flag indicating whether you wish to log losses (default: True). ~~Optional[bool]~~                                                    |
+| `log_other_scores`     | Flag indicating whether you wish to log other scores (default: True). ~~Optional[bool]~~                                              |
+| `model_artifact_path`  | Relative directory within the run artifacts where you wish to save your models (default: None). ~~Optional[str]~~                     |
+| `dataset_source_path`  | Directory where your dataset files reside (default: None). ~~Optional[int]~~                                                          |
+| `dataset_artifact_path`| Relative directory within the run artifacts where you wish for dataset files to reside. (default: None). ~~Optional[str]~~            |
+
 
 ## Readers {#readers}
 


### PR DESCRIPTION
This PR is to add support for logging metrics, models and datasets to [MLflow](https://www.mlflow.org/) during spaCy training loop.

## Description
Users who wish to use the new `spacy.MLflowLogger.v1` need to have mlflow installed in their environment. The changes were tested against `mlflow==1.15.0`. Steps to replicate usage include:

1. Install `mlflow`:
`pip install mlflow`

2. Start `mlflow` tracking server locally (or skip if you already have an `mlflo` server ready and running).
`mlflow server --backend-store-uri sqlite:///mlflow.db --host localhost --port 5001 --default-artifact-root ./artifacts`

3. Setup required environment variable (change`localhost:5001` based on your setup).
`export MLFLOW_TRACKING_URI=http://localhost:5001`

4. Update `training.logger` config (below is a bare minimum config, there are other optional parameters with reasonable defaults and these are documented):
```
[training.logger]
@loggers = "spacy.MLflowLogger.v1"
experiment_name = "test_re_ner_pipe"
```

### Types of change
The changes include optional enhancement for users and also updates documentation informing how to use the enhancement. The new logger (similar to the existing WandbLogger) also outputs to the console.

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
