### PR TITLE
Warn and document spangroup.doc weakref

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -115,6 +115,8 @@ class Warnings:
     W036 = ("The component '{name}' does not have any patterns defined.")
 
     # New warnings added in v3.x
+    W085 = ("A SpanGroup is not functional after the corresponding Doc has "
+            "been garbage collected.")
     W086 = ("Component '{listener}' will be (re)trained, but it needs the component "
             "'{name}' which is frozen. You can either freeze both, or neither "
             "of the two. If you're sourcing the component from "

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -115,8 +115,6 @@ class Warnings:
     W036 = ("The component '{name}' does not have any patterns defined.")
 
     # New warnings added in v3.x
-    W085 = ("A SpanGroup is not functional after the corresponding Doc has "
-            "been garbage collected.")
     W086 = ("Component '{listener}' will be (re)trained, but it needs the component "
             "'{name}' which is frozen. You can either freeze both, or neither "
             "of the two. If you're sourcing the component from "
@@ -523,6 +521,10 @@ class Errors:
     E202 = ("Unsupported alignment mode '{mode}'. Supported modes: {modes}.")
 
     # New errors added in v3.x
+    E866 = ("A SpanGroup is not functional after the corresponding Doc has "
+            "been garbage collected. To keep using the spans, make sure that "
+            "the corresponding Doc object is still available in the scope of "
+            "your function.")
     E867 = ("The 'textcat' component requires at least two labels because it "
             "uses mutually exclusive classes where exactly one label is True "
             "for each doc. For binary classification tasks, you can use two "

--- a/spacy/tests/pipeline/test_spancat.py
+++ b/spacy/tests/pipeline/test_spancat.py
@@ -87,7 +87,7 @@ def test_doc_gc():
         for key, spangroup in spangroups.items():
             assert isinstance(spangroup, SpanGroup)
             assert len(spangroup) > 0
-            with pytest.raises(Exception):
+            with pytest.raises(RuntimeError):
                 span = spangroup[0]
 
 

--- a/spacy/tests/pipeline/test_spancat.py
+++ b/spacy/tests/pipeline/test_spancat.py
@@ -1,8 +1,10 @@
 import pytest
 import numpy
-from numpy.testing import assert_equal, assert_array_equal, assert_almost_equal
+from numpy.testing import assert_array_equal, assert_almost_equal
 from thinc.api import get_current_ops
 from spacy.language import Language
+from spacy.tokens.doc import SpanGroups
+from spacy.tokens import SpanGroup
 from spacy.training import Example
 from spacy.util import fix_random_seed, registry
 
@@ -70,6 +72,23 @@ def test_explicit_labels():
     spancat.add_label("LOC")
     nlp.initialize()
     assert spancat.labels == ("PERSON", "LOC")
+
+
+def test_doc_gc():
+    # If the Doc object is garbage collected, the spans won't be functional afterwards
+    nlp = Language()
+    spancat = nlp.add_pipe("spancat", config={"spans_key": SPAN_KEY})
+    spancat.add_label("PERSON")
+    nlp.initialize()
+    texts = ["Just a sentence.", "I like London and Berlin", "I like Berlin", "I eat ham."]
+    all_spans = [doc.spans for doc in nlp.pipe(texts)]
+    for text, spangroups in zip(texts, all_spans):
+        assert isinstance(spangroups, SpanGroups)
+        for key, spangroup in spangroups.items():
+            assert isinstance(spangroup, SpanGroup)
+            assert len(spangroup) > 0
+            with pytest.raises(Exception):
+                span = spangroup[0]
 
 
 @pytest.mark.parametrize(

--- a/spacy/tokens/span_group.pyx
+++ b/spacy/tokens/span_group.pyx
@@ -1,9 +1,8 @@
-import warnings
 import weakref
 import struct
 import srsly
 
-from spacy.errors import Warnings
+from spacy.errors import Errors
 from .span cimport Span
 from libc.stdint cimport uint64_t, uint32_t, int32_t
 
@@ -64,7 +63,7 @@ cdef class SpanGroup:
         doc = self._doc_ref()
         if doc is None:
             # referent has been garbage collected
-            warnings.warn(Warnings.W085)
+            raise RuntimeError(Errors.E866)
         return doc
 
     @property

--- a/spacy/tokens/span_group.pyx
+++ b/spacy/tokens/span_group.pyx
@@ -1,6 +1,9 @@
+import warnings
 import weakref
 import struct
 import srsly
+
+from spacy.errors import Warnings
 from .span cimport Span
 from libc.stdint cimport uint64_t, uint32_t, int32_t
 
@@ -58,7 +61,11 @@ cdef class SpanGroup:
 
         DOCS: https://spacy.io/api/spangroup#doc
         """
-        return self._doc_ref()
+        doc = self._doc_ref()
+        if doc is None:
+            # referent has been garbage collected
+            warnings.warn(Warnings.W085)
+        return doc
 
     @property
     def has_overlap(self):

--- a/website/docs/api/spangroup.md
+++ b/website/docs/api/spangroup.md
@@ -17,10 +17,9 @@ access a member at a given index.
 
 When a `Doc` object is garbage collected, any related `SpanGroup` object won't
 be functional anymore, as these objects use a `weakref` to refer to the
-document. A `W085` warning will be shown when attempting to access the `spans`
-and eventually an error will be raised as the internal `doc` object will be
-`None`. To avoid this, make sure that the original `Doc` objects are still
-available in the scope of your function.
+document. An error will be raised as the internal `doc` object will be `None`.
+To avoid this, make sure that the original `Doc` objects are still available in
+the scope of your function.
 
 </Infobox>
 

--- a/website/docs/api/spangroup.md
+++ b/website/docs/api/spangroup.md
@@ -13,16 +13,6 @@ into a `SpanGroup` object for you automatically on assignment. `SpanGroup`
 objects behave similar to `list`s, so you can append `Span` objects to them or
 access a member at a given index.
 
-<Infobox title="SpanGroup and Doc lifecycle" variant="warning">
-
-When a `Doc` object is garbage collected, any related `SpanGroup` object won't
-be functional anymore, as these objects use a `weakref` to refer to the
-document. An error will be raised as the internal `doc` object will be `None`.
-To avoid this, make sure that the original `Doc` objects are still available in
-the scope of your function.
-
-</Infobox>
-
 ## SpanGroup.\_\_init\_\_ {#init tag="method"}
 
 Create a `SpanGroup`.
@@ -55,6 +45,16 @@ Create a `SpanGroup`.
 ## SpanGroup.doc {#doc tag="property"}
 
 The [`Doc`](/api/doc) object the span group is referring to.
+
+<Infobox title="SpanGroup and Doc lifecycle" variant="warning">
+
+When a `Doc` object is garbage collected, any related `SpanGroup` object won't
+be functional anymore, as these objects use a `weakref` to refer to the
+document. An error will be raised as the internal `doc` object will be `None`.
+To avoid this, make sure that the original `Doc` objects are still available in
+the scope of your function.
+
+</Infobox>
 
 > #### Example
 >

--- a/website/docs/api/spangroup.md
+++ b/website/docs/api/spangroup.md
@@ -13,6 +13,16 @@ into a `SpanGroup` object for you automatically on assignment. `SpanGroup`
 objects behave similar to `list`s, so you can append `Span` objects to them or
 access a member at a given index.
 
+<Infobox title="SpanGroup and Doc lifecycle" variant="warning">
+
+When a `Doc` object is garbage collected, any reference to a related `SpanGroup`
+object won't be functional anymore. A `W085` warning will be shown when
+attempting to access the `spans` and eventually an error will be raised as the
+internal `doc` object will be `None`. To avoid this, make sure that the original
+`Doc` objects are still available in the scope of your function.
+
+</Infobox>
+
 ## SpanGroup.\_\_init\_\_ {#init tag="method"}
 
 Create a `SpanGroup`.

--- a/website/docs/api/spangroup.md
+++ b/website/docs/api/spangroup.md
@@ -15,11 +15,12 @@ access a member at a given index.
 
 <Infobox title="SpanGroup and Doc lifecycle" variant="warning">
 
-When a `Doc` object is garbage collected, any reference to a related `SpanGroup`
-object won't be functional anymore. A `W085` warning will be shown when
-attempting to access the `spans` and eventually an error will be raised as the
-internal `doc` object will be `None`. To avoid this, make sure that the original
-`Doc` objects are still available in the scope of your function.
+When a `Doc` object is garbage collected, any related `SpanGroup` object won't
+be functional anymore, as these objects use a `weakref` to refer to the
+document. A `W085` warning will be shown when attempting to access the `spans`
+and eventually an error will be raised as the internal `doc` object will be
+`None`. To avoid this, make sure that the original `Doc` objects are still
+available in the scope of your function.
 
 </Infobox>
 


### PR DESCRIPTION

## Description
`SpanGroup.doc` uses a `weakref.ref` to refer to the `Doc` without causing circular references. Unfortunately this means that something like this will fail:
```
all_spans = [doc.spans for doc in nlp.pipe(texts)]
print(all_spans)
```
because the `SpanGroup` objects within `all_spans` will refer to dead referents.

In this PR, we raise a custom error to explain why this happens & to avoid it + document this behaviour in the API docs.

> RuntimeError: [E866] A SpanGroup is not functional after the corresponding Doc has been garbage collected. To keep using the spans, make sure that the corresponding Doc object is still available in the scope of your function.

I'm not sure there's a solution where we can avoid the whole issue entirely...

### Types of change
UX & docs

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
