### PR TITLE
Correct parser.py use_upper param info

### DIFF
--- a/spacy/ml/models/parser.py
+++ b/spacy/ml/models/parser.py
@@ -56,7 +56,7 @@ def build_tb_parser_model(
         non-linearity if use_upper=False.
     use_upper (bool): Whether to use an additional hidden layer after the state
         vector in order to predict the action scores. It is recommended to set
-        this to False for large pretrained models such as transformers, and False
+        this to False for large pretrained models such as transformers, and True
         for smaller networks. The upper layer is computed on CPU, which becomes
         a bottleneck on larger GPU-based models, where it's also less necessary.
     nO (int or None): The number of actions the model will predict between.


### PR DESCRIPTION
# Update use_upper param info in parser.py


## Description
Dear SpaCy team,

I think there was a mistake in the documentation: In (e.g.) NER, the parser uses an additional network to predict the action/state scores in the transition-based parsing stage when using a small, non-transformer network.

Kind regards,
Johann

### Types of change
Documentation update

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
