### PR TITLE
Fix silent evaluation

### DIFF
--- a/spacy/cli/_util.py
+++ b/spacy/cli/_util.py
@@ -504,12 +504,14 @@ def string_to_list(value: str, intify: bool = False) -> Union[List[str], List[in
     return result
 
 
-def setup_gpu(use_gpu: int) -> None:
+def setup_gpu(use_gpu: int, printer=None) -> None:
     """Configure the GPU and log info."""
+    if printer is None:
+        printer = msg
     if use_gpu >= 0:
-        msg.info(f"Using GPU: {use_gpu}")
+        printer.info(f"Using GPU: {use_gpu}")
         require_gpu(use_gpu)
     else:
-        msg.info("Using CPU")
+        printer.info("Using CPU")
         if has_cupy and gpu_is_available():
-            msg.info("To switch to GPU 0, use the option: --gpu-id 0")
+            printer.info("To switch to GPU 0, use the option: --gpu-id 0")

--- a/spacy/cli/_util.py
+++ b/spacy/cli/_util.py
@@ -2,7 +2,7 @@ from typing import Dict, Any, Union, List, Optional, Tuple, Iterable, TYPE_CHECK
 import sys
 import shutil
 from pathlib import Path
-from wasabi import msg
+from wasabi import msg, Printer
 import srsly
 import hashlib
 import typer
@@ -504,14 +504,14 @@ def string_to_list(value: str, intify: bool = False) -> Union[List[str], List[in
     return result
 
 
-def setup_gpu(use_gpu: int, printer=None) -> None:
+def setup_gpu(use_gpu: int, silent=None) -> None:
     """Configure the GPU and log info."""
-    if printer is None:
-        printer = msg
+    if silent is not None:
+        msg = Printer(no_print=silent, pretty=not silent)
     if use_gpu >= 0:
-        printer.info(f"Using GPU: {use_gpu}")
+        msg.info(f"Using GPU: {use_gpu}")
         require_gpu(use_gpu)
     else:
-        printer.info("Using CPU")
+        msg.info("Using CPU")
         if has_cupy and gpu_is_available():
-            printer.info("To switch to GPU 0, use the option: --gpu-id 0")
+            msg.info("To switch to GPU 0, use the option: --gpu-id 0")

--- a/spacy/cli/evaluate.py
+++ b/spacy/cli/evaluate.py
@@ -64,7 +64,7 @@ def evaluate(
 ) -> Scorer:
     msg = Printer(no_print=silent, pretty=not silent)
     fix_random_seed()
-    setup_gpu(use_gpu)
+    setup_gpu(use_gpu, printer=msg)
     data_path = util.ensure_path(data_path)
     output_path = util.ensure_path(output)
     displacy_path = util.ensure_path(displacy_path)

--- a/spacy/cli/evaluate.py
+++ b/spacy/cli/evaluate.py
@@ -64,7 +64,7 @@ def evaluate(
 ) -> Scorer:
     msg = Printer(no_print=silent, pretty=not silent)
     fix_random_seed()
-    setup_gpu(use_gpu, printer=msg)
+    setup_gpu(use_gpu, silent=silent)
     data_path = util.ensure_path(data_path)
     output_path = util.ensure_path(output)
     displacy_path = util.ensure_path(displacy_path)

--- a/website/docs/usage/processing-pipelines.md
+++ b/website/docs/usage/processing-pipelines.md
@@ -1105,10 +1105,10 @@ While you could use a registered function or a file loader like
 [`srsly.read_json.v1`](/api/top-level#file_readers) as an argument of the
 component factory, this approach is problematic: the component factory runs
 **every time the component is created**. This means it will run when creating
-the `nlp` object before training, but also every a user loads your pipeline. So
-your runtime pipeline would either depend on a local path on your file system,
-or it's loaded twice: once when the component is created, and then again when
-the data is by `from_disk`.
+the `nlp` object before training, but also every time a user loads your
+pipeline. So your runtime pipeline would either depend on a local path on your
+file system, or it's loaded twice: once when the component is created, and then
+again when the data is by `from_disk`.
 
 > ```ini
 > ### config.cfg


### PR DESCRIPTION
## Description
The `evaluate` command calls `setup_gpu` but the latter doesn't respect the `silent` setting because it defines a new `Printer`. Adding an option to pass the `silent` parameter forward.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
