### PR TITLE
Add allowed_teams to the explosion-bot config

### DIFF
--- a/.github/workflows/explosionbot.yml
+++ b/.github/workflows/explosionbot.yml
@@ -24,3 +24,4 @@ jobs:
           INPUT_TOKEN: ${{ secrets.EXPLOSIONBOT_TOKEN }}
           INPUT_BK_TOKEN: ${{ secrets.BUILDKITE_SECRET }}
           ENABLED_COMMANDS: "test_gpu"
+          ALLOWED_TEAMS: "spaCy"


### PR DESCRIPTION
So the spaCy team can summon the bot!