### PR TITLE
No output info message in train

### DIFF
--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -43,9 +43,12 @@ def train_cli(
     # Make sure all files and paths exists if they are needed
     if not config_path or (str(config_path) != "-" and not config_path.exists()):
         msg.fail("Config file not found", config_path, exits=1)
-    if output_path is not None and not output_path.exists():
-        output_path.mkdir(parents=True)
-        msg.good(f"Created output directory: {output_path}")
+    if output_path is not None:
+        if not output_path.exists()
+            output_path.mkdir(parents=True)
+            msg.good(f"Created output directory: {output_path}")
+    else:
+        msg.info("No output directory provided")
     overrides = parse_config_overrides(ctx.args)
     import_code(code_path)
     setup_gpu(use_gpu)

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -44,7 +44,7 @@ def train_cli(
     if not config_path or (str(config_path) != "-" and not config_path.exists()):
         msg.fail("Config file not found", config_path, exits=1)
     if output_path is not None:
-        if not output_path.exists()
+        if not output_path.exists():
             output_path.mkdir(parents=True)
             msg.good(f"Created output directory: {output_path}")
     else:

--- a/spacy/cli/train.py
+++ b/spacy/cli/train.py
@@ -43,12 +43,13 @@ def train_cli(
     # Make sure all files and paths exists if they are needed
     if not config_path or (str(config_path) != "-" and not config_path.exists()):
         msg.fail("Config file not found", config_path, exits=1)
-    if output_path is not None:
+    if not output_path:
+        msg.info("No output directory provided")
+    else:
         if not output_path.exists():
             output_path.mkdir(parents=True)
             msg.good(f"Created output directory: {output_path}")
-    else:
-        msg.info("No output directory provided")
+        msg.info(f"Saving to output directory: {output_path}")
     overrides = parse_config_overrides(ctx.args)
     import_code(code_path)
     setup_gpu(use_gpu)


### PR DESCRIPTION
Add info message when no output directory was provided in `spacy train` CLI