### PR TITLE
Remove unsupported attrs from attrs.IDS

### DIFF
--- a/spacy/attrs.pyx
+++ b/spacy/attrs.pyx
@@ -74,7 +74,6 @@ IDS = {
     "SUFFIX": SUFFIX,
 
     "LENGTH": LENGTH,
-    "CLUSTER": CLUSTER,
     "LEMMA": LEMMA,
     "POS": POS,
     "TAG": TAG,
@@ -85,9 +84,7 @@ IDS = {
     "ENT_KB_ID": ENT_KB_ID,
     "HEAD": HEAD,
     "SENT_START": SENT_START,
-    "SENT_END": SENT_END,
     "SPACY": SPACY,
-    "PROB": PROB,
     "LANG": LANG,
     "MORPH": MORPH,
     "IDX": IDX

--- a/spacy/tests/vocab_vectors/test_vocab_api.py
+++ b/spacy/tests/vocab_vectors/test_vocab_api.py
@@ -1,5 +1,5 @@
 import pytest
-from spacy.attrs import LEMMA, ORTH, PROB, IS_ALPHA
+from spacy.attrs import LEMMA, ORTH, IS_ALPHA
 from spacy.parts_of_speech import NOUN, VERB
 
 
@@ -30,7 +30,6 @@ def test_vocab_api_shape_attr(en_vocab, text):
         ("VERB", VERB),
         ("LEMMA", LEMMA),
         ("ORTH", ORTH),
-        ("PROB", PROB),
     ],
 )
 def test_vocab_api_symbols(en_vocab, string, symbol):


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

The attributes `PROB`, `CLUSTER` and `SENT_END` are not supported by `Lexeme.get_struct_attr` so should not be included through `attrs.IDS` as supported attributes in `Doc.to_array` and other methods.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bug fix?

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
