### PR TITLE
Don't serialize user data in DocBin if not saving it (fix #9190)

### DIFF
--- a/spacy/tests/training/test_training.py
+++ b/spacy/tests/training/test_training.py
@@ -524,6 +524,30 @@ def test_roundtrip_docs_to_docbin(doc):
     assert cats["TRAVEL"] == reloaded_example.reference.cats["TRAVEL"]
     assert cats["BAKING"] == reloaded_example.reference.cats["BAKING"]
 
+def test_docbin_user_data_serialized(doc):
+    doc.user_data["check"] = True
+    nlp = English()
+
+    with make_tempdir() as tmpdir:
+        output_file = tmpdir / "userdata.spacy"
+        DocBin(docs=[doc], store_user_data=True).to_disk(output_file)
+        reloaded_docs = DocBin().from_disk(output_file).get_docs(nlp.vocab)
+        reloaded_doc = list(reloaded_docs)[0]
+
+    assert reloaded_doc.user_data["check"] == True
+
+def test_docbin_user_data_not_serialized(doc):
+    # this isn't serializable, but that shouldn't cause an error
+    doc.user_data["check"] = set()
+    nlp = English()
+
+    with make_tempdir() as tmpdir:
+        output_file = tmpdir / "userdata.spacy"
+        DocBin(docs=[doc], store_user_data=False).to_disk(output_file)
+        reloaded_docs = DocBin().from_disk(output_file).get_docs(nlp.vocab)
+        reloaded_doc = list(reloaded_docs)[0]
+
+    assert "check" not in reloaded_doc.user_data
 
 @pytest.mark.parametrize(
     "tokens_a,tokens_b,expected",

--- a/spacy/tokens/_serialize.py
+++ b/spacy/tokens/_serialize.py
@@ -110,7 +110,8 @@ class DocBin:
             self.strings.add(token.ent_kb_id_)
             self.strings.add(token.ent_id_)
         self.cats.append(doc.cats)
-        self.user_data.append(srsly.msgpack_dumps(doc.user_data))
+        if self.store_user_data:
+            self.user_data.append(srsly.msgpack_dumps(doc.user_data))
         self.span_groups.append(doc.spans.to_bytes())
         for key, group in doc.spans.items():
             for span in group:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

If you create a DocBin with `store_user_data = False`, the data won't be included in `to_bytes`, but it will still be serialized as soon as it's added to the DocBin. If you have a non-serializable item in user data, this means you can get an error about that even though you don't want to serialize it, which is confusing. See #9190 

This just doesn't save user data if `store_user_data` is `False`. Another option would be to save empty user data. That might be better if someone changes the value on an existing DocBin, but that sounds like a terrible idea in general.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Convenience fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
