### PR TITLE
Include .pyi files in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 recursive-include include *.h
-recursive-include spacy *.pyx *.pxd *.txt *.cfg *.jinja *.toml
+recursive-include spacy *.pyi *.pyx *.pxd *.txt *.cfg *.jinja *.toml
 include LICENSE
 include README.md
 include pyproject.toml


### PR DESCRIPTION
## Description

Included stub files from https://github.com/explosion/spaCy/pull/8427 in `MANIFEST.in` (cf. https://github.com/explosion/spaCy/discussions/8373#discussioncomment-1469159) so that they're included in the package.

From what I understand, `recursive-include` should include all directories inside `spacy` (i.e., `spacy/tokens/*.pyi`, `spacy/**/*.pyi`). Let me know if my understanding is incorrect.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
