### PR TITLE
Add WordDumb to spaCy Universe

### DIFF
--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -3518,7 +3518,21 @@
             },
             "category": ["pipeline", "research", "standalone"],
             "tags": ["spacy", "python", "nlp", "ner"]
-        }        
+        },
+        {
+            "id": "WordDumb",
+            "title": "WordDumb",
+            "slogan": "A calibre plugin that generates Word Wise and X-Ray files.",
+            "description": "A calibre plugin that generates Word Wise and X-Ray files then sends them to Kindle. Supports KFX, AZW3 and MOBI eBooks. X-Ray supports 18 languages.",
+            "github": "xxyzz/WordDumb",
+            "code_language": "python",
+            "thumb": "https://raw.githubusercontent.com/xxyzz/WordDumb/master/starfish.svg",
+            "image": "https://user-images.githubusercontent.com/21101839/130245435-b874f19a-7785-4093-9975-81596efc42bb.png",
+            "author": "xxyzz",
+            "author_links": {
+                "github": "xxyzz"
+            }
+        }
     ],
 
     "categories": [

--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -3531,7 +3531,8 @@
             "author": "xxyzz",
             "author_links": {
                 "github": "xxyzz"
-            }
+            },
+            "category": ["standalone"]
         }
     ],
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
Add [WordDumb](https://github.com/xxyzz/WordDumb/) to spaCy Universe. WordDumb uses spaCy to find named entities in books to create Kindle X-Ray file.

### Types of change
Update `universe.json`.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

I only run `.github/validate_universe_json.py` on `universe.json`, I guess this commit won't affect other tests...