### PR TITLE
Add test for case where parser overwrite annotations

### DIFF
--- a/spacy/tests/regression/test_issue7716.py
+++ b/spacy/tests/regression/test_issue7716.py
@@ -43,7 +43,7 @@ def parser(vocab):
     return parser
 
 
-# @pytest.mark.xfail(reason="Not fixed yet", strict=False)
+@pytest.mark.xfail(reason="Not fixed yet")
 def test_partial_annotation(parser):
     doc = Doc(parser.vocab, words=["a", "b", "c", "d"])
     doc[2].is_sent_start = False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

As pointed out in #7716, the parser can overwrite `is_sent_start` annotations if not all tokens in a doc have them. The exact circumstances for this are unclear, but specifically it can turn `False` annotations into `True`.

This just adds a failing test for that case. The bad news is the test is flaky and succeeds occasionally. 

It might make sense to leave this PR around until a fix can be added to it, or to change the test to a non-strict xfail instead.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Adds a test.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
