### PR TITLE
WIP: Matcher allow overwriting ent_iob 

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -887,6 +887,10 @@ class Errors(metaclass=ErrorsWithCodes):
     E1021 = ("`pos` value \"{pp}\" is not a valid Universal Dependencies tag. "
              "Non-UD tags should use the `tag` property.")
     E1022 = ("Words must be of type str or int, but input is of type '{wtype}'")
+    E1023 = ("Possible entity IOB values are 0, 1, 2 and 3, but the provided argument '{tag}' is not one of these values.")
+    E1024 = ("Possible entity IOB strings are I, O and B, but the provided argument '{tag}' is not one of these values.")
+
+
 
 
 # Deprecated model shortcuts, only used in errors and warnings

--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -438,13 +438,14 @@ class EntityRuler(Pipe):
             label = f"{label}{self.ent_id_sep}{ent_id}"
         return label
 
-    def _create_iob_label(self, label: Any, ent_iobs: str) -> str:
+    def _create_iob_label(self, label: Any, ent_iobs: Any) -> str:
         """Join Entity label with ent_iobs if the pattern has an `ent_iobs` attribute
         label (str): The label to set for ent.label_
         ent_iobs (str): The ent_iobs string
         RETURNS (str): The ent_label joined with configured `ent_iob_sep`
         """
-        label = f"{label}{self.ent_iob_sep}{ent_iobs}"
+        if isinstance(ent_iobs, str):
+            label = f"{label}{self.ent_iob_sep}{ent_iobs}"
         return label
 
     def from_bytes(

--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -228,7 +228,7 @@ class EntityRuler(Pipe):
                 label, _ = self._split_label(l)
                 all_labels.add(label)
             elif self.ent_iob_sep in l:
-                label, _ = self.split_iob_label(l)
+                label, _ = self._split_iob_label(l)
                 all_labels.add(label)
             else:
                 all_labels.add(l)
@@ -436,6 +436,15 @@ class EntityRuler(Pipe):
         """
         if isinstance(ent_id, str):
             label = f"{label}{self.ent_id_sep}{ent_id}"
+        return label
+
+    def _create_iob_label(self, label: Any, ent_iobs: str) -> str:
+        """Join Entity label with ent_iobs if the pattern has an `ent_iobs` attribute
+        label (str): The label to set for ent.label_
+        ent_iobs (str): The ent_iobs string
+        RETURNS (str): The ent_label joined with configured `ent_iob_sep`
+        """
+        label = f"{label}{self.ent_iob_sep}{ent_iobs}"
         return label
 
     def from_bytes(

--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -192,6 +192,15 @@ class EntityRuler(Pipe):
                     if ent_id:
                         for token in span:
                             token.ent_id_ = ent_id
+                    if match_id in self_ent_iobs:
+                        ent_iobs = self._ent_iobs[match_id]
+                        for token,iob in zip(span, ent_iobs):
+                            token.ent_iob_ = iob
+                elif match_id in self._ent_iobs:
+                    label, ent_iobs = self._ent_iobs[match_id]
+                    span = Span(doc, start, end, label=label)
+                    for token,iob in zip(span, ent_iobs):
+                        token.ent_iob_ = iob
                 else:
                     span = Span(doc, start, end, label=match_id)
                 new_entities.append(span)

--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -192,7 +192,7 @@ class EntityRuler(Pipe):
                     if ent_id:
                         for token in span:
                             token.ent_id_ = ent_id
-                    if match_id in self_ent_iobs:
+                    if match_id in self._ent_iobs:
                         ent_iobs = self._ent_iobs[match_id]
                         for token,iob in zip(span, ent_iobs):
                             token.ent_iob_ = iob

--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -129,6 +129,7 @@ class EntityRuler(Pipe):
             nlp.vocab, attr=self.phrase_matcher_attr, validate=validate
         )
         self.ent_id_sep = ent_id_sep
+        self.ent_iob_sep = ent_iob_sep
         self._ent_ids = defaultdict(tuple)  # type: ignore
         self._ent_iobs = defaultdict(list)  # type: ignore
         if patterns is not None:

--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -16,7 +16,6 @@ from ..scorer import get_ner_prf
 
 
 DEFAULT_ENT_ID_SEP = "||"
-DEFAULT_ENT_IOB_SEP = "|-|"
 PatternType = Dict[str, Union[str, List[Dict[str, Any]]]]
 
 
@@ -28,7 +27,6 @@ PatternType = Dict[str, Union[str, List[Dict[str, Any]]]]
         "validate": False,
         "overwrite_ents": False,
         "ent_id_sep": DEFAULT_ENT_ID_SEP,
-        "ent_iob_sep": DEFAULT_ENT_IOB_SEP,
         "scorer": {"@scorers": "spacy.entity_ruler_scorer.v1"},
     },
     default_score_weights={
@@ -45,7 +43,6 @@ def make_entity_ruler(
     validate: bool,
     overwrite_ents: bool,
     ent_id_sep: str,
-    ent_iob_sep: str,
     scorer: Optional[Callable],
 ):
     return EntityRuler(
@@ -55,7 +52,6 @@ def make_entity_ruler(
         validate=validate,
         overwrite_ents=overwrite_ents,
         ent_id_sep=ent_id_sep,
-        ent_iob_sep=ent_iob_sep,
         scorer=scorer,
     )
 
@@ -89,7 +85,6 @@ class EntityRuler(Pipe):
         validate: bool = False,
         overwrite_ents: bool = False,
         ent_id_sep: str = DEFAULT_ENT_ID_SEP,
-        ent_iob_sep: str = DEFAULT_ENT_IOB_SEP,
         patterns: Optional[List[PatternType]] = None,
         scorer: Optional[Callable] = entity_ruler_score,
     ) -> None:
@@ -129,9 +124,7 @@ class EntityRuler(Pipe):
             nlp.vocab, attr=self.phrase_matcher_attr, validate=validate
         )
         self.ent_id_sep = ent_id_sep
-        self.ent_iob_sep = ent_iob_sep
         self._ent_ids = defaultdict(tuple)  # type: ignore
-        self._ent_iobs = defaultdict(list)  # type: ignore
         if patterns is not None:
             self.add_patterns(patterns)
         self.scorer = scorer
@@ -193,15 +186,6 @@ class EntityRuler(Pipe):
                     if ent_id:
                         for token in span:
                             token.ent_id_ = ent_id
-                    if match_id in self._ent_iobs:
-                        ent_iobs = self._ent_iobs[match_id]
-                        for token,iob in zip(span, ent_iobs):
-                            token.ent_iob_ = iob
-                elif match_id in self._ent_iobs:
-                    label, ent_iobs = self._ent_iobs[match_id]
-                    span = Span(doc, start, end, label=label)
-                    for token,iob in zip(span, ent_iobs):
-                        token.ent_iob_ = iob
                 else:
                     span = Span(doc, start, end, label=match_id)
                 new_entities.append(span)
@@ -226,9 +210,6 @@ class EntityRuler(Pipe):
         for l in keys:
             if self.ent_id_sep in l:
                 label, _ = self._split_label(l)
-                all_labels.add(label)
-            elif self.ent_iob_sep in l:
-                label, _ = self._split_iob_label(l)
                 all_labels.add(label)
             else:
                 all_labels.add(l)
@@ -273,22 +254,6 @@ class EntityRuler(Pipe):
         return tuple(all_ent_ids)
 
     @property
-    def ent_iobs(self) -> Tuple[Optional[str], ...]:
-        """All entity iobs present in the match patterns `ent_iobs` properties
-        RETURNS (set): The entity iobs.
-        DOCS: https://spacy.io/api/entityruler#ent_iobs
-        """
-        keys = set(self.token_patterns.keys())
-        keys.update(self.phrase_patterns.keys())
-        all_ent_iobs = set()
-
-        for l in keys:
-            if self.ent_iob_sep in l:
-                _, ent_iobs = self._split_iob_label(l)
-                all_ent_iobs.add(ent_iobs)
-        return tuple(all_ent_iobs)
-
-    @property
     def patterns(self) -> List[PatternType]:
         """Get all patterns that were added to the entity ruler.
 
@@ -300,22 +265,16 @@ class EntityRuler(Pipe):
         for label, patterns in self.token_patterns.items():
             for pattern in patterns:
                 ent_label, ent_id = self._split_label(label)
-                ent_label, ent_iobs = self._split_iob_label(ent_label)
                 p = {"label": ent_label, "pattern": pattern}
                 if ent_id:
                     p["id"] = ent_id
-                if ent_iobs:
-                    p[ent_iobs] = ent_iobs
                 all_patterns.append(p)
         for label, patterns in self.phrase_patterns.items():
             for pattern in patterns:
                 ent_label, ent_id = self._split_label(label)
-                ent_label, ent_iobs = self._split_iob_label(ent_label)
                 p = {"label": ent_label, "pattern": pattern.text}
                 if ent_id:
                     p["id"] = ent_id
-                if ent_iobs:
-                    p["ent_iobs"] = ent_iobs
                 all_patterns.append(p)
         return all_patterns
 
@@ -369,13 +328,6 @@ class EntityRuler(Pipe):
                     label = self._create_label(label, entry["id"])
                     key = self.matcher._normalize_key(label)
                     self._ent_ids[key] = (ent_label, entry["id"])
-                    if "ent_iobs" in entry:
-                        self._ent_iobs[key] = entry["ent_iobs"]
-                elif "ent_iobs" in entry:
-                    ent_label = label
-                    label = self._create_iob_label(label, entry["ent_iobs"])
-                    key = self.matcher._normalize_key(label)
-                    self._ent_iobs[key] = (ent_label, entry["ent_iobs"])
                 pattern = entry["pattern"]  # type: ignore
                 if isinstance(pattern, Doc):
                     self.phrase_patterns[label].append(pattern)
@@ -414,18 +366,6 @@ class EntityRuler(Pipe):
             ent_id = None  # type: ignore
         return ent_label, ent_id
 
-    def _split_iob_label(self, label: str) -> Tuple[str, Optional[str]]:
-        """Split Entity label into ent_label and ent_iobs if it contains self.ent_iob_sep
-        label (str): The value of label in a pattern entry
-        RETURNS (tuple): ent_label, ent_iobs
-        """
-        if self.ent_iob_sep in label:
-            ent_label, ent_iobs = label.rsplit(self.ent_iob_sep, 1)
-        else:
-            ent_label = label
-            ent_iobs = None  # type: ignore
-        return ent_label, ent_iobs
-
     def _create_label(self, label: Any, ent_id: Any) -> str:
         """Join Entity label with ent_id if the pattern has an `id` attribute
         If ent_id is not a string, the label is returned as is.
@@ -436,16 +376,6 @@ class EntityRuler(Pipe):
         """
         if isinstance(ent_id, str):
             label = f"{label}{self.ent_id_sep}{ent_id}"
-        return label
-
-    def _create_iob_label(self, label: Any, ent_iobs: Any) -> str:
-        """Join Entity label with ent_iobs if the pattern has an `ent_iobs` attribute
-        label (str): The label to set for ent.label_
-        ent_iobs (str): The ent_iobs string
-        RETURNS (str): The ent_label joined with configured `ent_iob_sep`
-        """
-        if isinstance(ent_iobs, str):
-            label = f"{label}{self.ent_iob_sep}{ent_iobs}"
         return label
 
     def from_bytes(

--- a/spacy/tokens/token.pyi
+++ b/spacy/tokens/token.pyi
@@ -140,12 +140,10 @@ class Token:
     def conjuncts(self) -> Tuple[Token]: ...
     ent_type: int
     ent_type_: str
-    @property
-    def ent_iob(self) -> int: ...
+    ent_iob: int
     @classmethod
     def iob_strings(cls) -> Tuple[str]: ...
-    @property
-    def ent_iob_(self) -> str: ...
+    ent_iob_: str
     ent_id: int
     ent_id_: str
     ent_kb_id: int

--- a/spacy/tokens/token.pyx
+++ b/spacy/tokens/token.pyx
@@ -732,21 +732,24 @@ cdef class Token:
         def __set__(self, ent_type):
             self.c.ent_type = self.vocab.strings.add(ent_type)
 
-    @property
-    def ent_iob(self):
+    property ent_iob:
         """IOB code of named entity tag. `1="I", 2="O", 3="B"`. 0 means no tag
         is assigned.
 
         RETURNS (uint64): IOB code of named entity tag.
         """
-        return self.c.ent_iob
+        def __get__(self):
+            return self.c.ent_iob
+        def __set__(self, hash_t tag):
+            if not (1 <= tag <= 3):
+                raise ValueError(Errors.E1023.format(tag=tag))
+            self.c.ent_iob = tag
 
     @classmethod
     def iob_strings(cls):
         return ("", "I", "O", "B")
 
-    @property
-    def ent_iob_(self):
+    property ent_iob_:
         """IOB code of named entity tag. "B" means the token begins an entity,
         "I" means it is inside an entity, "O" means it is outside an entity,
         and "" means no entity tag is set. "B" with an empty ent_type
@@ -754,7 +757,12 @@ cdef class Token:
 
         RETURNS (str): IOB code of named entity tag.
         """
-        return self.iob_strings()[self.c.ent_iob]
+        def __get__(self):
+            return self.iob_strings()[self.c.ent_iob]
+        def __set__(self, str tag):
+            if tag not in "IOB":
+                raise ValueError(Errors.E1024.format(tag=tag))
+            self.c.ent_iob = self.iob_strings().inde
 
     property ent_id:
         """RETURNS (uint64): ID of the entity the token is an instance of,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
This issue sourced from #3940 . Basically we want to make it possible to override `token.ent_iob_` by EntityRuler , hence forming longer entities from existing entities is possible. This will work then:

```
ruler.add_patterns([{"label":'GPE', "ent_iobs": "I", "pattern":[{"LOWER":"california"}]}])
doc = nlp("New York california")
doc.ents
("New York california", )
```

where current output is

```
("New York", "california")
```

### Types of change
New feature

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
