### PR TITLE
Add scores to output in spancat

### DIFF
--- a/spacy/pipeline/spancat.py
+++ b/spacy/pipeline/spancat.py
@@ -405,7 +405,7 @@ class SpanCategorizer(TrainablePipe):
     def _make_span_group(
         self, doc: Doc, indices: Ints2d, scores: Floats2d, labels: List[str]
     ) -> SpanGroup:
-        spans = SpanGroup(doc, name=self.key)
+        spans = SpanGroup(doc, name=self.key, attrs={"scores": []})
         max_positive = self.cfg["max_positive"]
         threshold = self.cfg["threshold"]
         for i in range(indices.shape[0]):
@@ -420,4 +420,5 @@ class SpanCategorizer(TrainablePipe):
                 positives = positives[:max_positive]
             for score, start, end, label in positives:
                 spans.append(Span(doc, start, end, label=label))
+                spans.attrs["scores"].append(score)
         return spans

--- a/spacy/pipeline/spancat.py
+++ b/spacy/pipeline/spancat.py
@@ -413,6 +413,10 @@ class SpanCategorizer(TrainablePipe):
         ranked = (scores * -1).argsort()
         keeps[ranked[:, max_positive:]] = False
         spans.attrs["scores"] = scores[keeps].flatten()
+
+        indices = self.model.ops.to_numpy(indices)
+        keeps = self.model.ops.to_numpy(keeps)
+
         for i in range(indices.shape[0]):
             start = int(indices[i, 0])
             end = int(indices[i, 1])

--- a/spacy/pipeline/spancat.py
+++ b/spacy/pipeline/spancat.py
@@ -418,8 +418,8 @@ class SpanCategorizer(TrainablePipe):
         keeps = self.model.ops.to_numpy(keeps)
 
         for i in range(indices.shape[0]):
-            start = int(indices[i, 0])
-            end = int(indices[i, 1])
+            start = indices[i, 0]
+            end = indices[i, 1]
 
             for j, keep in enumerate(keeps[i]):
                 if keep:

--- a/spacy/tests/pipeline/test_spancat.py
+++ b/spacy/tests/pipeline/test_spancat.py
@@ -83,10 +83,12 @@ def test_simple_train():
     doc = nlp("I like London and Berlin.")
     assert doc.spans[spancat.key] == doc.spans[SPAN_KEY]
     assert len(doc.spans[spancat.key]) == 2
+    assert len(doc.spans[spancat.key].attrs["scores"]) == 2
     assert doc.spans[spancat.key][0].text == "London"
     scores = nlp.evaluate(get_examples())
     assert f"spans_{SPAN_KEY}_f" in scores
     assert scores[f"spans_{SPAN_KEY}_f"] == 1.0
+
 
 
 def test_ngram_suggester(en_tokenizer):

--- a/website/docs/api/spancategorizer.md
+++ b/website/docs/api/spancategorizer.md
@@ -18,16 +18,16 @@ Individual span scores can be found in `spangroup.attrs["scores"]`.
 
 ## Annotation Format {#annotations}
 
-Annotations will be saved to `Doc.spans[SPAN_KEY]` as a
+Annotations will be saved to `Doc.spans[spans_key]` as a
 [`SpanGroup`](/api/spangroup). The scores for the spans in the `SpanGroup`
 will be saved in `SpanGroup.attrs["scores"]`. 
 
-`SPAN_KEY` defaults to `"spans"`, but can be passed as a parameter.
+`spans_key` defaults to `"sc"`, but can be passed as a parameter.
 
 | Location              | Value                      |
 | --------------------- | -------------------------------- |
-| `Doc.spans[SPAN_KEY]`  | The annotated spans. ~~SpanGroup~~ |
-| `Doc.spans[SPAN_KEY].attrs["scores"]` | The score for each span in the `SpanGroup`. ~~Floats1d~~  |
+| `Doc.spans[spans_key]`  | The annotated spans. ~~SpanGroup~~ |
+| `Doc.spans[spans_key].attrs["scores"]` | The score for each span in the `SpanGroup`. ~~Floats1d~~  |
 
 ## Config and implementation {#config}
 

--- a/website/docs/api/spancategorizer.md
+++ b/website/docs/api/spancategorizer.md
@@ -19,15 +19,15 @@ Individual span scores can be found in `spangroup.attrs["scores"]`.
 ## Assigned Attributes {#assigned-attributes}
 
 Predictions will be saved to `Doc.spans[spans_key]` as a
-[`SpanGroup`](/api/spangroup). The scores for the spans in the `SpanGroup`
-will be saved in `SpanGroup.attrs["scores"]`. 
+[`SpanGroup`](/api/spangroup). The scores for the spans in the `SpanGroup` will
+be saved in `SpanGroup.attrs["scores"]`.
 
 `spans_key` defaults to `"sc"`, but can be passed as a parameter.
 
-| Location              | Value                      |
-| --------------------- | -------------------------------- |
-| `Doc.spans[spans_key]`  | The annotated spans. ~~SpanGroup~~ |
-| `Doc.spans[spans_key].attrs["scores"]` | The score for each span in the `SpanGroup`. ~~Floats1d~~  |
+| Location                               | Value                                                    |
+| -------------------------------------- | -------------------------------------------------------- |
+| `Doc.spans[spans_key]`                 | The annotated spans. ~~SpanGroup~~                       |
+| `Doc.spans[spans_key].attrs["scores"]` | The score for each span in the `SpanGroup`. ~~Floats1d~~ |
 
 ## Config and implementation {#config}
 

--- a/website/docs/api/spancategorizer.md
+++ b/website/docs/api/spancategorizer.md
@@ -16,6 +16,19 @@ that predicts zero or more labels for each candidate.
 Predicted spans will be saved in a [`SpanGroup`](/api/spangroup) on the doc.
 Individual span scores can be found in `spangroup.attrs["scores"]`.
 
+## Annotation Format {#annotations}
+
+Annotations will be saved to `Doc.spans[SPAN_KEY]` as a
+[`SpanGroup`](/api/spangroup). The scores for the spans in the `SpanGroup`
+will be saved in `SpanGroup.attrs["scores"]`. 
+
+`SPAN_KEY` defaults to `"spans"`, but can be passed as a parameter.
+
+| Location              | Value                      |
+| --------------------- | -------------------------------- |
+| `Doc.spans[SPAN_KEY]`  | The annotated spans. ~~SpanGroup~~ |
+| `Doc.spans[SPAN_KEY].attrs["scores"]` | The score for each span in the `SpanGroup`. ~~Floats1d~~  |
+
 ## Config and implementation {#config}
 
 The default config is defined by the pipeline component factory and describes

--- a/website/docs/api/spancategorizer.md
+++ b/website/docs/api/spancategorizer.md
@@ -13,6 +13,9 @@ A span categorizer consists of two parts: a [suggester function](#suggesters)
 that proposes candidate spans, which may or may not overlap, and a labeler model
 that predicts zero or more labels for each candidate.
 
+Predicted spans will be saved in a [`SpanGroup`](/api/spangroup) on the doc.
+Individual span scores can be found in `spangroup.attrs["scores"]`.
+
 ## Config and implementation {#config}
 
 The default config is defined by the pipeline component factory and describes

--- a/website/docs/api/spancategorizer.md
+++ b/website/docs/api/spancategorizer.md
@@ -16,9 +16,9 @@ that predicts zero or more labels for each candidate.
 Predicted spans will be saved in a [`SpanGroup`](/api/spangroup) on the doc.
 Individual span scores can be found in `spangroup.attrs["scores"]`.
 
-## Annotation Format {#annotations}
+## Assigned Attributes {#assigned-attributes}
 
-Annotations will be saved to `Doc.spans[spans_key]` as a
+Predictions will be saved to `Doc.spans[spans_key]` as a
 [`SpanGroup`](/api/spangroup). The scores for the spans in the `SpanGroup`
 will be saved in `SpanGroup.attrs["scores"]`. 
 


### PR DESCRIPTION
This exposes the scores as an attribute on the SpanGroup. Includes a
basic test.

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Scores can now be accessed in spancat output for all spans.

```
doc = nlp(...)
spans = doc.spans["spancat"] # SpanGroup
print(spans.attrs["scores"]) # list of numbers, span length as SpanGroup
```

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Minor enhancement.

(Docs update still needed)

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
