### PR TITLE
Add support for fasttext-bloom hash-only vectors

### DIFF
--- a/spacy/cli/init_pipeline.py
+++ b/spacy/cli/init_pipeline.py
@@ -23,6 +23,7 @@ def init_vectors_cli(
     name: Optional[str] = Opt(None, "--name", "-n", help="Optional name for the word vectors, e.g. en_core_web_lg.vectors"),
     verbose: bool = Opt(False, "--verbose", "-V", "-VV", help="Display more information for debugging purposes"),
     jsonl_loc: Optional[Path] = Opt(None, "--lexemes-jsonl", "-j", help="Location of JSONL-formatted attributes file", hidden=True),
+    fasttext_bloom_vectors: bool = Opt(False, "--fasttext-bloom-vectors", "-F", help="Vectors in fastText Bloom hash ngram format"),
     # fmt: on
 ):
     """Convert word vectors for use with spaCy. Will export an nlp object that
@@ -34,7 +35,14 @@ def init_vectors_cli(
     nlp = util.get_lang_class(lang)()
     if jsonl_loc is not None:
         update_lexemes(nlp, jsonl_loc)
-    convert_vectors(nlp, vectors_loc, truncate=truncate, prune=prune, name=name)
+    convert_vectors(
+        nlp,
+        vectors_loc,
+        truncate=truncate,
+        prune=prune,
+        name=name,
+        fasttext_bloom_vectors=fasttext_bloom_vectors,
+    )
     msg.good(f"Successfully converted {len(nlp.vocab.vectors)} vectors")
     nlp.to_disk(output_dir)
     msg.good(

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -24,8 +24,13 @@ def setup_default_warnings():
     for pipe in ["matcher", "entity_ruler"]:
         filter_warning("once", error_msg=Warnings.W036.format(name=pipe))
 
-    # warn once about lemmatizer without required POS
+    # warn once about:
+
+    # lemmatizer without required POS
     filter_warning("once", error_msg="[W108]")
+
+    # ngram vector table cannot be modified
+    filter_warning("once", error_msg="[W114]")
 
 
 def filter_warning(action: str, error_msg: str):
@@ -192,6 +197,8 @@ class Warnings:
             "vectors. This is almost certainly a mistake.")
     W113 = ("Sourced component '{name}' may not work as expected: source "
             "vectors are not identical to current pipeline vectors.")
+    W114 = ("Skipping {method}: the ngram vector table cannot be modified. "
+            "Vectors are calculated from character ngrams.")
 
 
 @add_codes
@@ -518,9 +525,19 @@ class Errors:
     E199 = ("Unable to merge 0-length span at `doc[{start}:{end}]`.")
     E200 = ("Can't yet set {attr} from Span. Vote for this feature on the "
             "issue tracker: http://github.com/explosion/spaCy/issues")
-    E202 = ("Unsupported alignment mode '{mode}'. Supported modes: {modes}.")
+    E202 = ("Unsupported {name} mode '{mode}'. Supported modes: {modes}.")
 
     # New errors added in v3.x
+    E860 = ("Can't truncate fasttext-bloom vectors.")
+    E861 = ("No 'keys' should be provided when initializing ngram vectors "
+            "with 'minn' and 'maxn'.")
+    E862 = ("'hash_count' must be between 1-4 for ngram vectors.")
+    E863 = ("'maxn' must be greater than or equal to 'minn'.")
+    E864 = ("The complete vector table 'data' is required to initialize ngram "
+            "vectors.")
+    E865 = ("The {mode} vector table does not support this operation. "
+            "{alternative}")
+    E866 = ("The ngram vector table cannot be modified.")
     E867 = ("The 'textcat' component requires at least two labels because it "
             "uses mutually exclusive classes where exactly one label is True "
             "for each doc. For binary classification tasks, you can use two "

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -218,6 +218,7 @@ class Language:
             "vectors": len(self.vocab.vectors),
             "keys": self.vocab.vectors.n_keys,
             "name": self.vocab.vectors.name,
+            "mode": self.vocab.vectors.mode,
         }
         self._meta["labels"] = dict(self.pipe_labels)
         # TODO: Adding this back to prevent breaking people's code etc., but

--- a/spacy/tests/serialize/test_serialize_vocab_strings.py
+++ b/spacy/tests/serialize/test_serialize_vocab_strings.py
@@ -1,7 +1,9 @@
 import pytest
 import pickle
+from thinc.api import get_current_ops
 from spacy.vocab import Vocab
 from spacy.strings import StringStore
+from spacy.vectors import Vectors
 
 from ..util import make_tempdir
 
@@ -129,7 +131,11 @@ def test_serialize_stringstore_roundtrip_disk(strings1, strings2):
 @pytest.mark.parametrize("strings,lex_attr", test_strings_attrs)
 def test_pickle_vocab(strings, lex_attr):
     vocab = Vocab(strings=strings)
+    ops = get_current_ops()
+    vectors = Vectors(data=ops.xp.zeros((10, 10)), mode="ngram", hash_count=1)
+    vocab.vectors = vectors
     vocab[strings[0]].norm_ = lex_attr
     vocab_pickled = pickle.dumps(vocab)
     vocab_unpickled = pickle.loads(vocab_pickled)
     assert vocab.to_bytes() == vocab_unpickled.to_bytes()
+    assert vocab_unpickled.vectors.mode == "ngram"

--- a/spacy/tests/vocab_vectors/test_vectors.py
+++ b/spacy/tests/vocab_vectors/test_vectors.py
@@ -1,12 +1,14 @@
 import pytest
 import numpy
-from numpy.testing import assert_allclose, assert_equal
+from numpy.testing import assert_allclose, assert_equal, assert_almost_equal
 from thinc.api import get_current_ops
+from spacy.lang.en import English
 from spacy.vocab import Vocab
 from spacy.vectors import Vectors
 from spacy.tokenizer import Tokenizer
 from spacy.strings import hash_string
 from spacy.tokens import Doc
+from spacy.training.initialize import convert_vectors
 
 from ..util import add_vecs_to_vocab, get_cosine, make_tempdir
 
@@ -27,22 +29,6 @@ def vectors():
         ("juice", OPS.asarray([5, 5, 10])),
         ("pie", OPS.asarray([7, 6.3, 8.9])),
     ]
-
-
-@pytest.fixture
-def ngrams_vectors():
-    return [
-        ("apple", OPS.asarray([1, 2, 3])),
-        ("app", OPS.asarray([-0.1, -0.2, -0.3])),
-        ("ppl", OPS.asarray([-0.2, -0.3, -0.4])),
-        ("pl", OPS.asarray([0.7, 0.8, 0.9])),
-    ]
-
-
-@pytest.fixture()
-def ngrams_vocab(en_vocab, ngrams_vectors):
-    add_vecs_to_vocab(en_vocab, ngrams_vectors)
-    return en_vocab
 
 
 @pytest.fixture
@@ -125,6 +111,7 @@ def test_init_vectors_with_data(strings, data):
 def test_init_vectors_with_shape(strings):
     v = Vectors(shape=(len(strings), 3))
     assert v.shape == (len(strings), 3)
+    assert v.is_full is False
 
 
 def test_get_vector(strings, data):
@@ -178,30 +165,6 @@ def test_vectors_token_vector(tokenizer_v, vectors, text):
     assert all([a == b for a, b in zip(vectors[0][1], doc[0].vector)])
     assert vectors[1][0] == doc[2].text
     assert all([a == b for a, b in zip(vectors[1][1], doc[2].vector)])
-
-
-@pytest.mark.parametrize("text", ["apple"])
-def test_vectors__ngrams_word(ngrams_vocab, ngrams_vectors, text):
-    assert list(ngrams_vocab.get_vector(text)) == list(ngrams_vectors[0][1])
-
-
-@pytest.mark.parametrize("text", ["applpie"])
-def test_vectors__ngrams_subword(ngrams_vocab, ngrams_vectors, text):
-    truth = list(ngrams_vocab.get_vector(text, 1, 6))
-    test = list(
-        [
-            (
-                ngrams_vectors[1][1][i]
-                + ngrams_vectors[2][1][i]
-                + ngrams_vectors[3][1][i]
-            )
-            / 3
-            for i in range(len(ngrams_vectors[1][1]))
-        ]
-    )
-    eps = [abs(truth[i] - test[i]) for i in range(len(truth))]
-    for i in eps:
-        assert i < 1e-6
 
 
 @pytest.mark.parametrize("text", ["apple", "orange"])
@@ -379,3 +342,156 @@ def test_vector_is_oov():
     assert vocab["cat"].is_oov is False
     assert vocab["dog"].is_oov is False
     assert vocab["hamster"].is_oov is True
+
+
+def test_init_vectors_unset():
+    v = Vectors(shape=(10, 10))
+    assert v.is_full is False
+    assert v.data.shape == (10, 10)
+
+    with pytest.raises(ValueError):
+        v = Vectors(shape=(10, 10), mode="ngram")
+
+    v = Vectors(data=OPS.xp.zeros((10, 10)), mode="ngram", hash_count=1)
+    assert v.is_full is True
+
+
+def test_vectors_clear():
+    data = OPS.asarray([[4, 2, 2, 2], [4, 2, 2, 2], [1, 1, 1, 1]], dtype="f")
+    v = Vectors(data=data, keys=["A", "B", "C"])
+    assert v.is_full is True
+    assert hash_string("A") in v
+    v.clear()
+    # no keys
+    assert v.key2row == {}
+    assert list(v) == []
+    assert v.is_full is False
+    assert "A" not in v
+    with pytest.raises(KeyError):
+        v["A"]
+
+
+@pytest.fixture()
+def ngram_vectors_hashvec_str():
+    """The full hashvec table from fasttext-bloom with the settings:
+    bucket 10, dim 10, minn 2, maxn 3, hash count 2, hash seed 2166136261,
+    bow <, eow >"""
+    return """10 10 2 3 2 2166136261 < >
+0 -2.2611 3.9302 2.6676 -11.233 0.093715 -10.52 -9.6463 -0.11853 2.101 -0.10145
+1 -3.12 -1.7981 10.7 -6.171 4.4527 10.967 9.073 6.2056 -6.1199 -2.0402
+2 9.5689 5.6721 -8.4832 -1.2249 2.1871 -3.0264 -2.391 -5.3308 -3.2847 -4.0382
+3 3.6268 4.2759 -1.7007 1.5002 5.5266 1.8716 -12.063 0.26314 2.7645 2.4929
+4 -11.683 -7.7068 2.1102 2.214 7.2202 0.69799 3.2173 -5.382 -2.0838 5.0314
+5 -4.3024 8.0241 2.0714 -1.0174 -0.28369 1.7622 7.8797 -1.7795 6.7541 5.6703
+6 8.3574 -5.225 8.6529 8.5605 -8.9465 3.767 -5.4636 -1.4635 -0.98947 -0.58025
+7 -10.01 3.3894 -4.4487 1.1669 -11.904 6.5158 4.3681 0.79913 -6.9131 -8.687
+8 -5.4576 7.1019 -8.8259 1.7189 4.955 -8.9157 -3.8905 -0.60086 -2.1233 5.892
+9 8.0678 -4.4142 3.6236 4.5889 -2.7611 2.4455 0.67096 -4.2822 2.0875 4.6274
+"""
+
+
+@pytest.fixture()
+def ngram_vectors_vec_str():
+    """The top 10 rows from fasttext-bloom with the settings above, to verify
+    that the spacy ngrams vectors are equivalent to the fasttext static
+    vectors."""
+    return """10 10
+, -5.7814 2.6918 0.57029 -3.6985 -2.7079 1.4406 1.0084 1.7463 -3.8625 -3.0565
+. 3.8016 -1.759 0.59118 3.3044 -0.72975 0.45221 -2.1412 -3.8933 -2.1238 -0.47409
+der 0.08224 2.6601 -1.173 1.1549 -0.42821 -0.097268 -2.5589 -1.609 -0.16968 0.84687
+die -2.8781 0.082576 1.9286 -0.33279 0.79488 3.36 3.5609 -0.64328 -2.4152 0.17266
+und 2.1558 1.8606 -1.382 0.45424 -0.65889 1.2706 0.5929 -2.0592 -2.6949 -1.6015
+" -1.1242 1.4588 -1.6263 1.0382 -2.7609 -0.99794 -0.83478 -1.5711 -1.2137 1.0239
+in -0.87635 2.0958 4.0018 -2.2473 -1.2429 2.3474 1.8846 0.46521 -0.506 -0.26653
+von -0.10589 1.196 1.1143 -0.40907 -1.0848 -0.054756 -2.5016 -1.0381 -0.41598 0.36982
+( 0.59263 2.1856 0.67346 1.0769 1.0701 1.2151 1.718 -3.0441 2.7291 3.719
+) 0.13812 3.3267 1.657 0.34729 -3.5459 0.72372 0.63034 -1.6145 1.2733 0.37798
+"""
+
+
+def test_ngram_vectors(ngram_vectors_vec_str, ngram_vectors_hashvec_str):
+    nlp = English()
+    nlp_plain = English()
+    # load both vec and hashvec tables
+    with make_tempdir() as tmpdir:
+        p = tmpdir / "test.hashvec"
+        with open(p, "w") as fileh:
+            fileh.write(ngram_vectors_hashvec_str)
+        convert_vectors(nlp, p, truncate=0, prune=-1, fasttext_bloom_vectors=True)
+        p = tmpdir / "test.vec"
+        with open(p, "w") as fileh:
+            fileh.write(ngram_vectors_vec_str)
+        convert_vectors(nlp_plain, p, truncate=0, prune=-1)
+
+    word = "der"
+    # ngrams: full padded word + padded 2-grams + padded 3-grams
+    ngrams = nlp.vocab.vectors._get_ngrams(word)
+    assert ngrams == ["<der>", "<d", "de", "er", "r>", "<de", "der", "er>"]
+    # rows: 2 rows per ngram
+    rows = OPS.xp.asarray(
+        [
+            h % nlp.vocab.vectors.data.shape[0]
+            for ngram in ngrams
+            for h in nlp.vocab.vectors._get_ngram_hashes(ngram)
+        ],
+        dtype="uint32",
+    )
+    assert_equal(
+        OPS.to_numpy(rows),
+        numpy.asarray([5, 6, 7, 5, 8, 2, 8, 9, 3, 3, 4, 6, 7, 3, 0, 2]),
+    )
+    assert len(rows) == len(ngrams) * nlp.vocab.vectors.hash_count
+    # all vectors are equivalent for plain static table vs. hash ngrams
+    for word in nlp_plain.vocab.vectors:
+        word = nlp_plain.vocab.strings.as_string(word)
+        assert_almost_equal(
+            nlp.vocab[word].vector, nlp_plain.vocab[word].vector, decimal=3
+        )
+
+        # every word has a vector
+        assert nlp.vocab[word * 5].has_vector
+
+    # the loaded ngram vector table cannot be modified
+    # except for clear: warning, then return without modifications
+    vector = list(range(nlp.vocab.vectors.shape[1]))
+    orig_bytes = nlp.vocab.vectors.to_bytes(exclude=["strings"])
+    with pytest.warns(UserWarning):
+        nlp.vocab.set_vector("the", vector)
+    assert orig_bytes == nlp.vocab.vectors.to_bytes(exclude=["strings"])
+    with pytest.warns(UserWarning):
+        nlp.vocab[word].vector = vector
+    assert orig_bytes == nlp.vocab.vectors.to_bytes(exclude=["strings"])
+    with pytest.warns(UserWarning):
+        nlp.vocab.vectors.add("the", row=6)
+    assert orig_bytes == nlp.vocab.vectors.to_bytes(exclude=["strings"])
+    with pytest.warns(UserWarning):
+        nlp.vocab.vectors.resize(shape=(100, 10))
+    assert orig_bytes == nlp.vocab.vectors.to_bytes(exclude=["strings"])
+    with pytest.raises(ValueError):
+        nlp.vocab.vectors.clear()
+
+    # data and settings are serialized correctly
+    with make_tempdir() as d:
+        nlp.vocab.to_disk(d)
+        vocab_r = Vocab()
+        vocab_r.from_disk(d)
+        assert nlp.vocab.vectors.to_bytes() == vocab_r.vectors.to_bytes()
+        assert_equal(
+            OPS.to_numpy(nlp.vocab.vectors.data), OPS.to_numpy(vocab_r.vectors.data)
+        )
+        assert_equal(nlp.vocab.vectors._get_cfg(), vocab_r.vectors._get_cfg())
+        assert_almost_equal(
+            OPS.to_numpy(nlp.vocab[word].vector),
+            OPS.to_numpy(vocab_r[word].vector),
+            decimal=6,
+        )
+
+    # default cache size is the same as hash ngram table size
+    assert nlp.vocab.vectors.ngram_cache_size == nlp.vocab.vectors.data.shape[0]
+    # modify cache size
+    nlp.vocab.vectors.ngram_cache_size = 5
+    assert nlp.vocab.vectors.ngram_cache_size == 5
+    assert nlp.vocab.vectors._ngram_cache.data.shape == (
+        5,
+        nlp.vocab.vectors.data.shape[1],
+    )

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -529,7 +529,13 @@ cdef class Doc:
             kb_id = self.vocab.strings.add(kb_id)
         alignment_modes = ("strict", "contract", "expand")
         if alignment_mode not in alignment_modes:
-            raise ValueError(Errors.E202.format(mode=alignment_mode, modes=", ".join(alignment_modes)))
+            raise ValueError(
+                Errors.E202.format(
+                    name="alignment",
+                    mode=alignment_mode,
+                    modes=", ".join(alignment_modes),
+                )
+            )
         cdef int start = token_by_char(self.c, self.length, start_idx)
         if start < 0 or (alignment_mode == "strict" and start_idx != self[start].idx):
             return None

--- a/spacy/training/initialize.py
+++ b/spacy/training/initialize.py
@@ -13,7 +13,7 @@ import warnings
 
 from .pretrain import get_tok2vec_ref
 from ..lookups import Lookups
-from ..vectors import Vectors
+from ..vectors import Vectors, Mode as VectorsMode
 from ..errors import Errors, Warnings
 from ..schemas import ConfigSchemaTraining
 from ..util import registry, load_model_from_config, resolve_dot_names, logger
@@ -154,7 +154,13 @@ def load_vectors_into_model(
         err = ConfigValidationError.from_error(e, title=title, desc=desc)
         raise err from None
 
-    if len(vectors_nlp.vocab.vectors.keys()) == 0:
+    if (
+        len(vectors_nlp.vocab.vectors.keys()) == 0
+        and not vectors_nlp.vocab.vectors.mode == VectorsMode.ngram
+    ) or (
+        vectors_nlp.vocab.vectors.data.shape[0] == 0
+        and vectors_nlp.vocab.vectors.mode == VectorsMode.ngram
+    ):
         logger.warning(Warnings.W112.format(name=name))
 
     nlp.vocab.vectors = vectors_nlp.vocab.vectors
@@ -198,41 +204,78 @@ def convert_vectors(
     truncate: int,
     prune: int,
     name: Optional[str] = None,
+    fasttext_bloom_vectors: bool = False,
 ) -> None:
     vectors_loc = ensure_path(vectors_loc)
     if vectors_loc and vectors_loc.parts[-1].endswith(".npz"):
-        nlp.vocab.vectors = Vectors(data=numpy.load(vectors_loc.open("rb")))
+        nlp.vocab.vectors = Vectors(
+            strings=nlp.vocab.strings, data=numpy.load(vectors_loc.open("rb"))
+        )
         for lex in nlp.vocab:
             if lex.rank and lex.rank != OOV_RANK:
                 nlp.vocab.vectors.add(lex.orth, row=lex.rank)
     else:
         if vectors_loc:
             logger.info(f"Reading vectors from {vectors_loc}")
-            vectors_data, vector_keys = read_vectors(vectors_loc, truncate)
+            vectors_data, vector_keys, fasttext_bloom_settings = read_vectors(
+                vectors_loc, truncate, fasttext_bloom_vectors=fasttext_bloom_vectors
+            )
             logger.info(f"Loaded vectors from {vectors_loc}")
         else:
             vectors_data, vector_keys = (None, None)
-        if vector_keys is not None:
+        if vector_keys is not None and not fasttext_bloom_vectors:
             for word in vector_keys:
                 if word not in nlp.vocab:
                     nlp.vocab[word]
         if vectors_data is not None:
-            nlp.vocab.vectors = Vectors(data=vectors_data, keys=vector_keys)
+            if not fasttext_bloom_vectors:
+                nlp.vocab.vectors = Vectors(
+                    strings=nlp.vocab.strings, data=vectors_data, keys=vector_keys
+                )
+            else:
+                nlp.vocab.vectors = Vectors(
+                    strings=nlp.vocab.strings,
+                    data=vectors_data,
+                    **fasttext_bloom_settings,
+                )
     if name is None:
         # TODO: Is this correct? Does this matter?
         nlp.vocab.vectors.name = f"{nlp.meta['lang']}_{nlp.meta['name']}.vectors"
     else:
         nlp.vocab.vectors.name = name
     nlp.meta["vectors"]["name"] = nlp.vocab.vectors.name
-    if prune >= 1:
+    if prune >= 1 and not fasttext_bloom_vectors:
         nlp.vocab.prune_vectors(prune)
 
 
-def read_vectors(vectors_loc: Path, truncate_vectors: int):
+def read_vectors(
+    vectors_loc: Path, truncate_vectors: int, *, fasttext_bloom_vectors: bool = False
+):
     f = ensure_shape(vectors_loc)
-    shape = tuple(int(size) for size in next(f).split())
-    if truncate_vectors >= 1:
-        shape = (truncate_vectors, shape[1])
+    header_parts = next(f).split()
+    shape = tuple(int(size) for size in header_parts[:2])
+    fasttext_bloom_settings = {}
+    if fasttext_bloom_vectors:
+        if len(header_parts) != 8:
+            raise ValueError(
+                "Invalid header for fasttext ngram vectors. "
+                "Expected: bucket dim minn maxn hash_count hash_seed BOW EOW"
+            )
+        fasttext_bloom_settings = {
+            "mode": "ngram",
+            "minn": int(header_parts[2]),
+            "maxn": int(header_parts[3]),
+            "hash_count": int(header_parts[4]),
+            "hash_seed": int(header_parts[5]),
+            "bow": header_parts[6],
+            "eow": header_parts[7],
+        }
+        if truncate_vectors >= 1:
+            raise ValueError(Errors.E860)
+    else:
+        assert len(header_parts) == 2
+        if truncate_vectors >= 1:
+            shape = (truncate_vectors, shape[1])
     vectors_data = numpy.zeros(shape=shape, dtype="f")
     vectors_keys = []
     for i, line in enumerate(tqdm.tqdm(f)):
@@ -245,7 +288,7 @@ def read_vectors(vectors_loc: Path, truncate_vectors: int):
         vectors_keys.append(word)
         if i == truncate_vectors - 1:
             break
-    return vectors_data, vectors_keys
+    return vectors_data, vectors_keys, fasttext_bloom_settings
 
 
 def open_file(loc: Union[str, Path]) -> IO:
@@ -272,7 +315,8 @@ def ensure_shape(vectors_loc):
     lines = open_file(vectors_loc)
     first_line = next(lines)
     try:
-        shape = tuple(int(size) for size in first_line.split())
+        parts = first_line.split()
+        shape = tuple(int(size) for size in first_line.split()[:2])
     except ValueError:
         shape = None
     if shape is not None:

--- a/spacy/vectors.pyx
+++ b/spacy/vectors.pyx
@@ -1,16 +1,20 @@
 cimport numpy as np
+from libc.stdint cimport uint32_t
 from cython.operator cimport dereference as deref
 from libcpp.set cimport set as cppset
+from murmurhash.mrmr cimport hash128_x64
 
 import functools
 import numpy
+import warnings
+from enum import Enum
 import srsly
 from thinc.api import get_array_module, get_current_ops
 
 from .strings cimport StringStore
 
 from .strings import get_string_id
-from .errors import Errors
+from .errors import Errors, Warnings
 from . import util
 
 
@@ -18,18 +22,13 @@ def unpickle_vectors(bytes_data):
     return Vectors().from_bytes(bytes_data)
 
 
-class GlobalRegistry:
-    """Global store of vectors, to avoid repeatedly loading the data."""
-    data = {}
+class Mode(str, Enum):
+    default = "default"
+    ngram = "ngram"
 
     @classmethod
-    def register(cls, name, data):
-        cls.data[name] = data
-        return functools.partial(cls.get, name)
-
-    @classmethod
-    def get(cls, name):
-        return cls.data[name]
+    def values(cls):
+        return list(cls.__members__.keys())
 
 
 cdef class Vectors:
@@ -37,45 +36,118 @@ cdef class Vectors:
 
     Vectors data is kept in the vectors.data attribute, which should be an
     instance of numpy.ndarray (for CPU vectors) or cupy.ndarray
-    (for GPU vectors). `vectors.key2row` is a dictionary mapping word hashes to
-    rows in the vectors.data table.
+    (for GPU vectors).
 
-    Multiple keys can be mapped to the same vector, and not all of the rows in
-    the table need to be assigned - so len(list(vectors.keys())) may be
-    greater or smaller than vectors.shape[0].
+    In the default mode, `vectors.key2row` is a dictionary mapping word hashes
+    to rows in the vectors.data table. Multiple keys can be mapped to the same
+    vector, and not all of the rows in the table need to be assigned - so
+    len(list(vectors.keys())) may be greater or smaller than vectors.shape[0].
+
+    In ngram mode, the fasttext-bloom ngram settings (minn, maxn, etc.) are
+    used to calculate the vector from the rows corresponding to the key's
+    ngrams.
 
     DOCS: https://spacy.io/api/vectors
     """
+    cdef public object strings
     cdef public object name
+    cdef readonly object mode
     cdef public object data
     cdef public object key2row
     cdef cppset[int] _unset
+    cdef readonly uint32_t minn
+    cdef readonly uint32_t maxn
+    cdef readonly uint32_t hash_count
+    cdef readonly uint32_t hash_seed
+    cdef readonly unicode bow
+    cdef readonly unicode eow
+    cdef readonly object _ngram_cache
 
-    def __init__(self, *, shape=None, data=None, keys=None, name=None):
+    def __init__(self, *, strings=None, shape=None, data=None, keys=None, name=None, mode=Mode.default, minn=0, maxn=0, hash_count=0, hash_seed=0, bow="<", eow=">", ngram_cache_size=None):
         """Create a new vector store.
 
+        strings (StringStore): The string store.
         shape (tuple): Size of the table, as (# entries, # columns)
         data (numpy.ndarray or cupy.ndarray): The vector data.
         keys (iterable): A sequence of keys, aligned with the data.
         name (str): A name to identify the vectors table.
+        mode (str): Vectors mode: "default" or "ngram" (default: "default").
+        minn (int): The fasttext-bloom ngram minn (default: 0).
+        maxn (int): The fasttext-bloom ngram maxn (default: 0).
+        hash_count (int): The fasttext-bloom ngram hash count (1-4, default: 0).
+        hash_seed (int): The fasttext-bloom ngram hash seed (default: 0).
+        bow (str): The fasttext-bloom bow string (default: "<").
+        eow (str): The fasttext-bloom eow string (default: ">").
+        ngram_cache_size (int): The fasttext-bloom vector cache size
+            (default: data.shape[0]).
 
         DOCS: https://spacy.io/api/vectors#init
         """
+        self.strings = strings
+        if self.strings is None:
+            self.strings = StringStore()
         self.name = name
-        if data is None:
-            if shape is None:
-                shape = (0,0)
-            ops = get_current_ops()
-            data = ops.xp.zeros(shape, dtype="f")
-        self.data = data
+        if mode not in Mode.values():
+            raise ValueError(
+                Errors.E202.format(
+                    name="vectors",
+                    mode=mode,
+                    modes=str(Mode.values())
+                )
+            )
+        self.mode = Mode(mode).value
         self.key2row = {}
-        if self.data is not None:
-            self._unset = cppset[int]({i for i in range(self.data.shape[0])})
-        else:
+        self.minn = minn
+        self.maxn = maxn
+        self.hash_count = hash_count
+        self.hash_seed = hash_seed
+        self.bow = bow
+        self.eow = eow
+        if self.mode == Mode.default:
+            if data is None:
+                if shape is None:
+                    shape = (0,0)
+                ops = get_current_ops()
+                data = ops.xp.zeros(shape, dtype="f")
+                self._unset = cppset[int]({i for i in range(data.shape[0])})
+            else:
+                self._unset = cppset[int]()
+            self.data = data
+            if keys is not None:
+                for i, key in enumerate(keys):
+                    self.add(key, row=i)
+        elif self.mode == Mode.ngram:
+            if maxn < minn:
+                raise ValueError(Errors.E863)
+            if hash_count < 1 or hash_count >= 5:
+                raise ValueError(Errors.E862)
+            if data is None:
+                raise ValueError(Errors.E864)
+            if keys is not None:
+                raise ValueError(Errors.E861)
+            self.data = data
+            if ngram_cache_size is None:
+                ngram_cache_size = data.shape[0]
+            self.ngram_cache_size = ngram_cache_size
             self._unset = cppset[int]()
-        if keys is not None:
-            for i, key in enumerate(keys):
-                self.add(key, row=i)
+
+    property ngram_cache_size:
+        def __get__(self):
+            if self.mode == Mode.ngram:
+                if not self._ngram_cache:
+                    return 0
+                else:
+                    return self._ngram_cache.data.shape[0]
+            else:
+                return -1
+
+        def __set__(self, size):
+            if self.mode == Mode.ngram:
+                shape = (size, self.data.shape[1])
+                if not self._ngram_cache:
+                    self._ngram_cache = Vectors(strings=self.strings, shape=shape)
+                else:
+                    self._ngram_cache.resize(shape)
 
     @property
     def shape(self):
@@ -106,6 +178,8 @@ cdef class Vectors:
 
         DOCS: https://spacy.io/api/vectors#is_full
         """
+        if self.mode == Mode.ngram:
+            return True
         return self._unset.size() == 0
 
     @property
@@ -113,7 +187,8 @@ cdef class Vectors:
         """Get the number of keys in the table. Note that this is the number
         of all keys, not just unique vectors.
 
-        RETURNS (int): The number of keys in the table.
+        RETURNS (int): The number of keys in the table for default vectors.
+        For ngram vectors, return -1.
 
         DOCS: https://spacy.io/api/vectors#n_keys
         """
@@ -125,25 +200,33 @@ cdef class Vectors:
     def __getitem__(self, key):
         """Get a vector by key. If the key is not found, a KeyError is raised.
 
-        key (int): The key to get the vector for.
+        key (str/int): The key to get the vector for.
         RETURNS (ndarray): The vector for the key.
 
         DOCS: https://spacy.io/api/vectors#getitem
         """
-        i = self.key2row[key]
-        if i is None:
-            raise KeyError(Errors.E058.format(key=key))
-        else:
-            return self.data[i]
+        if self.mode == Mode.default:
+            i = self.key2row.get(get_string_id(key), None)
+            if i is None:
+                raise KeyError(Errors.E058.format(key=key))
+            else:
+                return self.data[i]
+        elif self.mode == Mode.ngram:
+            return self._get_ngram_vector(self.strings.as_string(key))
+        raise KeyError(Errors.E058.format(key=key))
 
     def __setitem__(self, key, vector):
         """Set a vector for the given key.
 
-        key (int): The key to set the vector for.
+        key (str/int): The key to set the vector for.
         vector (ndarray): The vector to set.
 
         DOCS: https://spacy.io/api/vectors#setitem
         """
+        if self.mode == Mode.ngram:
+            warnings.warn(Warnings.W114.format(method="Vectors.__setitem__"))
+            return
+        key = get_string_id(key)
         i = self.key2row[key]
         self.data[i] = vector
         if self._unset.count(i):
@@ -175,7 +258,10 @@ cdef class Vectors:
 
         DOCS: https://spacy.io/api/vectors#contains
         """
-        return key in self.key2row
+        if self.mode == Mode.ngram:
+            return True
+        else:
+            return key in self.key2row
 
     def resize(self, shape, inplace=False):
         """Resize the underlying vectors array. If inplace=True, the memory
@@ -192,6 +278,9 @@ cdef class Vectors:
 
         DOCS: https://spacy.io/api/vectors#resize
         """
+        if self.mode == Mode.ngram:
+            warnings.warn(Warnings.W114.format(method="Vectors.resize"))
+            return -1
         xp = get_array_module(self.data)
         if inplace:
             if shape[1] != self.data.shape[1]:
@@ -254,6 +343,13 @@ cdef class Vectors:
             Returns ndarray.
         RETURNS: The requested key, keys, row or rows.
         """
+        if self.mode == Mode.ngram:
+            raise ValueError(
+                Errors.E865.format(
+                    mode=self.mode,
+                    alternative="Use Vectors[key] instead.",
+                )
+            )
         if sum(arg is None for arg in (key, keys, row, rows)) != 3:
             bad_kwargs = {"key": key, "keys": keys, "row": row, "rows": rows}
             raise ValueError(Errors.E059.format(kwargs=bad_kwargs))
@@ -273,6 +369,66 @@ cdef class Vectors:
                 results = [row2key[row] for row in rows]
                 return xp.asarray(results, dtype="uint64")
 
+    def _get_ngram_hashes(self, unicode s):
+        """Calculate up to 4 32-bit hash values with MurmurHash3_x64_128 using
+        the ngram hash settings.
+        key (str): The string key.
+        RETURNS: A list of the integer hashes.
+        """
+        cdef uint32_t[4] out
+        chars = s.encode("utf8")
+        cdef char* utf8_string = chars
+        hash128_x64(utf8_string, len(chars), self.hash_seed, &out)
+        rows = [out[i] for i in range(min(self.hash_count, 4))]
+        return rows
+
+    def _get_ngrams(self, unicode key):
+        """Get all padded ngram strings using the ngram settings.
+        key (str): The string key.
+        RETURNS: A list of the ngram strings for the padded key.
+        """
+        key = self.bow + key + self.eow
+        ngrams = [key] + [
+            key[start:start+ngram_size]
+            for ngram_size in range(self.minn, self.maxn + 1)
+            for start in range(0, len(key) - ngram_size + 1)
+        ]
+        return ngrams
+
+    def _get_ngram_vector(self, key):
+        """Get the ngram-based vector for the provided string key.
+        key (str): The string key.
+        RETURNS: The requested vector from the ngram-based vector table.
+        """
+        if self.mode != Mode.ngram:
+            raise ValueError(
+                Errors.E865.format(
+                    mode=self.mode,
+                    alternative="Use Vectors[key] or Vectors.find() instead.",
+                )
+            )
+        if key in self._ngram_cache:
+            return self._ngram_cache[key]
+        key = self.strings.as_string(key)
+        xp = get_array_module(self.data)
+        if len(key) == 0:
+            return xp.zeros((1, self.data.shape[1]))
+        ngrams = self._get_ngrams(key)
+        rows = xp.asarray(
+            [
+                h % self.data.shape[0]
+                for ngram in ngrams
+                for h in self._get_ngram_hashes(ngram)
+            ],
+            dtype="uint32",
+        )
+        vec = xp.sum(self.data[rows], axis=0)
+        if len(rows) > 0:
+            vec = vec / len(rows)
+        if not self._ngram_cache.is_full:
+            self._ngram_cache.add(key, vector=vec)
+        return vec
+
     def add(self, key, *, vector=None, row=None):
         """Add a key to the table. Keys can be mapped to an existing vector
         by setting `row`, or a new vector can be added.
@@ -284,6 +440,9 @@ cdef class Vectors:
 
         DOCS: https://spacy.io/api/vectors#add
         """
+        if self.mode == Mode.ngram:
+            warnings.warn(Warnings.W114.format(method="Vectors.add"))
+            return -1
         # use int for all keys and rows in key2row for more efficient access
         # and serialization
         key = int(get_string_id(key))
@@ -324,6 +483,11 @@ cdef class Vectors:
         RETURNS (tuple): The most similar entries as a `(keys, best_rows, scores)`
             tuple.
         """
+        if self.mode == Mode.ngram:
+            raise ValueError(Errors.E865.format(
+                mode=self.mode,
+                alternative="",
+            ))
         xp = get_array_module(self.data)
         filled = sorted(list({row for row in self.key2row.values()}))
         if len(filled) < n:
@@ -368,7 +532,34 @@ cdef class Vectors:
                     for i in range(len(queries)) ], dtype="uint64")
         return (keys, best_rows, scores)
 
-    def to_disk(self, path, **kwargs):
+    def _get_cfg(self):
+        if self.mode == Mode.default:
+            return {
+                "mode": Mode(self.mode).value,
+            }
+        elif self.mode == Mode.ngram:
+            return {
+                "mode": Mode(self.mode).value,
+                "minn": self.minn,
+                "maxn": self.maxn,
+                "hash_count": self.hash_count,
+                "hash_seed": self.hash_seed,
+                "bow": self.bow,
+                "eow": self.eow,
+                "ngram_cache_size": self.ngram_cache_size,
+            }
+
+    def _set_cfg(self, cfg):
+        self.mode = Mode(cfg.get("mode", Mode.default)).value
+        self.minn = cfg.get("minn", 0)
+        self.maxn = cfg.get("maxn", 0)
+        self.hash_count = cfg.get("hash_count", 0)
+        self.hash_seed = cfg.get("hash_seed", 0)
+        self.bow = cfg.get("bow", "<")
+        self.eow = cfg.get("eow", ">")
+        self.ngram_cache_size = cfg.get("ngram_cache_size", 0)
+
+    def to_disk(self, path, *, exclude=tuple()):
         """Save the current state to a directory.
 
         path (str / Path): A path to a directory, which will be created if
@@ -390,12 +581,14 @@ cdef class Vectors:
                 save_array(self.data, _file)
 
         serializers = {
+            "strings": lambda p: self.strings.to_disk(p.with_suffix(".json")),
             "vectors": lambda p: save_vectors(p),
-            "key2row": lambda p: srsly.write_msgpack(p, self.key2row)
+            "key2row": lambda p: srsly.write_msgpack(p, self.key2row),
+            "vectors.cfg": lambda p: srsly.write_json(p, self._get_cfg()),
         }
-        return util.to_disk(path, serializers, [])
+        return util.to_disk(path, serializers, exclude)
 
-    def from_disk(self, path, **kwargs):
+    def from_disk(self, path, *, exclude=tuple()):
         """Loads state from a directory. Modifies the object in place and
         returns it.
 
@@ -422,17 +615,23 @@ cdef class Vectors:
             if path.exists():
                 self.data = ops.xp.load(str(path))
 
+        def load_settings(path):
+            if path.exists():
+                self._set_cfg(srsly.read_json(path))
+
         serializers = {
+            "strings": lambda p: self.strings.from_disk(p.with_suffix(".json")),
             "vectors": load_vectors,
             "keys": load_keys,
             "key2row": load_key2row,
+            "vectors.cfg": load_settings,
         }
 
-        util.from_disk(path, serializers, [])
+        util.from_disk(path, serializers, exclude)
         self._sync_unset()
         return self
 
-    def to_bytes(self, **kwargs):
+    def to_bytes(self, *, exclude=tuple()):
         """Serialize the current state to a binary string.
 
         exclude (list): String names of serialization fields to exclude.
@@ -447,12 +646,14 @@ cdef class Vectors:
                 return srsly.msgpack_dumps(self.data)
 
         serializers = {
+            "strings": lambda: self.strings.to_bytes(),
             "key2row": lambda: srsly.msgpack_dumps(self.key2row),
-            "vectors": serialize_weights
+            "vectors": serialize_weights,
+            "vectors.cfg": lambda: srsly.json_dumps(self._get_cfg()),
         }
-        return util.to_bytes(serializers, [])
+        return util.to_bytes(serializers, exclude)
 
-    def from_bytes(self, data, **kwargs):
+    def from_bytes(self, data, *, exclude=tuple()):
         """Load state from a binary string.
 
         data (bytes): The data to load from.
@@ -469,12 +670,24 @@ cdef class Vectors:
                 self.data = xp.asarray(srsly.msgpack_loads(b))
 
         deserializers = {
+            "strings": lambda b: self.strings.from_bytes(b),
             "key2row": lambda b: self.key2row.update(srsly.msgpack_loads(b)),
-            "vectors": deserialize_weights
+            "vectors": deserialize_weights,
+            "vectors.cfg": lambda b: self._set_cfg(srsly.json_loads(b))
         }
-        util.from_bytes(data, deserializers, [])
+        util.from_bytes(data, deserializers, exclude)
         self._sync_unset()
         return self
+
+    def clear(self):
+        """Clear all entries in the vector table.
+
+        DOCS: https://spacy.io/api/vectors#clear
+        """
+        if self.mode == Mode.ngram:
+            raise ValueError(Errors.E866)
+        self.key2row = {}
+        self._sync_unset()
 
     def _sync_unset(self):
         filled = {row for row in self.key2row.values()}

--- a/spacy/vocab.pxd
+++ b/spacy/vocab.pxd
@@ -27,7 +27,7 @@ cdef class Vocab:
     cdef Pool mem
     cdef readonly StringStore strings
     cdef public Morphology morphology
-    cdef public object vectors
+    cdef public object _vectors
     cdef public object _lookups
     cdef public object writing_system
     cdef public object get_noun_chunks

--- a/spacy/vocab.pyx
+++ b/spacy/vocab.pyx
@@ -14,7 +14,7 @@ from .attrs cimport LANG, ORTH
 from .compat import copy_reg
 from .errors import Errors
 from .attrs import intify_attrs, NORM, IS_STOP
-from .vectors import Vectors
+from .vectors import Vectors, Mode as VectorsMode
 from .util import registry
 from .lookups import Lookups
 from . import util
@@ -77,10 +77,20 @@ cdef class Vocab:
                 _ = self[string]
         self.lex_attr_getters = lex_attr_getters
         self.morphology = Morphology(self.strings)
-        self.vectors = Vectors(name=vectors_name)
+        self.vectors = Vectors(strings=self.strings, name=vectors_name)
         self.lookups = lookups
         self.writing_system = writing_system
         self.get_noun_chunks = get_noun_chunks
+
+    property vectors:
+        def __get__(self):
+            return self._vectors
+
+        def __set__(self, vectors):
+            for s in vectors.strings:
+                self.strings.add(s)
+            self._vectors = vectors
+            self._vectors.strings = self.strings
 
     @property
     def lang(self):
@@ -282,10 +292,10 @@ cdef class Vocab:
         if width is not None and shape is not None:
             raise ValueError(Errors.E065.format(width=width, shape=shape))
         elif shape is not None:
-            self.vectors = Vectors(shape=shape)
+            self.vectors = Vectors(strings=self.strings, shape=shape)
         else:
             width = width if width is not None else self.vectors.data.shape[1]
-            self.vectors = Vectors(shape=(self.vectors.shape[0], width))
+            self.vectors = Vectors(strings=self.strings, shape=(self.vectors.shape[0], width))
 
     def prune_vectors(self, nr_row, batch_size=1024):
         """Reduce the current vector table to `nr_row` unique entries. Words
@@ -314,6 +324,8 @@ cdef class Vocab:
 
         DOCS: https://spacy.io/api/vocab#prune_vectors
         """
+        if self.vectors.mode != VectorsMode.default:
+            raise ValueError(Errors.E866)
         ops = get_current_ops()
         xp = get_array_module(self.vectors.data)
         # Make sure all vectors are in the vocab
@@ -328,7 +340,7 @@ cdef class Vocab:
         keys = xp.asarray([key for (prob, i, key) in priority], dtype="uint64")
         keep = xp.ascontiguousarray(self.vectors.data[indices[:nr_row]])
         toss = xp.ascontiguousarray(self.vectors.data[indices[nr_row:]])
-        self.vectors = Vectors(data=keep, keys=keys[:nr_row], name=self.vectors.name)
+        self.vectors = Vectors(strings=self.strings, data=keep, keys=keys[:nr_row], name=self.vectors.name)
         syn_keys, syn_rows, scores = self.vectors.most_similar(toss, batch_size=batch_size)
         syn_keys = ops.to_numpy(syn_keys)
         remap = {}
@@ -340,19 +352,12 @@ cdef class Vocab:
             remap[word] = (synonym, score)
         return remap
 
-    def get_vector(self, orth, minn=None, maxn=None):
+    def get_vector(self, orth):
         """Retrieve a vector for a word in the vocabulary. Words can be looked
         up by string or int ID. If no vectors data is loaded, ValueError is
         raised.
 
-        If `minn` is defined, then the resulting vector uses Fasttext's
-        subword features by average over ngrams of `orth`.
-
         orth (int / unicode): The hash value of a word, or its unicode string.
-        minn (int): Minimum n-gram length used for Fasttext's ngram computation.
-            Defaults to the length of `orth`.
-        maxn (int): Maximum n-gram length used for Fasttext's ngram computation.
-            Defaults to the length of `orth`.
         RETURNS (numpy.ndarray or cupy.ndarray): A word vector. Size
             and shape determined by the `vocab.vectors` instance. Usually, a
             numpy ndarray of shape (300,) and dtype float32.
@@ -361,40 +366,10 @@ cdef class Vocab:
         """
         if isinstance(orth, str):
             orth = self.strings.add(orth)
-        word = self[orth].orth_
-        if orth in self.vectors.key2row:
+        if self.has_vector(orth):
             return self.vectors[orth]
         xp = get_array_module(self.vectors.data)
         vectors = xp.zeros((self.vectors_length,), dtype="f")
-        if minn is None:
-            return vectors
-        # Fasttext's ngram computation taken from
-        # https://github.com/facebookresearch/fastText
-        # Assign default ngram limit to maxn which is the length of the word.
-        if maxn is None:
-            maxn = len(word)
-        ngrams_size = 0;
-        for i in range(len(word)):
-            ngram = ""
-            if (word[i] and 0xC0) == 0x80:
-                continue
-            n = 1
-            j = i
-            while (j < len(word) and n <= maxn):
-                if n > maxn:
-                    break
-                ngram += word[j]
-                j = j + 1
-                while (j < len(word) and (word[j] and 0xC0) == 0x80):
-                    ngram += word[j]
-                    j = j + 1
-                if (n >= minn and not (n == 1 and (i == 0 or j == len(word)))):
-                    if self.strings[ngram] in self.vectors.key2row:
-                        vectors = xp.add(self.vectors[self.strings[ngram]], vectors)
-                        ngrams_size += 1
-                n = n + 1
-        if ngrams_size > 0:
-            vectors = vectors * (1.0/ngrams_size)
         return vectors
 
     def set_vector(self, orth, vector):
@@ -417,7 +392,8 @@ cdef class Vocab:
             self.vectors.resize((new_rows, width))
         lex = self[orth]  # Add word to vocab if necessary
         row = self.vectors.add(orth, vector=vector)
-        lex.rank = row
+        if row >= 0:
+            lex.rank = row
 
     def has_vector(self, orth):
         """Check whether a word has a vector. Returns False if no vectors have
@@ -461,7 +437,7 @@ cdef class Vocab:
         if "strings" not in exclude:
             self.strings.to_disk(path / "strings.json")
         if "vectors" not in "exclude":
-            self.vectors.to_disk(path)
+            self.vectors.to_disk(path, exclude=["strings"])
         if "lookups" not in "exclude":
             self.lookups.to_disk(path)
 
@@ -504,7 +480,7 @@ cdef class Vocab:
             if self.vectors is None:
                 return None
             else:
-                return self.vectors.to_bytes()
+                return self.vectors.to_bytes(exclude=["strings"])
 
         getters = {
             "strings": lambda: self.strings.to_bytes(),
@@ -526,7 +502,7 @@ cdef class Vocab:
             if self.vectors is None:
                 return None
             else:
-                return self.vectors.from_bytes(b)
+                return self.vectors.from_bytes(b, exclude=["strings"])
 
         setters = {
             "strings": lambda b: self.strings.from_bytes(b),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Overview:

* Extend `Vectors` to have two modes: `default` and `ngram`
  * `default` is the default mode and equivalent to the current `Vectors`
  * `ngram` supports the hash-only ngram tables from `fasttext-bloom`
* Extend `spacy.StaticVectors.v2` to handle both modes with no changes for `default` vectors
* Extend `spacy init vectors` to support ngram tables

The `ngram` mode **only** supports vector tables produced by the [`fasttext-bloom` fork of fastText](https://github.com/adrianeboyd/fastText/tree/feature/bloom), which adds an option to represent all vectors using only the ngram buckets table and which uses the exact same ngram generation algorithm and hash function (`MurmurHash3_x64_128`). `fasttext-bloom` produces an additional `.hashvec` table, which can be loaded by `spacy init vectors --fasttext-bloom-vectors`.

Implementation details:

* `Vectors` now includes the `StringStore` as `Vectors.strings` so that the API can stay consistent for both `default` (which can look up from `str` or `int`) and `ngram` (which requires `str` to calculate the ngrams).

* In ngram mode `Vectors` uses a default `Vectors` object as a cache since the ngram vectors lookups are relatively expensive.

  * The default cache size is the same size as the provided ngram vector table.

  * Once the cache is full, no more entries are added. The user is responsible for managing the cache in cases where the initial documents are not representative of the texts.

  * The cache can be resized by setting `Vectors.ngram_cache_size` or cleared with `vectors._ngram_cache.clear()`.

* The API ends up a bit split between methods for `default` and for `ngram`, so functions that only make sense for `default` or `ngram` include warnings with custom messages suggesting alternatives where possible.

* `Vocab.vectors` becomes a property so that the string stores can be synced when assigning vectors to a vocab.

* `Vectors` serializes its own config settings as `vectors.cfg`.

* The `Vectors` serialization methods have added support for `exclude` so that the `Vocab` can exclude the `Vectors` strings while serializing.

Removed:

* The `minn` and `maxn` options and related code from `Vocab.get_vector`, which does not work in a meaningful way for default vector tables.

* The unused `GlobalRegistry` in `Vectors`.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Enhancement.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
