### PR TITLE
Fix Japanese morph tests

### DIFF
--- a/spacy/tests/lang/ja/test_tokenizer.py
+++ b/spacy/tests/lang/ja/test_tokenizer.py
@@ -130,7 +130,7 @@ def test_ja_tokenizer_sub_tokens(
     [
         (
             "取ってつけた",
-            ("五段-ラ行,連用形-促音便", "", "下一段-カ行,連用形-一般", "助動詞-タ,終止形-一般"),
+            ("五段-ラ行;連用形-促音便", "", "下一段-カ行;連用形-一般", "助動詞-タ;終止形-一般"),
             ("トッ", "テ", "ツケ", "タ"),
         ),
     ],
@@ -139,7 +139,7 @@ def test_ja_tokenizer_inflections_reading_forms(
     ja_tokenizer, text, inflections, reading_forms
 ):
     tokens = ja_tokenizer(text)
-    test_inflections = [",".join(tt.morph.get("inflection")) for tt in tokens]
+    test_inflections = [tt.morph.get("inflection")[0] for tt in tokens]
     assert test_inflections == list(inflections)
     test_readings = [tt.morph.get("reading")[0] for tt in tokens]
     assert test_readings == list(reading_forms)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

The Japanese inflection attribute was initially joined with a comma internally, but this caused it to behave like multiple fields in the MorphAnalysis. That wasn't desirable, so the separator was changed to a semicolon. This updates the tests to match that.

As a note the structure of the inflection field is:

- conjugation type: this is like "strong verb" and often includes the final phonetic character (`五段-ラ行` is a typical value that means "five steps - ends in r")
- conjugation form: this is like "imperative" or "negative" or whatever, but can also have multiple levels like `連用形-促音便` or `終止形-一般`

Note these have internal structure sometimes as indicated by the hyphens, thus the need for a non-hyphen delimiter.

For non-inflecting forms these fields will both be blank. 

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

test fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
