### PR TITLE
Fix a command typo in models.md

### DIFF
--- a/website/docs/usage/models.md
+++ b/website/docs/usage/models.md
@@ -399,7 +399,7 @@ the package name or a path to the data directory:
 >
 > ```diff
 > - python -m spacy download en
-> + python -m spacy dowmload en_core_web_sm
+> + python -m spacy download en_core_web_sm
 > ```
 
 ```python


### PR DESCRIPTION
"dowmload" -> "download"

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Just a PR to fix a typo in the documentation on the [models page](https://spacy.io/usage/models). 

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Changes a typo in a suggested command on the models page. Just to be extra sure, I tried out the command. (It doesn't work 😄.)

```sh
$ python -m spacy dowmload en_core_web_sm
Usage: python -m spacy [OPTIONS] COMMAND [ARGS]...
Try 'python -m spacy --help' for help.

Error: No such command 'dowmload'.
```

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ ] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
