### PR TITLE
Additions to "neg examples" PR

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -490,6 +490,10 @@ class Errors:
     E202 = ("Unsupported alignment mode '{mode}'. Supported modes: {modes}.")
 
     # New errors added in v3.x
+    E869 = ("The notation '{label}' is not supported anymore. To annotate "
+            "negative NER samples, use `doc.spans[key]` instead, and "
+            "specify the key as 'negative_samples_key' when constructing "
+            "the NER component.")
     E870 = ("Could not serialize the DocBin because it is too large. Consider "
             "splitting up your documents into several doc bins and serializing "
             "each separately. spacy.Corpus.v1 will search recursively for all "

--- a/spacy/pipeline/_parser_internals/ner.pyx
+++ b/spacy/pipeline/_parser_internals/ner.pyx
@@ -174,10 +174,9 @@ cdef class BiluoPushDown(TransitionSystem):
             return Transition(clas=0, move=MISSING, label=0, score=0)
         elif '-' in name:
             move_str, label_str = name.split('-', 1)
-            # Hacky way to denote 'not this entity'
+            # Deprecated, hacky way to denote 'not this entity'
             if label_str.startswith('!'):
-                label_str = label_str[1:]
-                move_str = 'x'
+                raise ValueError(Errors.E869.format(label=name))
             label = self.strings.add(label_str)
         else:
             move_str = name

--- a/spacy/pipeline/_parser_internals/ner.pyx
+++ b/spacy/pipeline/_parser_internals/ner.pyx
@@ -423,6 +423,7 @@ cdef class Begin:
             for span in gold.negs[:gold.nr_neg]:
                 if span.label == label and span.start == b0:
                     cost += 1
+                    break
         return cost
 
 

--- a/spacy/pipeline/transition_parser.pyx
+++ b/spacy/pipeline/transition_parser.pyx
@@ -123,6 +123,10 @@ cdef class Parser(TrainablePipe):
         # Available for subclasses, e.g. to deprojectivize
         return []
 
+    @property
+    def negative_samples_key(self):
+        return self.cfg["negative_samples_key"]
+
     def add_label(self, label):
         resized = False
         for action in self.moves.action_types:

--- a/spacy/tests/parser/test_ner.py
+++ b/spacy/tests/parser/test_ner.py
@@ -254,6 +254,27 @@ def test_train_empty():
             nlp.update(batch, losses=losses)
 
 
+def test_train_negative_deprecated():
+    """Test that the deprecated negative entity format raises a custom error."""
+    train_data = [
+        ("Who is Shaka Khan?", {"entities": [(7, 17, "!PERSON")]}),
+    ]
+
+    nlp = English()
+    train_examples = []
+    for t in train_data:
+        train_examples.append(Example.from_dict(nlp.make_doc(t[0]), t[1]))
+    ner = nlp.add_pipe("ner", last=True)
+    ner.add_label("PERSON")
+    nlp.initialize()
+    for itn in range(2):
+        losses = {}
+        batches = util.minibatch(train_examples, size=8)
+        for batch in batches:
+            with pytest.raises(ValueError):
+                nlp.update(batch, losses=losses)
+
+
 def test_overwrite_token():
     nlp = English()
     nlp.add_pipe("ner")


### PR DESCRIPTION

- Add test to unlearn entity
- Add custom warning when using the old deprecated format of `!Label`
- Add test to check custom error
- Add `break` when defining the cost for `Begin` to be similar to `Last` and `Unit`
- Add property on `Parser`. If we keep this configuration with the parser, it would be convenient to query it easily.
