### PR TITLE
Small spancat fixes

### DIFF
--- a/spacy/pipeline/spancat.py
+++ b/spacy/pipeline/spancat.py
@@ -182,6 +182,7 @@ class SpanCategorizer(TrainablePipe):
             raise ValueError(Errors.E187)
         if label in self.labels:
             return 0
+        self._allow_extra_label()
         self.cfg["labels"].append(label)
         self.vocab.strings.add(label)
         return 1
@@ -348,7 +349,7 @@ class SpanCategorizer(TrainablePipe):
                 self.add_label(label)
         for eg in get_examples():
             if labels is None:
-                for span in eg.reference.spans[self.key]:
+                for span in eg.reference.spans.get(self.key, []):
                     self.add_label(span.label_)
             if len(subbatch) < 10:
                 subbatch.append(eg)

--- a/spacy/tests/pipeline/test_spancat.py
+++ b/spacy/tests/pipeline/test_spancat.py
@@ -48,7 +48,7 @@ def test_no_resize():
         spancat.add_label("Stuff")
 
 
-def test_implicit_label():
+def test_implicit_labels():
     nlp = Language()
     spancat = nlp.add_pipe("spancat", config={"spans_key": SPAN_KEY})
     assert len(spancat.labels) == 0
@@ -59,7 +59,7 @@ def test_implicit_label():
     assert spancat.labels == ("PERSON", "LOC")
 
 
-def test_explicit_label():
+def test_explicit_labels():
     nlp = Language()
     spancat = nlp.add_pipe("spancat", config={"spans_key": SPAN_KEY})
     assert len(spancat.labels) == 0

--- a/spacy/tests/pipeline/test_spancat.py
+++ b/spacy/tests/pipeline/test_spancat.py
@@ -1,3 +1,4 @@
+import pytest
 from numpy.testing import assert_equal
 from spacy.language import Language
 from spacy.training import Example
@@ -25,6 +26,47 @@ def make_get_examples(nlp):
         return train_examples
 
     return get_examples
+
+
+def test_no_label():
+    nlp = Language()
+    nlp.add_pipe("spancat", config={"spans_key": SPAN_KEY})
+    with pytest.raises(ValueError):
+        nlp.initialize()
+
+
+def test_no_resize():
+    nlp = Language()
+    spancat = nlp.add_pipe("spancat", config={"spans_key": SPAN_KEY})
+    spancat.add_label("Thing")
+    spancat.add_label("Phrase")
+    assert spancat.labels == ("Thing", "Phrase")
+    nlp.initialize()
+    assert spancat.model.get_dim("nO") == 2
+    # this throws an error because the spancat can't be resized after initialization
+    with pytest.raises(ValueError):
+        spancat.add_label("Stuff")
+
+
+def test_implicit_label():
+    nlp = Language()
+    spancat = nlp.add_pipe("spancat", config={"spans_key": SPAN_KEY})
+    assert len(spancat.labels) == 0
+    train_examples = []
+    for t in TRAIN_DATA:
+        train_examples.append(Example.from_dict(nlp.make_doc(t[0]), t[1]))
+    nlp.initialize(get_examples=lambda: train_examples)
+    assert spancat.labels == ("PERSON", "LOC")
+
+
+def test_explicit_label():
+    nlp = Language()
+    spancat = nlp.add_pipe("spancat", config={"spans_key": SPAN_KEY})
+    assert len(spancat.labels) == 0
+    spancat.add_label("PERSON")
+    spancat.add_label("LOC")
+    nlp.initialize()
+    assert spancat.labels == ("PERSON", "LOC")
 
 
 def test_simple_train():


### PR DESCRIPTION

## Description
Two small `spancat` fixes
- The spancat is not resizable (adding a label won't change the output `nO`) so make sure to raise an error when this is attempted
- Allow the `initialize` method to take in examples without actual spans if the labels were added explicitely

Added unit tests for both cases + some additional ones for basic behaviour

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
