### PR TITLE
clarify how to connect pretraining to training

### DIFF
--- a/website/docs/usage/embeddings-transformers.md
+++ b/website/docs/usage/embeddings-transformers.md
@@ -759,7 +759,8 @@ init_tok2vec = ${paths.init_tok2vec}
 <Infobox variant="warning">
 
 The outputs of `spacy pretrain` are not the same data format as the
-pre-packaged word vectors that would go into `initialize.vectors`.
+pre-packaged static word vectors that would go into 
+[`initialize.vectors`](/api/data-formats#config-initialize).
 The pretraining output consists of the weights that the `tok2vec`
 component should start with in an existing pipeline, so it goes in
 `initialize.init_tok2vec`.


### PR DESCRIPTION
## Description

Pretraining is a great feature and I want to make the path to using it smoother. I'm proposing adding a section to its documentation, about how to specifically set up your config so that training uses the result of pretraining, that would have helped me.

### Types of change

Documentation change

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
