### PR TITLE
Make Jsonl Corpus reader path optional again

### DIFF
--- a/spacy/training/corpus.py
+++ b/spacy/training/corpus.py
@@ -41,7 +41,7 @@ def create_docbin_reader(
 
 @util.registry.readers("spacy.JsonlCorpus.v1")
 def create_jsonl_reader(
-    path: Union[None, str, Path], min_length: int = 0, max_length: int = 0, limit: int = 0
+    path: Optional[Union[str, Path]], min_length: int = 0, max_length: int = 0, limit: int = 0
 ) -> Callable[["Language"], Iterable[Example]]:
     return JsonlCorpus(path, min_length=min_length, max_length=max_length, limit=limit)
 

--- a/spacy/training/corpus.py
+++ b/spacy/training/corpus.py
@@ -41,7 +41,7 @@ def create_docbin_reader(
 
 @util.registry.readers("spacy.JsonlCorpus.v1")
 def create_jsonl_reader(
-    path: Union[str, Path], min_length: int = 0, max_length: int = 0, limit: int = 0
+    path: Union[None, str, Path], min_length: int = 0, max_length: int = 0, limit: int = 0
 ) -> Callable[["Language"], Iterable[Example]]:
     return JsonlCorpus(path, min_length=min_length, max_length=max_length, limit=limit)
 

--- a/spacy/training/corpus.py
+++ b/spacy/training/corpus.py
@@ -221,7 +221,7 @@ class JsonlCorpus:
 
     def __init__(
         self,
-        path: Union[str, Path],
+        path: Optional[Union[str, Path]],
         *,
         limit: int = 0,
         min_length: int = 0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

In #8396 the path arg to the JsonlCorpus was made optional. This was done so that you could use a config with a pretraining section for training without including the raw text path. However, #9167 made the path non-optional again, apparently inadvertently. 

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

minor fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
