### PR TITLE
avoid crash when unicode in title

### DIFF
--- a/spacy/cli/project/run.py
+++ b/spacy/cli/project/run.py
@@ -1,6 +1,7 @@
 from typing import Optional, List, Dict, Sequence, Any, Iterable
 from pathlib import Path
 from wasabi import msg
+from wasabi.util import locale_escape
 import sys
 import srsly
 import typer
@@ -135,7 +136,7 @@ def print_run_help(project_dir: Path, subcommand: Optional[str] = None) -> None:
         print("")
         title = config.get("title")
         if title:
-            print(f"{title}\n")
+            print(f"{locale_escape(title)}\n")
         if config_commands:
             print(f"Available commands in {PROJECT_FILE}")
             print(f"Usage: {COMMAND} project run [COMMAND] {project_loc}")


### PR DESCRIPTION
## Description
Avoid crash when there's unicode in a project title and console doesn't support unicode well enough. Prints "?" instead.

### Types of change
bug fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
