### PR TITLE
Move scores per type handling into util function

### DIFF
--- a/spacy/cli/evaluate.py
+++ b/spacy/cli/evaluate.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Any, Union
 from wasabi import Printer
 from pathlib import Path
 import re
@@ -60,8 +60,8 @@ def evaluate(
     displacy_path: Optional[Path] = None,
     displacy_limit: int = 25,
     silent: bool = True,
-    spans_key="sc",
-) -> Scorer:
+    spans_key: str = "sc",
+) -> Dict[str, Any]:
     msg = Printer(no_print=silent, pretty=not silent)
     fix_random_seed()
     setup_gpu(use_gpu)
@@ -112,7 +112,37 @@ def evaluate(
             data[re.sub(r"[\s/]", "_", key.lower())] = scores[key]
 
     msg.table(results, title="Results")
+    data = handle_scores_per_type(scores, data, spans_key=spans_key, silent=silent)
 
+    if displacy_path:
+        factory_names = [nlp.get_pipe_meta(pipe).factory for pipe in nlp.pipe_names]
+        docs = list(nlp.pipe(ex.reference.text for ex in dev_dataset[:displacy_limit]))
+        render_deps = "parser" in factory_names
+        render_ents = "ner" in factory_names
+        render_parses(
+            docs,
+            displacy_path,
+            model_name=model,
+            limit=displacy_limit,
+            deps=render_deps,
+            ents=render_ents,
+        )
+        msg.good(f"Generated {displacy_limit} parses as HTML", displacy_path)
+
+    if output_path is not None:
+        srsly.write_json(output_path, data)
+        msg.good(f"Saved results to {output_path}")
+    return data
+
+
+def handle_scores_per_type(
+    scores: Union[Scorer, Dict[str, Any]],
+    data: Dict[str, Any] = {},
+    *,
+    spans_key: str = "sc",
+    silent: bool = False,
+) -> Dict[str, Any]:
+    msg = Printer(no_print=silent, pretty=not silent)
     if "morph_per_feat" in scores:
         if scores["morph_per_feat"]:
             print_prf_per_type(msg, scores["morph_per_feat"], "MORPH", "feat")
@@ -139,26 +169,7 @@ def evaluate(
         if scores["cats_auc_per_type"]:
             print_textcats_auc_per_cat(msg, scores["cats_auc_per_type"])
             data["cats_auc_per_type"] = scores["cats_auc_per_type"]
-
-    if displacy_path:
-        factory_names = [nlp.get_pipe_meta(pipe).factory for pipe in nlp.pipe_names]
-        docs = list(nlp.pipe(ex.reference.text for ex in dev_dataset[:displacy_limit]))
-        render_deps = "parser" in factory_names
-        render_ents = "ner" in factory_names
-        render_parses(
-            docs,
-            displacy_path,
-            model_name=model,
-            limit=displacy_limit,
-            deps=render_deps,
-            ents=render_ents,
-        )
-        msg.good(f"Generated {displacy_limit} parses as HTML", displacy_path)
-
-    if output_path is not None:
-        srsly.write_json(output_path, data)
-        msg.good(f"Saved results to {output_path}")
-    return data
+    return scores
 
 
 def render_parses(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

This isn't perfectly elegant, but it'd be very useful to be able to access the logic that outputs the scores per type separately (e.g. for Prodigy). I tried to avoid code duplication, so the helper currently takes an optional existing dict that it updates and returns 🤷‍♀️

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
