### PR TITLE
Validate pos values when creating Doc

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -872,7 +872,7 @@ class Errors:
     E1020 = ("No `epoch_resume` value specified and could not infer one from "
              "filename. Specify an epoch to resume from.")
     E1021 = ("`pos` value \"{pp}\" is not a valid Universal Dependencies tag. "
-             "Non-UD tags should use the `tag` field.")
+             "Non-UD tags should use the `tag` property.")
 
 
 # Deprecated model shortcuts, only used in errors and warnings

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -871,6 +871,8 @@ class Errors:
              "the documentation:\nhttps://spacy.io/usage/models")
     E1020 = ("No `epoch_resume` value specified and could not infer one from "
              "filename. Specify an epoch to resume from.")
+    E1021 = ("`pos` value \"{pp}\" is not a valid Universal Dependencies tag. "
+             "Non-UD tags should use the `tag` field.")
 
 
 # Deprecated model shortcuts, only used in errors and warnings

--- a/spacy/tests/doc/test_creation.py
+++ b/spacy/tests/doc/test_creation.py
@@ -70,3 +70,10 @@ def test_create_with_heads_and_no_deps(vocab):
     heads = list(range(len(words)))
     with pytest.raises(ValueError):
         Doc(vocab, words=words, heads=heads)
+
+
+def test_create_invalid_pos(vocab):
+    words = "I like ginger".split()
+    pos = "QQ ZZ XX".split()
+    with pytest.raises(ValueError):
+        Doc(vocab, words=words, pos=pos)

--- a/spacy/tests/doc/test_token_api.py
+++ b/spacy/tests/doc/test_token_api.py
@@ -202,6 +202,10 @@ def test_set_pos():
     doc[1].pos = VERB
     assert doc[1].pos_ == "VERB"
 
+def test_set_invalid_pos():
+    doc = Doc(Vocab(), words=["hello", "world"])
+    with pytest.raises(ValueError):
+        doc[0].pos_ = "blah"
 
 def test_tokens_sent(doc):
     """Test token.sent property"""

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -287,7 +287,7 @@ cdef class Doc:
                 elif sent_starts[i] is None or sent_starts[i] not in [-1, 0, 1]:
                     sent_starts[i] = 0
         if pos is not None:
-            for pp in pos:
+            for pp in set(pos):
                 if pp not in parts_of_speech.IDS:
                     raise ValueError(Errors.E1021.format(pp=pp))
         ent_iobs = None

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -30,6 +30,7 @@ from ..compat import copy_reg, pickle
 from ..errors import Errors, Warnings
 from ..morphology import Morphology
 from .. import util
+from .. import parts_of_speech
 from .underscore import Underscore, get_ext_args
 from ._retokenize import Retokenizer
 from ._serialize import ALL_ATTRS as DOCBIN_ALL_ATTRS
@@ -285,6 +286,10 @@ cdef class Doc:
                     sent_starts[i] = -1
                 elif sent_starts[i] is None or sent_starts[i] not in [-1, 0, 1]:
                     sent_starts[i] = 0
+        if pos is not None:
+            for pp in pos:
+                if pp not in parts_of_speech.IDS:
+                    raise ValueError(Errors.E1021.format(pp=pp))
         ent_iobs = None
         ent_types = None
         if ents is not None:

--- a/spacy/tokens/token.pyx
+++ b/spacy/tokens/token.pyx
@@ -867,6 +867,8 @@ cdef class Token:
             return parts_of_speech.NAMES[self.c.pos]
 
         def __set__(self, pos_name):
+            if pos_name not in parts_of_speech.IDS:
+                raise ValueError(Errors.E1021.format(pp=pp))
             self.c.pos = parts_of_speech.IDS[pos_name]
 
     property tag_:

--- a/spacy/tokens/token.pyx
+++ b/spacy/tokens/token.pyx
@@ -868,7 +868,7 @@ cdef class Token:
 
         def __set__(self, pos_name):
             if pos_name not in parts_of_speech.IDS:
-                raise ValueError(Errors.E1021.format(pp=pp))
+                raise ValueError(Errors.E1021.format(pp=pos_name))
             self.c.pos = parts_of_speech.IDS[pos_name]
 
     property tag_:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

When you pass pos values to a Doc they aren't validated. Before this change, any value could be set via `Doc.__init__`, but if you tried to access `.pos_` on an invalid value you would get a `KeyError`.

In contrast, if you try to set an invalid pos value directly you get a `KeyError` immediately.

This checks if pos values are valid, and if not throws an error that explains they must be UD values, and other tags should use the `tag` field.

See #9145 for motivating case.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Added validation

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
