### PR TITLE
Allow overriding vars in the project assets subcommand

### DIFF
--- a/spacy/cli/project/assets.py
+++ b/spacy/cli/project/assets.py
@@ -1,18 +1,24 @@
-from typing import Optional
+from typing import Any, Dict, Optional
 from pathlib import Path
 from wasabi import msg
 import re
 import shutil
 import requests
+import typer
 
 from ...util import ensure_path, working_dir
 from .._util import project_cli, Arg, Opt, PROJECT_FILE, load_project_config
 from .._util import get_checksum, download_file, git_checkout, get_git_version
+from .._util import SimpleFrozenDict, parse_config_overrides
 
 
-@project_cli.command("assets")
+@project_cli.command(
+    "assets",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
 def project_assets_cli(
     # fmt: off
+    ctx: typer.Context,  # This is only used to read additional arguments
     project_dir: Path = Arg(Path.cwd(), help="Path to cloned project. Defaults to current working directory.", exists=True, file_okay=False),
     sparse_checkout: bool = Opt(False, "--sparse", "-S", help="Use sparse checkout for assets provided via Git, to only check out and clone the files needed. Requires Git v22.2+.")
     # fmt: on
@@ -24,16 +30,22 @@ def project_assets_cli(
 
     DOCS: https://spacy.io/api/cli#project-assets
     """
-    project_assets(project_dir, sparse_checkout=sparse_checkout)
+    overrides = parse_config_overrides(ctx.args)
+    project_assets(project_dir, overrides=overrides, sparse_checkout=sparse_checkout)
 
 
-def project_assets(project_dir: Path, *, sparse_checkout: bool = False) -> None:
+def project_assets(
+    project_dir: Path,
+    *,
+    overrides: Dict[str, Any] = SimpleFrozenDict(),
+    sparse_checkout: bool = False,
+) -> None:
     """Fetch assets for a project using DVC if possible.
 
     project_dir (Path): Path to project directory.
     """
     project_path = ensure_path(project_dir)
-    config = load_project_config(project_path)
+    config = load_project_config(project_path, overrides=overrides)
     assets = config.get("assets", {})
     if not assets:
         msg.warn(f"No assets specified in {PROJECT_FILE}", exits=0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

`spacy project run` allows overriding arguments through the command-line (e.g. `--vars.gpu=-1`). Overriding variables is not supported by the `spacy project assets` subcommand. However, this would be handy when e.g. a data repository contains multiple corpora and one wants to fetch a different corpus based on the variable set.

This change makes the `project assets` subcommand accept variables to override as well, making the interface more similar to `project run`.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.

With regards to the last checkbox: from the current documentation I inferred that it would be possible to override variables with `project assets` as well, until I found out you can't 😅.