### PR TITLE
Make JsonlReader path optional

### DIFF
--- a/spacy/training/corpus.py
+++ b/spacy/training/corpus.py
@@ -41,7 +41,7 @@ def create_docbin_reader(
 
 @util.registry.readers("spacy.JsonlCorpus.v1")
 def create_jsonl_reader(
-    path: Path, min_length: int = 0, max_length: int = 0, limit: int = 0
+    path: Optional[Path], min_length: int = 0, max_length: int = 0, limit: int = 0
 ) -> Callable[["Language"], Iterable[Doc]]:
     return JsonlCorpus(path, min_length=min_length, max_length=max_length, limit=limit)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

To avoid config errors during training when `[corpora.pretrain.path]` is `None` with the default `spacy.JsonlCorpus.v1` reader, make the reader path optional, similar to `spacy.Corpus.v1`.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bug fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
