### PR TITLE
Fix check for RIGHT_ATTRS in dep matcher

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -356,9 +356,8 @@ class Errors:
     E098 = ("Invalid pattern: expected both RIGHT_ID and RIGHT_ATTRS.")
     E099 = ("Invalid pattern: the first node of pattern should be an anchor "
             "node. The node should only contain RIGHT_ID and RIGHT_ATTRS.")
-    E100 = ("Nodes other than the anchor node should all contain LEFT_ID, "
-            "REL_OP, RIGHT_ID, and RIGHT_ATTRS, but these are missing: "
-            "{missing}")
+    E100 = ("Nodes other than the anchor node should all contain {required}, "
+            "but these are missing: {missing}")
     E101 = ("RIGHT_ID should be a new node and LEFT_ID should already have "
             "have been declared in previous edges.")
     E102 = ("Can't merge non-disjoint spans. '{token}' is already part of "

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -357,7 +357,8 @@ class Errors:
     E099 = ("Invalid pattern: the first node of pattern should be an anchor "
             "node. The node should only contain RIGHT_ID and RIGHT_ATTRS.")
     E100 = ("Nodes other than the anchor node should all contain LEFT_ID, "
-            "REL_OP and RIGHT_ID.")
+            "REL_OP, RIGHT_ID, and RIGHT_ATTRS, but these are missing: "
+            "{missing}")
     E101 = ("RIGHT_ID should be a new node and LEFT_ID should already have "
             "have been declared in previous edges.")
     E102 = ("Can't merge non-disjoint spans. '{token}' is already part of "

--- a/spacy/matcher/dependencymatcher.pyx
+++ b/spacy/matcher/dependencymatcher.pyx
@@ -130,7 +130,7 @@ cdef class DependencyMatcher:
                 if missing:
                     missing_txt = ", ".join(list(missing))
                     raise ValueError(Errors.E100.format(
-                        key=key,
+                        required=required_keys,
                         missing=missing_txt
                     ))
                 if (

--- a/spacy/matcher/dependencymatcher.pyx
+++ b/spacy/matcher/dependencymatcher.pyx
@@ -122,14 +122,17 @@ cdef class DependencyMatcher:
                     raise ValueError(Errors.E099.format(key=key))
                 visited_nodes[relation["RIGHT_ID"]] = True
             else:
-                if not "RIGHT_ATTRS" in relation:
-                    relation["RIGHT_ATTRS"] = {}
-                if not(
-                    "RIGHT_ID" in relation
-                    and "REL_OP" in relation
-                    and "LEFT_ID" in relation
-                ):
-                    raise ValueError(Errors.E100.format(key=key))
+                required_keys = set(
+                    ("RIGHT_ID", "RIGHT_ATTRS", "REL_OP", "LEFT_ID")
+                )
+                relation_keys = set(relation.keys())
+                missing = required_keys - relation_keys
+                if missing:
+                    missing_txt = ", ".join(list(missing))
+                    raise ValueError(Errors.E100.format(
+                        key=key,
+                        missing=missing_txt
+                    ))
                 if (
                     relation["RIGHT_ID"] in visited_nodes
                     or relation["LEFT_ID"] not in visited_nodes

--- a/spacy/matcher/dependencymatcher.pyx
+++ b/spacy/matcher/dependencymatcher.pyx
@@ -122,9 +122,10 @@ cdef class DependencyMatcher:
                     raise ValueError(Errors.E099.format(key=key))
                 visited_nodes[relation["RIGHT_ID"]] = True
             else:
+                if not "RIGHT_ATTRS" in relation:
+                    relation["RIGHT_ATTRS"] = {}
                 if not(
                     "RIGHT_ID" in relation
-                    and "RIGHT_ATTRS" in relation
                     and "REL_OP" in relation
                     and "LEFT_ID" in relation
                 ):

--- a/spacy/tests/matcher/test_dependency_matcher.py
+++ b/spacy/tests/matcher/test_dependency_matcher.py
@@ -194,10 +194,6 @@ def test_dependency_matcher_pattern_validation(en_vocab):
         matcher.add("FOUNDED", [pattern2])
     with pytest.raises(ValueError):
         pattern2 = copy.deepcopy(pattern)
-        del pattern2[1]["RIGHT_ATTRS"]
-        matcher.add("FOUNDED", [pattern2])
-    with pytest.raises(ValueError):
-        pattern2 = copy.deepcopy(pattern)
         del pattern2[1]["LEFT_ID"]
         matcher.add("FOUNDED", [pattern2])
     with pytest.raises(ValueError):

--- a/spacy/tests/matcher/test_dependency_matcher.py
+++ b/spacy/tests/matcher/test_dependency_matcher.py
@@ -194,6 +194,10 @@ def test_dependency_matcher_pattern_validation(en_vocab):
         matcher.add("FOUNDED", [pattern2])
     with pytest.raises(ValueError):
         pattern2 = copy.deepcopy(pattern)
+        del pattern2[1]["RIGHT_ATTRS"]
+        matcher.add("FOUNDED", [pattern2])
+    with pytest.raises(ValueError):
+        pattern2 = copy.deepcopy(pattern)
         del pattern2[1]["LEFT_ID"]
         matcher.add("FOUNDED", [pattern2])
     with pytest.raises(ValueError):


### PR DESCRIPTION
If a non-anchor node does not have RIGHT_ATTRS, the dep matcher throws
an E100, which says that non-anchor nodes must have LEFT_ID, REL_OP, and
RIGHT_ID. It specifically does not say RIGHT_ATTRS is required.

An empty dict for RIGHT_ATTRS is also valid, and patterns with one will be
accepted. While not normal, sometimes a REL_OP is enough to specify a
non-anchor node - maybe you just want the head of another node
unconditionally, for example.

This change just sets RIGHT_ATTRS to {} if not present. Alternatively
changing E100 to state RIGHT_ATTRS is required could also be reasonable.

Became aware of this issue while looking at https://github.com/explosion/spaCy/discussions/8803. 

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bug fix?

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
