### PR TITLE
Fix kb.set_entities

### DIFF
--- a/spacy/kb.pyx
+++ b/spacy/kb.pyx
@@ -156,6 +156,7 @@ cdef class KnowledgeBase:
 
         nr_entities = len(set(entity_list))
         self.initialize_entities(nr_entities)
+        self.initialize_vectors(nr_entities)
 
         i = 0
         cdef KBEntryC entry
@@ -174,8 +175,8 @@ cdef class KnowledgeBase:
                 entry.entity_hash = entity_hash
                 entry.freq = freq_list[i]
 
-                vector_index = self.c_add_vector(entity_vector=vector_list[i])
-                entry.vector_index = vector_index
+                self._vectors_table[i] = entity_vector
+                entry.vector_index = i
 
                 entry.feats_row = -1   # Features table currently not implemented
 

--- a/spacy/tests/pipeline/test_entity_linker.py
+++ b/spacy/tests/pipeline/test_entity_linker.py
@@ -158,14 +158,34 @@ def test_kb_serialize(nlp):
 def test_kb_serialize_2(nlp):
     v = [5, 6, 7, 8]
     kb1 = KnowledgeBase(vocab=nlp.vocab, entity_vector_length=4)
-    kb1.set_entities(["1"], [1], [v])
+    kb1.set_entities(["E1"], [1], [v])
+    assert kb1.get_vector("E1") == v
     with make_tempdir() as d:
         kb1.to_disk(d / "kb")
-        assert kb1.get_vector("1") == v
-
         kb2 = KnowledgeBase(vocab=nlp.vocab, entity_vector_length=4)
         kb2.from_disk(d / "kb")
-        assert kb2.get_vector("1") == v
+        assert kb2.get_vector("E1") == v
+
+
+def test_kb_set_entities(nlp):
+    """ Test that set_entities entirely overwrites the previous set of entities """
+    v = [5, 6, 7, 8]
+    v1 = [1, 1, 1, 0]
+    v2 = [2, 2, 2, 3]
+    kb1 = KnowledgeBase(vocab=nlp.vocab, entity_vector_length=4)
+    kb1.set_entities(["E0"], [1], [v])
+    assert kb1.get_entity_strings() == ["E0"]
+    kb1.set_entities(["E1", "E2"], [1, 9], [v1, v2])
+    assert set(kb1.get_entity_strings()) == {"E1", "E2"}
+    assert kb1.get_vector("E1") == v1
+    assert kb1.get_vector("E2") == v2
+    with make_tempdir() as d:
+        kb1.to_disk(d / "kb")
+        kb2 = KnowledgeBase(vocab=nlp.vocab, entity_vector_length=4)
+        kb2.from_disk(d / "kb")
+        assert set(kb2.get_entity_strings()) == {"E1", "E2"}
+        assert kb2.get_vector("E1") == v1
+        assert kb2.get_vector("E2") == v2
 
 
 def test_kb_serialize_vocab(nlp):


### PR DESCRIPTION

## Description
The method `kb.set_entities` sets a bunch of entities and vectors in one go, and calls `initialize_entities` at the start. Before this PR, this method would also initialize `self._vectors_table` at the total number of entities, but that doesn't work in combination with the call to `self.c_add_vector` (in `set_entities`) as this will perform a `self._vectors_table.push_back`, effectively creating an even larger `self._vectors_table`. This ends up with indices out of sync, and memory access trouble after serializing.

The solution here is to avoid using the `push_back` and write to `self._vectors_table` directly. I've also split up the initialization of the entities and the vectors, so that each method can pick which to initialize and the dependence on this is made more clear.

Fixes #9137 

### Types of change
bug fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
