### PR TITLE
Fix double slash in model release web page

### DIFF
--- a/website/src/templates/models.js
+++ b/website/src/templates/models.js
@@ -218,7 +218,7 @@ const Model = ({
         }
     }, [initialized, version, baseUrl, name])
 
-    const releaseTag = meta.fullName ? `/tag/${meta.fullName}` : ''
+    const releaseTag = meta.fullName ? `tag/${meta.fullName}` : ''
     const releaseUrl = `https://github.com/${repo}/releases/${releaseTag}`
     const pipeline = linkComponents(meta.pipeline)
     const components = linkComponents(meta.components)


### PR DESCRIPTION
Fixes that the links are like:

https://github.com/explosion/spacy-models/releases//tag/en_core_web_sm-3.0.0

The link still works, but who knows if in the future GitHub would prevent this from working.