### PR TITLE
Preserve whitespace in span lemma (fix #8368)

### DIFF
--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -736,7 +736,7 @@ cdef class Span:
     @property
     def lemma_(self):
         """RETURNS (str): The span's lemma."""
-        return " ".join([t.lemma_ for t in self]).strip()
+        return "".join([t.lemma_ + t.whitespace_ for t in self]).strip()
 
     property label_:
         """RETURNS (str): The span's label."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Before this the `lemma` of a Span joined terms using a single space unconditionally, this uses the token whitespace attributes. 

This behavior is probably desirable for noun chunks. Consider "hot-dogs" as three tokens - it makes sense that the lemma would preserve the spacing rather than rendering it as "hot - dog". 

### Types of change

Minor behavior change / bug? fix. 

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
