### PR TITLE
TransitionBasedParser.v1 to legacy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Our libraries
-spacy-legacy>=3.0.6,<3.1.0
+spacy-legacy>=3.0.7,<3.1.0
 cymem>=2.0.2,<2.1.0
 preshed>=3.0.2,<3.1.0
 thinc>=8.0.7,<8.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ setup_requires =
     thinc>=8.0.7,<8.1.0
 install_requires =
     # Our libraries
-    spacy-legacy>=3.0.6,<3.1.0
+    spacy-legacy>=3.0.7,<3.1.0
     murmurhash>=0.28.0,<1.1.0
     cymem>=2.0.2,<2.1.0
     preshed>=3.0.2,<3.1.0

--- a/spacy/ml/_precomputable_affine.py
+++ b/spacy/ml/_precomputable_affine.py
@@ -1,6 +1,9 @@
 from thinc.api import Model, normal_init
 
+from ..util import registry
 
+
+@registry.layers("spacy.PrecomputableAffine.v1")
 def PrecomputableAffine(nO, nI, nF, nP, dropout=0.1):
     model = Model(
         "precomputable_affine",

--- a/spacy/ml/models/parser.py
+++ b/spacy/ml/models/parser.py
@@ -10,27 +10,6 @@ from ..tb_framework import TransitionModel
 from ...tokens import Doc
 
 
-@registry.architectures("spacy.TransitionBasedParser.v1")
-def transition_parser_v1(
-    tok2vec: Model[List[Doc], List[Floats2d]],
-    state_type: Literal["parser", "ner"],
-    extra_state_tokens: bool,
-    hidden_width: int,
-    maxout_pieces: int,
-    use_upper: bool = True,
-    nO: Optional[int] = None,
-) -> Model:
-    return build_tb_parser_model(
-        tok2vec,
-        state_type,
-        extra_state_tokens,
-        hidden_width,
-        maxout_pieces,
-        use_upper,
-        nO,
-    )
-
-
 @registry.architectures("spacy.TransitionBasedParser.v2")
 def transition_parser_v2(
     tok2vec: Model[List[Doc], List[Floats2d]],
@@ -52,6 +31,7 @@ def transition_parser_v2(
     )
 
 
+@registry.layers("spacy.build_tb_parser_model.v2")
 def build_tb_parser_model(
     tok2vec: Model[List[Doc], List[Floats2d]],
     state_type: Literal["parser", "ner"],

--- a/spacy/ml/models/parser.py
+++ b/spacy/ml/models/parser.py
@@ -11,27 +11,6 @@ from ...tokens import Doc
 
 
 @registry.architectures("spacy.TransitionBasedParser.v2")
-def transition_parser_v2(
-    tok2vec: Model[List[Doc], List[Floats2d]],
-    state_type: Literal["parser", "ner"],
-    extra_state_tokens: bool,
-    hidden_width: int,
-    maxout_pieces: int,
-    use_upper: bool,
-    nO: Optional[int] = None,
-) -> Model:
-    return build_tb_parser_model(
-        tok2vec,
-        state_type,
-        extra_state_tokens,
-        hidden_width,
-        maxout_pieces,
-        use_upper,
-        nO,
-    )
-
-
-@registry.layers("spacy.build_tb_parser_model.v2")
 def build_tb_parser_model(
     tok2vec: Model[List[Doc], List[Floats2d]],
     state_type: Literal["parser", "ner"],

--- a/spacy/ml/tb_framework.py
+++ b/spacy/ml/tb_framework.py
@@ -1,7 +1,9 @@
 from thinc.api import Model, noop
 from .parser_model import ParserStepModel
+from ..util import registry
 
 
+@registry.layers("spacy.TransitionModel.v1")
 def TransitionModel(
     tok2vec, lower, upper, resize_output, dropout=0.2, unseen_classes=set()
 ):

--- a/website/docs/api/architectures.md
+++ b/website/docs/api/architectures.md
@@ -553,6 +553,13 @@ consists of either two or three subnetworks:
 | `nO`                 | The number of actions the model will predict between. Usually inferred from data at the beginning of training, or loaded from disk. ~~int~~                                                                                                                                                                                                                             |
 | **CREATES**          | The model using the architecture. ~~Model[List[Docs], List[List[Floats2d]]]~~                                                                                                                                                                                                                                                                                           |
 
+<Accordion title="spacy.TransitionBasedParser.v1 definition" spaced>
+
+[TransitionBasedParser.v1](/api/legacy#TransitionBasedParser_v1) had the exact same signature, 
+but the `use_upper` argument was `True` by default.
+
+</Accordion>
+
 ## Tagging architectures {#tagger source="spacy/ml/models/tagger.py"}
 
 ### spacy.Tagger.v1 {#Tagger}

--- a/website/docs/api/legacy.md
+++ b/website/docs/api/legacy.md
@@ -103,6 +103,11 @@ and residual connections.
 | `depth`       | The number of convolutional layers. Recommended value is `4`. ~~int~~                                                                                                                                          |
 | **CREATES**   | The model using the architecture. ~~Model[Floats2d, Floats2d]~~                                                                                                                                                |
 
+### spacy.TransitionBasedParser.v1 {#TransitionBasedParser_v1}
+
+Identical to [`spacy.TransitionBasedParser.v2`](/api/architectures#TransitionBasedParser)
+except the `use_upper` was set to `True` by default.
+
 ### spacy.TextCatEnsemble.v1 {#TextCatEnsemble_v1}
 
 The `spacy.TextCatEnsemble.v1` architecture built an internal `tok2vec` and


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
Move TransitionBasedParser.v1 to `legacy` - https://github.com/explosion/spacy-legacy/pull/11 must be merged & released first. Keeping in Draft until then.

### Types of change
chore

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
