### PR TITLE
adjust whitespace tokenizer to avoid sep in split()

### DIFF
--- a/spacy/tests/test_language.py
+++ b/spacy/tests/test_language.py
@@ -427,13 +427,27 @@ def test_language_whitespace_tokenizer():
             self.vocab = vocab
 
         def __call__(self, text):
-            words = text.split()
-            return Doc(self.vocab, words=words)
+            words = text.split(" ")
+            spaces = [True] * len(words)
+            # Avoid zero-length tokens
+            for i, word in enumerate(words):
+                if word == "":
+                    words[i] = " "
+                    spaces[i] = False
+            # Remove the final trailing space
+            if words[-1] == " ":
+                words = words[0:-1]
+                spaces = spaces[0:-1]
+            else:
+                spaces[-1] = False
+
+            return Doc(self.vocab, words=words, spaces=spaces)
 
     nlp = spacy.blank("en")
     nlp.tokenizer = WhitespaceTokenizer(nlp.vocab)
-    doc = nlp("What's happened to    me? he thought. It wasn't a dream. ")
-    assert doc
+    text = "   What's happened to    me? he thought. It wasn't a dream.    "
+    doc = nlp(text)
+    assert doc.text == text
 
 
 def test_language_custom_tokenizer():

--- a/spacy/tests/test_language.py
+++ b/spacy/tests/test_language.py
@@ -419,6 +419,23 @@ def test_language_from_config_before_after_init_invalid():
             English.from_config(config)
 
 
+def test_language_whitespace_tokenizer():
+    """Test the custom whitespace tokenizer from the docs."""
+
+    class WhitespaceTokenizer:
+        def __init__(self, vocab):
+            self.vocab = vocab
+
+        def __call__(self, text):
+            words = text.split()
+            return Doc(self.vocab, words=words)
+
+    nlp = spacy.blank("en")
+    nlp.tokenizer = WhitespaceTokenizer(nlp.vocab)
+    doc = nlp("What's happened to    me? he thought. It wasn't a dream. ")
+    assert doc
+
+
 def test_language_custom_tokenizer():
     """Test that a fully custom tokenizer can be plugged in via the registry."""
     name = "test_language_custom_tokenizer"

--- a/website/docs/usage/linguistic-features.md
+++ b/website/docs/usage/linguistic-features.md
@@ -1168,7 +1168,7 @@ class WhitespaceTokenizer:
         self.vocab = vocab
 
     def __call__(self, text):
-        words = text.split(" ")
+        words = text.split()
         return Doc(self.vocab, words=words)
 
 nlp = spacy.blank("en")

--- a/website/docs/usage/linguistic-features.md
+++ b/website/docs/usage/linguistic-features.md
@@ -1168,8 +1168,21 @@ class WhitespaceTokenizer:
         self.vocab = vocab
 
     def __call__(self, text):
-        words = text.split()
-        return Doc(self.vocab, words=words)
+        words = text.split(" ")
+        spaces = [True] * len(words)
+        # Avoid zero-length tokens
+        for i, word in enumerate(words):
+            if word == "":
+                words[i] = " "
+                spaces[i] = False
+        # Remove the final trailing space
+        if words[-1] == " ":
+            words = words[0:-1]
+            spaces = spaces[0:-1]
+        else:
+           spaces[-1] = False
+            
+        return Doc(self.vocab, words=words, spaces=spaces)
 
 nlp = spacy.blank("en")
 nlp.tokenizer = WhitespaceTokenizer(nlp.vocab)


### PR DESCRIPTION

## Description
The docs show a custom whitespace tokenizer. Adjusting that example to not use a `sep` in the `text.split` call, as that could easily [lead to empty strings](https://docs.python.org/3.3/library/stdtypes.html?highlight=split#str.split), which are prohibited as tokens by spaCy. Ofcourse this is a silly example, but it could quickly become confusing to users when `E031` gets thrown.

### Types of change
small docs fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
