### PR TITLE
Fix Dependency Matcher Ordering Issue

### DIFF
--- a/spacy/matcher/dependencymatcher.pyx
+++ b/spacy/matcher/dependencymatcher.pyx
@@ -177,13 +177,14 @@ cdef class DependencyMatcher:
 
         # Add 'RIGHT_ATTRS' to self._patterns[key]
         _patterns = [[[pat["RIGHT_ATTRS"]] for pat in pattern] for pattern in patterns]
+        pattern_offset = len(self._patterns[key])
         self._patterns[key].extend(_patterns)
 
         # Add each node pattern of all the input patterns individually to the
         # matcher. This enables only a single instance of Matcher to be used.
         # Multiple adds are required to track each node pattern.
         tokens_to_key_list = []
-        for i, current_patterns in enumerate(_patterns):
+        for i, current_patterns in enumerate(_patterns, start=pattern_offset):
 
             # Preallocate list space
             tokens_to_key = [None] * len(current_patterns)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

This seems to fix at least some of the problems exposed in #9263, and includes a test that illustrates the issue.

Currently this handles this particular problem: if you have two rules with the same label, behavior is different adding them in one call to `DependencyMatcher.add` vs two calls. The one-call behavior is correct.

It's a little hard to tell from the issue if there are other problems, so this needs more work.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
