### PR TITLE
Fix inference of epoch_resume

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -869,6 +869,8 @@ class Errors:
     E1019 = ("`noun_chunks` requires the pos tagging, which requires a "
              "statistical model to be installed and loaded. For more info, see "
              "the documentation:\nhttps://spacy.io/usage/models")
+    E1020 = ("No `epoch_resume` value specified and could not infer one from "
+             "filename. Specify an epoch to resume from.")
 
 
 # Deprecated model shortcuts, only used in errors and warnings

--- a/spacy/training/pretrain.py
+++ b/spacy/training/pretrain.py
@@ -41,10 +41,14 @@ def pretrain(
     optimizer = P["optimizer"]
     # Load in pretrained weights to resume from
     if resume_path is not None:
-        _resume_model(model, resume_path, epoch_resume, silent=silent)
+        epoch_resume = _resume_model(model, resume_path, epoch_resume, silent=silent)
     else:
         # Without '--resume-path' the '--epoch-resume' argument is ignored
         epoch_resume = 0
+
+    if epoch_resume is None:
+        raise ValueError(Errors.E1020)
+
     objective = model.attrs["loss"]
     # TODO: move this to logger function?
     tracker = ProgressTracker(frequency=10000)
@@ -93,7 +97,7 @@ def ensure_docs(examples_or_docs: Iterable[Union[Doc, Example]]) -> List[Doc]:
 
 def _resume_model(
     model: Model, resume_path: Path, epoch_resume: int, silent: bool = True
-) -> None:
+) -> int:
     msg = Printer(no_print=silent)
     msg.info(f"Resume training tok2vec from: {resume_path}")
     with resume_path.open("rb") as file_:
@@ -107,6 +111,7 @@ def _resume_model(
         msg.info(f"Resuming from epoch: {epoch_resume}")
     else:
         msg.info(f"Resuming from epoch: {epoch_resume}")
+    return epoch_resume
 
 
 def make_update(


### PR DESCRIPTION
When an epoch_resume value is not specified individually, it can often
be inferred from the filename. The value inference code was there but
the value wasn't passed back to the training loop.

This also adds a specific error in the case where no epoch_resume value
is provided and it can't be inferred from the filename.

This does not handle the case where a value can be inferred from the filename and an epoch resume value is explicitly passed. In that case the explicitly passed value will be ignored, which seems a bit weird. Should there be a warning or error or something instead?

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I have submitted the spaCy Contributor Agreement.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
