### PR TITLE
Fix inconsistent lemmas

### DIFF
--- a/spacy/lang/ca/lemmatizer.py
+++ b/spacy/lang/ca/lemmatizer.py
@@ -2,7 +2,6 @@ from typing import List, Tuple
 
 from ...pipeline import Lemmatizer
 from ...tokens import Token
-from ...util import unique
 
 
 class CatalanLemmatizer(Lemmatizer):
@@ -77,6 +76,6 @@ class CatalanLemmatizer(Lemmatizer):
             forms.append(self.lookup_lemmatize(token)[0])
         if not forms:
             forms.append(string)
-        forms = unique(forms)
+        forms = list(dict.fromkeys(forms))
         self.cache[cache_key] = forms
         return forms

--- a/spacy/lang/fr/lemmatizer.py
+++ b/spacy/lang/fr/lemmatizer.py
@@ -2,7 +2,6 @@ from typing import List, Tuple
 
 from ...pipeline import Lemmatizer
 from ...tokens import Token
-from ...util import unique
 
 
 class FrenchLemmatizer(Lemmatizer):
@@ -76,6 +75,6 @@ class FrenchLemmatizer(Lemmatizer):
             forms.append(self.lookup_lemmatize(token)[0])
         if not forms:
             forms.append(string)
-        forms = unique(forms)
+        forms = list(dict.fromkeys(forms))
         self.cache[cache_key] = forms
         return forms

--- a/spacy/lang/nl/lemmatizer.py
+++ b/spacy/lang/nl/lemmatizer.py
@@ -2,7 +2,6 @@ from typing import List, Tuple
 
 from ...pipeline import Lemmatizer
 from ...tokens import Token
-from ...util import unique
 
 
 class DutchLemmatizer(Lemmatizer):
@@ -98,7 +97,7 @@ class DutchLemmatizer(Lemmatizer):
                     return forms
                 else:
                     oov_forms.append(form)
-        forms = unique(oov_forms)
+        forms = list(dict.fromkeys(oov_forms))
         # Back-off through remaining return value candidates.
         if forms:
             for form in forms:

--- a/spacy/lang/ru/lemmatizer.py
+++ b/spacy/lang/ru/lemmatizer.py
@@ -6,7 +6,6 @@ from ...pipeline import Lemmatizer
 from ...symbols import POS
 from ...tokens import Token
 from ...vocab import Vocab
-from ...util import unique
 
 
 PUNCT_RULES = {"«": '"', "»": '"'}
@@ -57,7 +56,7 @@ class RussianLemmatizer(Lemmatizer):
         if not len(filtered_analyses):
             return [string.lower()]
         if morphology is None or (len(morphology) == 1 and POS in morphology):
-            return unique([analysis.normal_form for analysis in filtered_analyses])
+            return list(dict.fromkeys([analysis.normal_form for analysis in filtered_analyses]))
         if univ_pos in ("ADJ", "DET", "NOUN", "PROPN"):
             features_to_compare = ["Case", "Number", "Gender"]
         elif univ_pos == "NUM":
@@ -88,7 +87,7 @@ class RussianLemmatizer(Lemmatizer):
                 filtered_analyses.append(analysis)
         if not len(filtered_analyses):
             return [string.lower()]
-        return unique([analysis.normal_form for analysis in filtered_analyses])
+        return list(dict.fromkeys([analysis.normal_form for analysis in filtered_analyses]))
 
     def pymorphy2_lookup_lemmatize(self, token: Token) -> List[str]:
         string = token.text

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -1395,22 +1395,6 @@ def walk_dict(
             yield (key_parent, value)
 
 
-def unique(ll):
-    """Return unique values in a list, preserving order.
-
-    When there are multiple versions of the same item, the first is kept. This
-    should be used instead of list(set(ll)) to avoid inconcistency between
-    different process runs.
-    """
-    seen = set()
-    out = []
-    for ii in ll:
-        if ii not in seen:
-            out.append(ii)
-            seen.add(ii)
-    return out
-
-
 def get_arg_names(func: Callable) -> List[str]:
     """Get a list of all named arguments of a function (regular,
     keyword-only).
@@ -1419,7 +1403,7 @@ def get_arg_names(func: Callable) -> List[str]:
     RETURNS (List[str]): The argument names.
     """
     argspec = inspect.getfullargspec(func)
-    return unique([*argspec.args, *argspec.kwonlyargs])
+    return list(dict.fromkeys([*argspec.args, *argspec.kwonlyargs]))
 
 
 def combine_score_weights(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

As reported in #9387, the Catalan lemmatizer has different lemmas across different processes. The cause is using `list(set(xxx))` to make a list unique. Since the order of a set can vary between process runs, and since the first item in the list is used as the final lemma, that caused inconsistent lemmas. 

This PR adds a function called `unique` to `spacy.util` that keeps order in a list but removes duplicate elements. The implementation is simple and there may be a better way to do it. 

Calls to `list(set())` in lemmatizers and elsewhere were replaced with `unique()`, except where the call was like `sorted(list(set()))`, which was left alone.

One thing about this is that I don't completely understand what's going on when multiple lemma forms are available, and whether being first in the list has any significance. It's possible we don't need a util function and the `sorted` call convention would be enough. 

One other thing is that I'm not really sure how to test this, since the inconsistency can only occur between processes. I could spin up a python child process but it seems like overkill.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
