### PR TITLE
fix spancat initialize with labels

### DIFF
--- a/spacy/cli/init_pipeline.py
+++ b/spacy/cli/init_pipeline.py
@@ -108,6 +108,10 @@ def init_labels_cli(
         config = util.load_config(config_path, overrides=overrides)
     with show_validation_error(hint_fill=False):
         nlp = init_nlp(config, use_gpu=use_gpu)
+    _init_labels(nlp, output_path)
+
+
+def _init_labels(nlp, output_path):
     for name, component in nlp.pipeline:
         if getattr(component, "label_data", None) is not None:
             output_file = output_path / f"{name}.json"

--- a/spacy/pipeline/spancat.py
+++ b/spacy/pipeline/spancat.py
@@ -329,7 +329,7 @@ class SpanCategorizer(TrainablePipe):
         get_examples: Callable[[], Iterable[Example]],
         *,
         nlp: Language = None,
-        labels: Optional[Dict] = None,
+        labels: Optional[List[str]] = None,
     ) -> None:
         """Initialize the pipe for training, using a representative set
         of data examples.


### PR DESCRIPTION

## Description
`spancat.initialize` had the wrong type definition for its `labels`, causing an error:
```
✘ Error validating initialization settings in [initialize.components]
spancat -> labels   value is not a valid dict
```

This PR fixes that, and adds a unit test for `init labels`.

### Types of change
bug fix

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
