### PR TITLE
Allow conftest.py to run twice for build envs

### DIFF
--- a/spacy/tests/conftest.py
+++ b/spacy/tests/conftest.py
@@ -3,8 +3,13 @@ from spacy.util import get_lang_class
 
 
 def pytest_addoption(parser):
-    parser.addoption("--slow", action="store_true", help="include slow tests")
-    parser.addoption("--issue", action="store", help="test specific issues")
+    try:
+        parser.addoption("--slow", action="store_true", help="include slow tests")
+        parser.addoption("--issue", action="store", help="test specific issues")
+    # Options are already added, e.g. if conftest is copied in a build pipeline
+    # and runs twice
+    except ValueError:
+        pass
 
 
 def pytest_runtest_setup(item):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

This is only relevant for our build/test pipelines on Buildkite if we want to run the `conftest.py` twice when executing tests with `--pyargs` and options. Keeping the conftest in the working directory ensures that options are recognized. In this case, we make sure that `pytest` doesn't fail if options are added twice.

### Types of change
tests

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
