### PR TITLE
Fix import path for JsonlCorpus documentation

### DIFF
--- a/spacy/training/__init__.py
+++ b/spacy/training/__init__.py
@@ -1,4 +1,4 @@
-from .corpus import Corpus  # noqa: F401
+from .corpus import Corpus, JsonlCorpus  # noqa: F401
 from .example import Example, validate_examples, validate_get_examples  # noqa: F401
 from .alignment import Alignment  # noqa: F401
 from .augment import dont_augment, orth_variants_augmenter  # noqa: F401


### PR DESCRIPTION
Minor documentation fix. Importing `JsonlCorpus via spacy.training` throws an `ImportError`. The `corpus` module should be specified explicitly

<!--- Provide a general summary of your changes in the title. -->

## Description

When running the following example in the website, I encountered an error:

```python
from spacy.training import JsonlCorpus
...
```


```python-traceback
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-14-6379356de907> in <module>
----> 1 from spacy.training import JsonlCorpus

ImportError: cannot import name 'JsonlCorpus' from 'spacy.training' (/home/lj/.local/lib/python3.8/site-packages/spacy/training/__init__.py)

In [15]: spacy.__version__
Out[15]: '3.1.3'
```

I updated the import path so that it works

### Types of change

Documentation change from `spacy.training` into `spacy.training.corpus`

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
