### PR TITLE
Use metaclass to subclass errors to allow better pickling

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -1,18 +1,13 @@
 import warnings
 
 
-def add_codes(err_cls):
-    """Add error codes to string messages via class attribute names."""
-
-    class ErrorsWithCodes(err_cls):
-        def __getattribute__(self, code):
-            msg = super(ErrorsWithCodes, self).__getattribute__(code)
-            if code.startswith("__"):  # python system attributes like __class__
-                return msg
-            else:
-                return "[{code}] {msg}".format(code=code, msg=msg)
-
-    return ErrorsWithCodes()
+class ErrorsWithCodes(type):
+    def __getattribute__(self, code):
+        msg = super().__getattribute__(code)
+        if code.startswith("__"):  # python system attributes like __class__
+            return msg
+        else:
+            return "[{code}] {msg}".format(code=code, msg=msg)
 
 
 def setup_default_warnings():
@@ -44,8 +39,7 @@ def _escape_warning_msg(msg):
 
 # fmt: off
 
-@add_codes
-class Warnings:
+class Warnings(metaclass=ErrorsWithCodes):
     W005 = ("Doc object not parsed. This means displaCy won't be able to "
             "generate a dependency visualization for it. Make sure the Doc "
             "was processed with a model that supports dependency parsing, and "
@@ -194,8 +188,7 @@ class Warnings:
             "lead to errors.")
 
 
-@add_codes
-class Errors:
+class Errors(metaclass=ErrorsWithCodes):
     E001 = ("No component '{name}' found in pipeline. Available names: {opts}")
     E002 = ("Can't find factory for '{name}' for language {lang} ({lang_code}). "
             "This usually happens when spaCy calls `nlp.{method}` with a custom "

--- a/spacy/tests/test_errors.py
+++ b/spacy/tests/test_errors.py
@@ -2,11 +2,10 @@ from inspect import isclass
 
 import pytest
 
-from spacy.errors import add_codes
+from spacy.errors import ErrorsWithCodes
 
 
-@add_codes
-class Errors:
+class Errors(metaclass=ErrorsWithCodes):
     E001 = "error description"
 
 


### PR DESCRIPTION
When trying to pickle with dill, as happens under the hood when processing a HuggingFace `dataset`, I found that spaCy couldn't be pickled (related issue: https://github.com/huggingface/datasets/issues/3178). I found that the cause was `dill.Pickler` that recursively pickled all objects (`Pickler(file, recurse=True).dump(obj)`). This is preferred in `datasets`: such iterative pickling allows for fingerprinting, i.e. keeping track of all the processing done to a dataset, deterministically. If the fingerprint is the same as an earlier processing attempt, then a cache can be used and the processing (e.g. tokenizing with spaCy) does not have to be done again. Very useful and great to save time and processing.

The culprit in the spaCy codebase that could not be pickled in this way, was this part

https://github.com/explosion/spaCy/blob/f1bc655a387a040bbd64d8650eade135215e8a0a/spacy/errors.py#L4-L15

The class `ErrorsWithCodes` cannot be pickled here because it does not have a fixed signature in the global scope (its superclass is not known beforehand). After digging through the Internet (thank you [Stack Overflow](https://stackoverflow.com/a/69808716/1150683)!) I found that a metaclass is the way to go, as implemented in this PR. In my opinion, this is also more structurally clear than before. Regular subclassing a metaclass instead of dynamically created a class based on a subclass with a decorator. The *meta*class defines the magic methods that are required to access the class' attributes, rather than accessing instance attributes.

I modified the error test accordingly, which completes successfully.

After this modification, recursive dill pickling works flawlessly as well.

closes #9584 
<!-- closes https://github.com/huggingface/datasets/issues/3178 (will close manually as soon as this PR is accepted and merged) -->

### Types of change
Enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
