### PR TITLE
Include component factories in third-party dependencies resolver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ ml_datasets>=0.2.0,<0.3.0
 murmurhash>=0.28.0,<1.1.0
 wasabi>=0.8.1,<1.1.0
 srsly>=2.4.1,<3.0.0
-catalogue>=2.0.4,<2.1.0
+catalogue>=2.0.6,<2.1.0
 typer>=0.3.0,<0.4.0
 pathy>=0.3.5
 # Third party dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     blis>=0.4.0,<0.8.0
     wasabi>=0.8.1,<1.1.0
     srsly>=2.4.1,<3.0.0
-    catalogue>=2.0.4,<2.1.0
+    catalogue>=2.0.6,<2.1.0
     typer>=0.3.0,<0.4.0
     pathy>=0.3.5
     # Third-party dependencies

--- a/spacy/cli/package.py
+++ b/spacy/cli/package.py
@@ -206,6 +206,9 @@ def get_third_party_dependencies(
     for path, value in util.walk_dict(config):
         if path[-1].startswith("@"):  # collect all function references by registry
             funcs[path[-1][1:]].add(value)
+    for component in config.get("components", {}).values():
+        if "factory" in component:
+            funcs["factories"].add(component["factory"])
     modules = set()
     for reg_name, func_names in funcs.items():
         sub_registry = getattr(util.registry, reg_name)

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -539,4 +539,6 @@ def test_get_third_party_dependencies_runs():
     # We can't easily test the detection of third-party packages here, but we
     # can at least make sure that the function and its importlib magic runs.
     nlp = Dutch()
+    # Test with component factory based on Cython module
+    nlp.add_pipe("tagger")
     assert get_third_party_dependencies(nlp.config) == []


### PR DESCRIPTION
## Description

The logic for automatically adding third-party dependencies to the package requirements in `spacy package` only checked for registered functions (`@` keys) in the config. However, component factories are also often provided via a third-party packages and weren't covered, because they are specified as `factory =`. This PR includes them.

### Types of change
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
