### PR TITLE
Add all symbols in Unicode Currency Symbols block

### DIFF
--- a/spacy/lang/char_classes.py
+++ b/spacy/lang/char_classes.py
@@ -260,7 +260,10 @@ _units = (
     "кг г мг м/с км/ч кПа Па мбар Кб КБ кб Мб МБ мб Гб ГБ гб Тб ТБ тб"
     "كم كم² كم³ م م² م³ سم سم² سم³ مم مم² مم³ كم غرام جرام جم كغ ملغ كوب اكواب"
 )
-_currency = r"\$ £ € ¥ ฿ US\$ C\$ A\$ ₽ ﷼ ₴"
+_currency = (
+    r"\$ £ € ¥ ฿ US\$ C\$ A\$ ₽ ﷼ ₴ ₠ ₡ ₢ ₣ ₤ ₥ ₦ ₧ ₨ ₩ ₪ ₫ € ₭ ₮ ₯ ₰ "
+    r"₱ ₲ ₳ ₴ ₵ ₶ ₷ ₸ ₹ ₺ ₻ ₼ ₽ ₾ ₿"
+)
 
 # These expressions contain various unicode variations, including characters
 # used in Chinese (see #1333, #1340, #1351) – unless there are cross-language

--- a/spacy/tests/training/test_training.py
+++ b/spacy/tests/training/test_training.py
@@ -336,15 +336,15 @@ def test_gold_biluo_additional_whitespace(en_vocab, en_tokenizer):
 
 
 def test_gold_biluo_4791(en_vocab, en_tokenizer):
-    doc = en_tokenizer("I'll return the ₹54 amount")
-    gold_words = ["I", "'ll", "return", "the", "₹", "54", "amount"]
+    doc = en_tokenizer("I'll return the A54 amount")
+    gold_words = ["I", "'ll", "return", "the", "A", "54", "amount"]
     gold_spaces = [False, True, True, True, False, True, False]
     entities = [(16, 19, "MONEY")]
     example = Example.from_dict(
         doc, {"words": gold_words, "spaces": gold_spaces, "entities": entities}
     )
     ner_tags = example.get_aligned_ner()
-    assert ner_tags == ["O", "O", "O", "O", "B-MONEY", "L-MONEY", "O"]
+    assert ner_tags == ["O", "O", "O", "O", "U-MONEY", "O"]
 
     doc = en_tokenizer("I'll return the $54 amount")
     gold_words = ["I", "'ll", "return", "the", "$", "54", "amount"]

--- a/spacy/tests/training/test_training.py
+++ b/spacy/tests/training/test_training.py
@@ -344,7 +344,7 @@ def test_gold_biluo_4791(en_vocab, en_tokenizer):
         doc, {"words": gold_words, "spaces": gold_spaces, "entities": entities}
     )
     ner_tags = example.get_aligned_ner()
-    assert ner_tags == ["O", "O", "O", "O", "U-MONEY", "O"]
+    assert ner_tags == ["O", "O", "O", "O", "B-MONEY", "L-MONEY", "O"]
 
     doc = en_tokenizer("I'll return the $54 amount")
     gold_words = ["I", "'ll", "return", "the", "$", "54", "amount"]


### PR DESCRIPTION
In #8102 it came up that the rupee symbol was treated different from
dollar / euro / yen symbols. This adds many symbols not already
included.

<!--- Provide a general summary of your changes in the title. -->

https://en.wikipedia.org/wiki/Currency_Symbols_(Unicode_block)

There are probably other symbols that could be added.

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Minor enhancement (?)

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
