### PR TITLE
Add glossary entry for _SP (fix #8982)

### DIFF
--- a/spacy/glossary.py
+++ b/spacy/glossary.py
@@ -95,6 +95,7 @@ GLOSSARY = {
     "XX": "unknown",
     "BES": 'auxiliary "be"',
     "HVS": 'forms of "have"',
+    "_SP": "whitespace",
     # POS Tags (German)
     # TIGER Treebank
     # http://www.ims.uni-stuttgart.de/forschung/ressourcen/korpora/TIGERCorpus/annotation/tiger_introduction.pdf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

This adds a glossary entry for the `_SP` tag, which is used for whitespace that gets a tag rather than being subsumed. This wasn't documented anywhere, as pointed out in #8982. 

It's possible this was `SP` at some point in the past but was changed. In Chinese OntoNotes SP is used for "sentence [final] particles", which is unrelated.

I guess this should also be added to model docs?

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Glossary addition.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
