### PR TITLE
Fix bug from Entityruler: ent_ids returns None for phrases

### DIFF
--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -301,7 +301,7 @@ class EntityRuler(Pipe):
                 self.nlp.pipe(phrase_pattern_texts),
                 phrase_pattern_ids,
             ):
-                phrase_pattern = {"label": label, "pattern": pattern, "id": ent_id}
+                phrase_pattern = {"label": label, "pattern": pattern}
                 if ent_id:
                     phrase_pattern["id"] = ent_id
                 phrase_patterns.append(phrase_pattern)

--- a/spacy/tests/regression/test_issue8168.py
+++ b/spacy/tests/regression/test_issue8168.py
@@ -1,0 +1,11 @@
+from spacy.lang.en import English
+
+def test_issue8168():
+    nlp = English()
+    ruler = nlp.add_pipe("entity_ruler")
+    patterns = [{"label": "ORG", "pattern": "Apple"},
+                {"label": "GPE", "pattern": [{"LOWER": "san"}, {"LOWER": "francisco"}], "id": "san-francisco"},
+                {"label": "GPE", "pattern": [{"LOWER": "san"}, {"LOWER": "fran"}], "id": "san-francisco"}]
+    ruler.add_patterns(patterns)
+
+    assert ruler._ent_ids == {8043148519967183733: ('GPE', 'san-francisco')}


### PR DESCRIPTION
## Summary
Removed a part of the line that adds a **None** `id` to the pattern in `entityruler`.
Added test for the same bug.
Resolves #8168 

## Description
**entityruler.py**:  Line 305 checks and adds an _id_ to `phrase_patterns` if it is passed in the pattern by a user, and Line  304 was also adding an _id_ to `phrase_patterns`.

This was redundant when an _id_ is present in patterns but results in a **None** _id_ when not passed.

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
