### PR TITLE
Support issue marker via pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -122,7 +122,8 @@ exclude =
 
 [tool:pytest]
 markers =
-    slow
+    slow: mark a test as slow
+    issue: reference specific issue
 
 [mypy]
 ignore_missing_imports = True

--- a/spacy/tests/conftest.py
+++ b/spacy/tests/conftest.py
@@ -4,6 +4,7 @@ from spacy.util import get_lang_class
 
 def pytest_addoption(parser):
     parser.addoption("--slow", action="store_true", help="include slow tests")
+    parser.addoption("--issue", action="store", help="test specific issues")
 
 
 def pytest_runtest_setup(item):
@@ -16,9 +17,23 @@ def pytest_runtest_setup(item):
         # options weren't given.
         return item.config.getoption(f"--{opt}", False)
 
+    # Integration of boolean flags
     for opt in ["slow"]:
         if opt in item.keywords and not getopt(opt):
             pytest.skip(f"need --{opt} option to run")
+
+    # Special integration to mark tests with issue numbers
+    issues = getopt("issue")
+    if isinstance(issues, str):
+        if "issue" in item.keywords:
+            # Convert issues provided on the CLI to list of ints
+            issue_nos = [int(issue.strip()) for issue in issues.split(",")]
+            # Get all issues specified by decorators and check if they're provided
+            issue_refs = [mark.args[0] for mark in item.iter_markers(name="issue")]
+            if not any([ref in issue_nos for ref in issue_refs]):
+                pytest.skip(f"not referencing specified issues: {issue_nos}")
+        else:
+            pytest.skip("not referencing any issues")
 
 
 # Fixtures for language tokenizers (languages sorted alphabetically)

--- a/spacy/tests/regression/test_issue8168.py
+++ b/spacy/tests/regression/test_issue8168.py
@@ -1,6 +1,8 @@
+import pytest
 from spacy.lang.en import English
 
 
+@pytest.mark.issue(8168)
 def test_issue8168():
     nlp = English()
     ruler = nlp.add_pipe("entity_ruler")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

This PR introduces an `issue` marker for `pytest` to label tests with one or more issues they're referring to:

```python
@pytest.mark.issue(1234)
def some_test_related_to_1234():
    ...
```

Decorators can also be stacked out-of-the-box:

```python
@pytest.mark.issue(1234)
@pytest.mark.issue(5678)
def some_test_related_to_1234_and_5678():
    ...
```

The `--issue` option on the `pytest` CLI now lets you run all tests referring to one or more issues only. All other tests (without a marker or referencing a different issue) will be skipped:

```bash
python -m pytest spacy --issue 1234,666
```

### Todo

- [ ] decorate more tests
- [ ] check performance? This is the correct usage as [documented](https://docs.pytest.org/en/6.2.x/example/markers.html) and maybe `pytest` does some fancy caching, or it just doesn't matter. But it felt wrong to me to do so much in the test setup 🤷‍♀️
- [x] Do we want a syntax that lets us specify multiple issues inline instead of stacking decorators (which might become a bit verbose)? It's doable but requires more custom logic compared to stacked decorators that work out-of-the-box.

### Types of change
tests

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
