### PR TITLE
Fix 'debug model' for transformers + generalize

### DIFF
--- a/website/docs/api/cli.md
+++ b/website/docs/api/cli.md
@@ -768,6 +768,7 @@ $ python -m spacy debug model ./config.cfg tagger -l "5,15" -DIM -PAR -P0 -P1 -P
 | `--print-step3`, `-P3`  | Print final predictions. ~~bool (flag)~~                                                                                                                                                                           |
 | `--gpu-id`, `-g`        | GPU ID or `-1` for CPU. Defaults to `-1`. ~~int (option)~~                                                                                                                                                         |
 | `--help`, `-h`          | Show help message and available arguments. ~~bool (flag)~~                                                                                                                                                         |
+| overrides               | Config parameters to override. Should be options starting with `--` that correspond to the config section and value to override, e.g. `--paths.train ./train.spacy`. ~~Any (option/flag)~~                         |
 | **PRINTS**              | Debugging information.                                                                                                                                                                                             |
 
 ## train {#train tag="command"}


### PR DESCRIPTION

## Description
When the `debug model` command was constructed, we attempted to create artificial training data to run the model. I think we don't have to do this anymore, we can assume the same usage as with `spacy train` - i.e. the training data is available in the config or from `overrides` parameters.

This makes the `debug model` command more generally applicable.

Also fix for Transformer listeners.

### Types of change
bug fix & enhancement

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
