### PR TITLE
Auto-generate README in spacy package

### DIFF
--- a/spacy/cli/package.py
+++ b/spacy/cli/package.py
@@ -1,7 +1,7 @@
 from typing import Optional, Union, Any, Dict, List, Tuple
 import shutil
 from pathlib import Path
-from wasabi import Printer, get_raw_input
+from wasabi import Printer, MarkdownRenderer, get_raw_input
 import srsly
 import sys
 
@@ -134,6 +134,11 @@ def package(
         file_path = package_path / model_name_v / file_name
         if file_path.exists():
             shutil.copy(str(file_path), str(main_path))
+    readme_path = main_path / "README.md"
+    if not readme_path.exists():
+        readme = generate_readme(meta)
+        create_file(readme_path, readme)
+        create_file(package_path / model_name_v / "README.md", readme)
     imports = []
     for code_path in code_paths:
         imports.append(code_path.stem)
@@ -232,6 +237,105 @@ def generate_meta(existing_meta: Dict[str, Any], msg: Printer) -> Dict[str, Any]
         response = get_raw_input(desc, default)
         meta[setting] = default if response == "" and default else response
     return meta
+
+
+def generate_readme(meta: Dict[str, Any]) -> str:
+    """
+    Generate a Markdown-formatted README text from a model meta.json. Used
+    within the GitHub release notes and as content for README.md file added
+    to model packages.
+    """
+    md = MarkdownRenderer()
+    lang = meta["lang"]
+    name = f"{lang}_{meta['name']}"
+    version = meta["version"]
+    pipeline = ", ".join([md.code(p) for p in meta.get("pipeline", [])])
+    components = ", ".join([md.code(p) for p in meta.get("components", [])])
+    vecs = meta.get("vectors", {})
+    vectors = f"{vecs.get('keys', 0)} keys, {vecs.get('vectors', 0)} unique vectors ({ vecs.get('width', 0)} dimensions)"
+    author = meta.get("author", "n/a")
+    notes = meta.get("notes", "")
+    table_data = [
+        (md.bold("Name"), md.code(name)),
+        (md.bold("Version"), md.code(version)),
+        (md.bold("spaCy"), md.code(meta["spacy_version"])),
+        (md.bold("Default Pipeline"), pipeline),
+        (md.bold("Components"), components),
+        (md.bold("Vectors"), vectors),
+        (md.bold("Sources"), _format_sources(meta.get("sources"))),
+        (md.bold("License"), md.code(meta.get("license", "n/a"))),
+        (md.bold("Author"), md.link(author, meta["url"]) if "url" in meta else author),
+    ]
+    # Put together Markdown body
+    md.add(meta.get("description", ""))
+    md.add(md.table(table_data, ["Feature", "Description"]))
+    md.add(md.title(3, "Label Scheme"))
+    md.add(_format_label_scheme(meta.get("labels")))
+    md.add(md.title(3, "Accuracy"))
+    md.add(_format_accuracy(meta.get("performance")))
+    if notes:
+        md.add(notes)
+    return md.text
+
+
+def _format_sources(data: Any) -> str:
+    if not data or not isinstance(data, list):
+        return "n/a"
+    sources = []
+    for source in data:
+        if not isinstance(source, dict):
+            source = {"name": source}
+        name = source.get("name")
+        if not name:
+            continue
+        url = source.get("url")
+        author = source.get("author")
+        result = name if not url else "[{}]({})".format(name, url)
+        if author:
+            result += " ({})".format(author)
+        sources.append(result)
+    return "<br />".join(sources)
+
+
+def _format_accuracy(data: Dict[str, Any], exclude: List[str] = ["speed"]) -> str:
+    if not data:
+        return ""
+    md = MarkdownRenderer()
+    scalars = [(k, v) for k, v in data.items() if isinstance(v, (int, float))]
+    scores = [
+        (md.code(acc.upper()), f"{score*100:.2f}")
+        for acc, score in scalars
+        if acc not in exclude
+    ]
+    md.add(md.table(scores, ["Type", "Score"]))
+    return md.text
+
+
+def _format_label_scheme(data: Dict[str, Any]) -> str:
+    if not data:
+        return ""
+    md = MarkdownRenderer()
+    n_labels = 0
+    n_pipes = 0
+    label_data = []
+    for pipe, labels in data.items():
+        if not labels:
+            continue
+        col1 = md.bold(md.code(pipe))
+        col2 = ", ".join(
+            [md.code(label.replace("|", "\|")) for label in labels]
+        )  # noqa: W605
+        label_data.append((col1, col2))
+        n_labels += len(labels)
+        n_pipes += 1
+    if not label_data:
+        return ""
+    label_info = f"View label scheme ({n_labels} labels for {n_pipes} components)"
+    md.add("<details>")
+    md.add(f"<summary>{label_info}</summary>")
+    md.add(md.table(label_data, ["Component", "Labels"]))
+    md.add("</details>")
+    return md.text
 
 
 TEMPLATE_SETUP = """

--- a/spacy/cli/package.py
+++ b/spacy/cli/package.py
@@ -253,8 +253,13 @@ def generate_readme(meta: Dict[str, Any]) -> str:
     components = ", ".join([md.code(p) for p in meta.get("components", [])])
     vecs = meta.get("vectors", {})
     vectors = f"{vecs.get('keys', 0)} keys, {vecs.get('vectors', 0)} unique vectors ({ vecs.get('width', 0)} dimensions)"
-    author = meta.get("author", "n/a")
+    author = meta.get("author") or "n/a"
     notes = meta.get("notes", "")
+    license_name = meta.get("license")
+    sources = _format_sources(meta.get("sources"))
+    description = meta.get("description")
+    label_scheme = _format_label_scheme(meta.get("labels"))
+    accuracy = _format_accuracy(meta.get("performance"))
     table_data = [
         (md.bold("Name"), md.code(name)),
         (md.bold("Version"), md.code(version)),
@@ -262,17 +267,20 @@ def generate_readme(meta: Dict[str, Any]) -> str:
         (md.bold("Default Pipeline"), pipeline),
         (md.bold("Components"), components),
         (md.bold("Vectors"), vectors),
-        (md.bold("Sources"), _format_sources(meta.get("sources"))),
-        (md.bold("License"), md.code(meta.get("license", "n/a"))),
+        (md.bold("Sources"), sources or "n/a"),
+        (md.bold("License"), md.code(license_name) if license_name else "n/a"),
         (md.bold("Author"), md.link(author, meta["url"]) if "url" in meta else author),
     ]
     # Put together Markdown body
-    md.add(meta.get("description", ""))
+    if description:
+        md.add(description)
     md.add(md.table(table_data, ["Feature", "Description"]))
-    md.add(md.title(3, "Label Scheme"))
-    md.add(_format_label_scheme(meta.get("labels")))
-    md.add(md.title(3, "Accuracy"))
-    md.add(_format_accuracy(meta.get("performance")))
+    if label_scheme:
+        md.add(md.title(3, "Label Scheme"))
+        md.add(label_scheme)
+    if accuracy:
+        md.add(md.title(3, "Accuracy"))
+        md.add(accuracy)
     if notes:
         md.add(notes)
     return md.text

--- a/website/docs/api/cli.md
+++ b/website/docs/api/cli.md
@@ -933,7 +933,10 @@ copied into the package and imported in the `__init__.py`. If the path to a
 [`meta.json`](/api/data-formats#meta) is supplied, or a `meta.json` is found in
 the input directory, this file is used. Otherwise, the data can be entered
 directly from the command line. spaCy will then create a build artifact that you
-can distribute and install with `pip install`.
+can distribute and install with `pip install`. As of v3.1, the `package` command
+will also create a formatted `README.md` based on the pipeline information
+defined in the `meta.json`. If a `README.md` is already present in the source
+directory, it will be used instead.
 
 <Infobox title="New in v3.0" variant="warning">
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

This PR moves some of our internal `README.md` generation for pipeline packages from our internal modelbuilder scripts into the `spacy package` command. The readme mostly includes the information present in the `meta.json`, but in a nicely-formatted and human-readable way. If a `README.md` is already present in the source directory, it's respected and just copied over.

Notes / drawbacks:

* I had to remove the "size" column, which was based on a value we calculate _after_ building the wheel in the modelbuilder. This means that the GitHub releases wouldn't list the size in the table anymore (but it'd still be on the website, since that uses the `meta.json` directly). I think this is okay, though? The GH release will have the actual files attached, so it lists the file sizes anyways.
* If no existing `README.md` is available, I'm currently copying the generated `README.md` into both the root and model directory. I mostly did this for consistency (because that's the default result if you use an existing file). But I'm not sure we want/need this.
* If a user wants to make changes to the auto-generated readme or add to it, they can edit it in the exported directory and re-run `python setup.py sdist`. I think that's okay? There are two `README.md` files, though, so they can either edit both or just the top-level one. Alternatively, if we don't copy the generated readme into the model director as well (see previous bullet point), we wouldn't have that problem.

<details>
<summary>Example output</summary>
English pipeline optimized for CPU. Components: tok2vec, tagger, parser, senter, ner, attribute_ruler, lemmatizer.

| Feature | Description |
| --- | --- |
| **Name** | `en_core_web_sm` |
| **Version** | `3.0.0` |
| **spaCy** | `>=3.1.0,<3.2.0` |
| **Default Pipeline** | `tok2vec`, `tagger`, `parser`, `ner`, `attribute_ruler`, `lemmatizer` |
| **Components** | `tok2vec`, `tagger`, `parser`, `senter`, `ner`, `attribute_ruler`, `lemmatizer` |
| **Vectors** | 0 keys, 0 unique vectors (0 dimensions) |
| **Sources** | [OntoNotes 5](https://catalog.ldc.upenn.edu/LDC2013T19) |
| **License** | `MIT` |
| **Author** | [Explosion](https://explosion.ai) |

### Label Scheme

<details>

<summary>View label scheme (114 labels for 4 components)</summary>

| Component | Labels |
| --- | --- |
| **`tagger`** | `$`, `''`, `,`, `-LRB-`, `-RRB-`, `.`, `:`, `ADD`, `AFX`, `CC`, `CD`, `DT`, `EX`, `FW`, `HYPH`, `IN`, `JJ`, `JJR`, `JJS`, `LS`, `MD`, `NFP`, `NN`, `NNP`, `NNPS`, `NNS`, `PDT`, `POS`, `PRP`, `PRP$`, `RB`, `RBR`, `RBS`, `RP`, `SYM`, `TO`, `UH`, `VB`, `VBD`, `VBG`, `VBN`, `VBP`, `VBZ`, `WDT`, `WP`, `WP$`, `WRB`, `XX`, ```` |
| **`parser`** | `ROOT`, `acl`, `acomp`, `advcl`, `advmod`, `agent`, `amod`, `appos`, `attr`, `aux`, `auxpass`, `case`, `cc`, `ccomp`, `compound`, `conj`, `csubj`, `csubjpass`, `dative`, `dep`, `det`, `dobj`, `expl`, `intj`, `mark`, `meta`, `neg`, `nmod`, `npadvmod`, `nsubj`, `nsubjpass`, `nummod`, `oprd`, `parataxis`, `pcomp`, `pobj`, `poss`, `preconj`, `predet`, `prep`, `prt`, `punct`, `quantmod`, `relcl`, `xcomp` |
| **`senter`** | `I`, `S` |
| **`ner`** | `CARDINAL`, `DATE`, `EVENT`, `FAC`, `GPE`, `LANGUAGE`, `LAW`, `LOC`, `MONEY`, `NORP`, `ORDINAL`, `ORG`, `PERCENT`, `PERSON`, `PRODUCT`, `QUANTITY`, `TIME`, `WORK_OF_ART` |

</details>

### Accuracy

| Type | Score |
| --- | --- |
| `TOKEN_ACC` | 99.93 |
| `TAG_ACC` | 97.21 |
| `DEP_UAS` | 91.63 |
| `DEP_LAS` | 89.77 |
| `ENTS_P` | 84.83 |
| `ENTS_R` | 83.54 |
| `ENTS_F` | 84.18 |
| `SENTS_P` | 89.79 |
| `SENTS_R` | 87.55 |
| `SENTS_F` | 88.66 |
</details>

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
