### PR TITLE
Fix Language-specific factory handling in package command

### DIFF
--- a/spacy/cli/package.py
+++ b/spacy/cli/package.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from wasabi import Printer, MarkdownRenderer, get_raw_input
 from thinc.api import Config
 from collections import defaultdict
+from catalogue import RegistryError
 import srsly
 import sys
 
@@ -212,9 +213,18 @@ def get_third_party_dependencies(
         if "factory" in component:
             funcs["factories"].add(component["factory"])
     modules = set()
+    lang = config["nlp"]["lang"]
     for reg_name, func_names in funcs.items():
         for func_name in func_names:
-            func_info = util.registry.find(reg_name, func_name)
+            # Try the lang-specific version and fall back
+            try:
+                func_info = util.registry.find(reg_name, lang + "." + func_name)
+            except RegistryError:
+                try:
+                    func_info = util.registry.find(reg_name, func_name)
+                except RegistryError as regerr:
+                    # lang-specific version being absent is not actually an issue
+                    raise regerr from None
             module_name = func_info.get("module")  # type: ignore[attr-defined]
             if module_name:  # the code is part of a module, not a --code file
                 modules.add(func_info["module"].split(".")[0])  # type: ignore[index]

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -671,7 +671,7 @@ class Language:
         resolved = registry.resolve(cfg, validate=validate)
         filled = registry.fill({"cfg": cfg[factory_name]}, validate=validate)["cfg"]
         filled = Config(filled)
-        filled["factory"] = internal_name
+        filled["factory"] = factory_name
         filled.pop("@factories", None)
         # Remove the extra values we added because we don't want to keep passing
         # them around, copying them etc.
@@ -681,7 +681,7 @@ class Language:
         # interpolated variables)
         if raw_config:
             filled = filled.merge(raw_config)
-        filled["factory"] = internal_name
+        filled["factory"] = factory_name
         self._pipe_configs[name] = filled
         return resolved[factory_name]
 

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -671,7 +671,7 @@ class Language:
         resolved = registry.resolve(cfg, validate=validate)
         filled = registry.fill({"cfg": cfg[factory_name]}, validate=validate)["cfg"]
         filled = Config(filled)
-        filled["factory"] = factory_name
+        filled["factory"] = internal_name
         filled.pop("@factories", None)
         # Remove the extra values we added because we don't want to keep passing
         # them around, copying them etc.
@@ -681,6 +681,7 @@ class Language:
         # interpolated variables)
         if raw_config:
             filled = filled.merge(raw_config)
+        filled["factory"] = internal_name
         self._pipe_configs[name] = filled
         return resolved[factory_name]
 

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -681,7 +681,6 @@ class Language:
         # interpolated variables)
         if raw_config:
             filled = filled.merge(raw_config)
-        filled["factory"] = factory_name
         self._pipe_configs[name] = filled
         return resolved[factory_name]
 

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -565,7 +565,16 @@ def test_get_third_party_dependencies():
             }
         },
     )
-    get_third_party_dependencies(nlp.config) == []
+    assert get_third_party_dependencies(nlp.config) == []
+
+    # Test with lang-specific factory
+    @Dutch.factory("third_party_test")
+    def test_factory(nlp, name):
+        return lambda x: x
+
+    nlp.add_pipe("third_party_test")
+    # Before #9674 this would throw an exception
+    get_third_party_dependencies(nlp.config)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
If a component factory is registered like `@French.factory(...)` instead
of `@Language.factory(...)`, the name in the factories registry will be
prefixed with the language code. However in the nlp.config object the
factory will be listed without the language code. The `add_pipe` code
has fallback logic to handle this, but packaging code and the registry
itself don't.

This change makes it so that the factory name in nlp.config is the
language-specific form. It's not clear if this will break anything else,
but it does seem to fix the inconsistency and resolve the specific user
issue that brought this to our attention (#9652). 

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bug fix, probably?

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
