### PR TITLE
Fix/fix en ordinals

### DIFF
--- a/spacy/lang/en/lex_attrs.py
+++ b/spacy/lang/en/lex_attrs.py
@@ -35,7 +35,7 @@ def like_num(text: str) -> bool:
     # Check ordinal number
     if text_lower in _ordinal_words:
         return True
-    if text_lower.endswith("th"):
+    if text_lower.endswith(("st", "nd", "rd", "th")):
         if text_lower[:-2].isdigit():
             return True
     return False

--- a/spacy/tests/lang/en/test_text.py
+++ b/spacy/tests/lang/en/test_text.py
@@ -56,7 +56,9 @@ def test_lex_attrs_like_number(en_tokenizer, text, match):
     assert tokens[0].like_num == match
 
 
-@pytest.mark.parametrize("word", ["third", "Millionth", "100th", "Hundredth"])
+@pytest.mark.parametrize(
+    "word", ["third", "Millionth", "100th", "Hundredth", "23rd", "52nd"]
+)
 def test_en_lex_attrs_like_number_for_ordinal(word):
     assert like_num(word)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Tokens consisting of digits and an ordinal suffix are supposed to be marked as ordinals (and thus `like_num`), but only the suffix `th` was checked. This adds `st`, `nd`, and `rd`. 

### Types of change

Minor english attribute related fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
