### PR TITLE
Handle errors while multiprocessing

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -501,6 +501,7 @@ class Errors:
     E202 = ("Unsupported alignment mode '{mode}'. Supported modes: {modes}.")
 
     # New errors added in v3.x
+    E871 = ("Error encountered in nlp.pipe with multiprocessing:\n\n{error}")
     E872 = ("Unable to copy tokenizer from base model due to different "
             'tokenizer settings: current tokenizer config "{curr_config}" '
             'vs. base model "{base_config}"')

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -13,6 +13,7 @@ import srsly
 import multiprocessing as mp
 from itertools import chain, cycle
 from timeit import default_timer as timer
+import traceback
 
 from .tokens.underscore import Underscore
 from .vocab import Vocab, create_vocab
@@ -1521,11 +1522,17 @@ class Language:
 
         # Cycle channels not to break the order of docs.
         # The received object is a batch of byte-encoded docs, so flatten them with chain.from_iterable.
-        byte_docs = chain.from_iterable(recv.recv() for recv in cycle(bytedocs_recv_ch))
-        docs = (Doc(self.vocab).from_bytes(byte_doc) for byte_doc in byte_docs)
+        byte_tuples = chain.from_iterable(recv.recv() for recv in cycle(bytedocs_recv_ch))
         try:
-            for i, (_, doc) in enumerate(zip(raw_texts, docs), 1):
-                yield doc
+            for i, (_, (byte_doc, byte_error)) in enumerate(zip(raw_texts, byte_tuples), 1):
+                if byte_doc is not None:
+                    doc = Doc(self.vocab).from_bytes(byte_doc)
+                    yield doc
+                else:
+                    error = ""
+                    if byte_error is not None:
+                        error = srsly.msgpack_loads(byte_error)
+                    self.default_error_handler(None, None, None, ValueError(Errors.E871.format(error=error)))
                 if i % batch_size == 0:
                     # tell `sender` that one batch was consumed.
                     sender.step()
@@ -2019,12 +2026,19 @@ def _apply_pipes(
     """
     Underscore.load_state(underscore_state)
     while True:
-        texts = receiver.get()
-        docs = (make_doc(text) for text in texts)
-        for pipe in pipes:
-            docs = pipe(docs)
-        # Connection does not accept unpickable objects, so send list.
-        sender.send([doc.to_bytes() for doc in docs])
+        try:
+            texts = receiver.get()
+            docs = (make_doc(text) for text in texts)
+            for pipe in pipes:
+                docs = pipe(docs)
+            # Connection does not accept unpickable objects, so send list.
+            byte_docs = [(doc.to_bytes(), None) for doc in docs]
+            padding = [(None, None)] * (len(texts) - len(byte_docs))
+            sender.send(byte_docs + padding)
+        except Exception:
+            error_msg = [(None, srsly.msgpack_dumps(traceback.format_exc()))]
+            padding = [(None, None)] * (len(texts) - 1)
+            sender.send(error_msg + padding)
 
 
 class _Sender:

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1528,10 +1528,8 @@ class Language:
                 if byte_doc is not None:
                     doc = Doc(self.vocab).from_bytes(byte_doc)
                     yield doc
-                else:
-                    error = ""
-                    if byte_error is not None:
-                        error = srsly.msgpack_loads(byte_error)
+                elif byte_error is not None:
+                    error = srsly.msgpack_loads(byte_error)
                     self.default_error_handler(None, None, None, ValueError(Errors.E871.format(error=error)))
                 if i % batch_size == 0:
                     # tell `sender` that one batch was consumed.

--- a/spacy/tests/test_language.py
+++ b/spacy/tests/test_language.py
@@ -29,6 +29,12 @@ def perhaps_set_sentences(doc):
     return doc
 
 
+def warn_error(proc_name, proc, docs, e):
+    from spacy.util import logger
+
+    logger.warning(f"Trouble with component {proc_name}.")
+
+
 @pytest.fixture
 def nlp():
     nlp = Language(Vocab())
@@ -209,11 +215,6 @@ def test_language_pipe_error_handler(n_process):
 @pytest.mark.parametrize("n_process", [1, 2])
 def test_language_pipe_error_handler_custom(en_vocab, n_process):
     """Test the error handling of a custom component that has no pipe method"""
-
-    def warn_error(proc_name, proc, docs, e):
-        from spacy.util import logger
-
-        logger.warning(f"Trouble with component {proc_name}.")
 
     ops = get_current_ops()
     if isinstance(ops, NumpyOps) or n_process < 2:

--- a/spacy/tests/test_language.py
+++ b/spacy/tests/test_language.py
@@ -29,9 +29,10 @@ def perhaps_set_sentences(doc):
     return doc
 
 
-@Language.component("assert_sents")
-def assert_sents(doc):
-    assert doc.has_annotation("SENT_START")
+@Language.component("assert_sents_error")
+def assert_sents_error(doc):
+    if not doc.has_annotation("SENT_START"):
+        raise ValueError("no sents")
     return doc
 
 
@@ -252,10 +253,10 @@ def test_language_pipe_error_handler_pipe(en_vocab, n_process):
         texts = [f"{str(i)} is enough. Done" for i in range(100)]
         nlp = English()
         nlp.add_pipe("my_perhaps_sentences")
-        nlp.add_pipe("assert_sents")
+        nlp.add_pipe("assert_sents_error")
         nlp.initialize()
         with pytest.raises(ValueError):
-            # assert_sents requires sentence boundaries, will throw an error otherwise
+            # assert_sents_error requires sentence boundaries, will throw an error otherwise
             docs = list(nlp.pipe(texts, n_process=n_process, batch_size=10))
         nlp.set_error_handler(ignore_error)
         docs = list(nlp.pipe(texts, n_process=n_process, batch_size=10))

--- a/spacy/tests/test_language.py
+++ b/spacy/tests/test_language.py
@@ -29,6 +29,12 @@ def perhaps_set_sentences(doc):
     return doc
 
 
+@Language.component("assert_sents")
+def assert_sents(doc):
+    assert doc.has_annotation("SENT_START")
+    return doc
+
+
 def warn_error(proc_name, proc, docs, e):
     from spacy.util import logger
 
@@ -246,11 +252,10 @@ def test_language_pipe_error_handler_pipe(en_vocab, n_process):
         texts = [f"{str(i)} is enough. Done" for i in range(100)]
         nlp = English()
         nlp.add_pipe("my_perhaps_sentences")
-        entity_linker = nlp.add_pipe("entity_linker", config={"entity_vector_length": 3})
-        entity_linker.kb.add_entity(entity="Q1", freq=12, entity_vector=[1, 2, 3])
+        nlp.add_pipe("assert_sents")
         nlp.initialize()
         with pytest.raises(ValueError):
-            # the entity linker requires sentence boundaries, will throw an error otherwise
+            # assert_sents requires sentence boundaries, will throw an error otherwise
             docs = list(nlp.pipe(texts, n_process=n_process, batch_size=10))
         nlp.set_error_handler(ignore_error)
         docs = list(nlp.pipe(texts, n_process=n_process, batch_size=10))

--- a/spacy/tests/test_language.py
+++ b/spacy/tests/test_language.py
@@ -260,8 +260,8 @@ def test_language_pipe_error_handler_pipe(en_vocab, n_process):
             docs = list(nlp.pipe(texts, n_process=n_process, batch_size=10))
         nlp.set_error_handler(ignore_error)
         docs = list(nlp.pipe(texts, n_process=n_process, batch_size=10))
-        # we lose/ignore the failing 0-9 and 40-49 batches
-        assert len(docs) == 80
+        # we lose/ignore the failing 40-49 batches
+        assert len(docs) == 89
 
 
 @pytest.mark.parametrize("n_process", [1, 2])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Handle errors while multiprocessing without hanging.

* Return the traceback for errors raised while processing a batch, which can be handled by the top-level error handler
* Allow for shortened batches due to custom error handlers that ignore errors and skip documents

Notes:

* The behavior between for errors raised by `nlp.make_doc` is currently slightly different with and without multiprocessing. For multiprocessing, an exception in `nlp.make_doc` is returned and handled in the same way as exceptions from the pipeline components using the default error handler. Without multiprocessing, an error in `nlp.make_doc` will be raised directly from `nlp.pipe` instead of being handled by the default error handler.
* Depending on whether a component has implemented `pipe`, when a batch is skipped due to an ignored raised error, the behavior is different. If a component has `pipe`, then the whole batch is skipped, but if it doesn't, then only the individual docs are skipped. There's probably not a good unified solution here.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bug fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
