### PR TITLE
ensure tolerance is properly passed on

### DIFF
--- a/spacy/training/batchers.py
+++ b/spacy/training/batchers.py
@@ -66,7 +66,7 @@ def configure_minibatch_by_words(
     """
     optionals = {"get_length": get_length} if get_length is not None else {}
     return partial(
-        minibatch_by_words, size=size, discard_oversize=discard_oversize, **optionals
+        minibatch_by_words, size=size, tolerance=tolerance, discard_oversize=discard_oversize, **optionals
     )
 
 


### PR DESCRIPTION
## Description
Looks like `spacy.batch_by_words.v1` wasn't correctly passing onwards the `tolerance` parameter.

Should we bump its version to v2?

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
