### PR TITLE
Only include runtime-relevant config in package CLI dependency detection

### DIFF
--- a/spacy/cli/package.py
+++ b/spacy/cli/package.py
@@ -203,9 +203,11 @@ def get_third_party_dependencies(
     own_packages = ("spacy", "spacy-legacy", "spacy-nightly", "thinc", "srsly")
     distributions = util.packages_distributions()
     funcs = defaultdict(set)
-    for path, value in util.walk_dict(config):
-        if path[-1].startswith("@"):  # collect all function references by registry
-            funcs[path[-1][1:]].add(value)
+    # We only want to look at runtime-relevant sections, not [training] or [initialize]
+    for section in ("nlp", "components"):
+        for path, value in util.walk_dict(config[section]):
+            if path[-1].startswith("@"):  # collect all function references by registry
+                funcs[path[-1][1:]].add(value)
     for component in config.get("components", {}).values():
         if "factory" in component:
             funcs["factories"].add(component["factory"])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Previously, the external package dependency detection in `spacy package` would include the entire config, including sections not relevant at runtime. So if the `[training]` or `[initialize]` block included references to registered functions exposed by third-party packages, these packages would become dependencies of the packaged pipeline. That's unideal, so this PR only includes the runtime-relevant sections `nlp` and `components`.

### Types of change
fix / enhancement (?)

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
