### PR TITLE
Updated Underscore to handle Spans with same boundaries

### DIFF
--- a/spacy/tests/doc/test_underscore.py
+++ b/spacy/tests/doc/test_underscore.py
@@ -189,6 +189,11 @@ def test_underscore_for_span(en_tokenizer) :
     span_1._.span_extension = 'span_1 extension'
     span_2._.span_extension =  'span_2 extension'
 
+    doc._.doc_extension == "doc extension"
+    doc[0]._.token_extension == "token extension"
+    span_1._.span_extension == 'span_1 extension'
+    span_2._.span_extension == 'span_2 extension'
+
     assert doc.user_data[('._.', 'span_extension', span_1.start_char, span_1.end_char, span_1.label, span_1.kb_id)] == 'span_1 extension'
     assert doc.user_data[('._.', 'span_extension', span_2.start_char, span_2.end_char, span_2.label, span_2.kb_id)] == 'span_2 extension'
 
@@ -196,9 +201,19 @@ def test_underscore_for_span(en_tokenizer) :
     assert doc.user_data[('._.', 'span_extension', span_1.start_char, span_1.end_char, span_1.label, span_1.kb_id)] == 'span_1 extension'
     assert doc.user_data[('._.', 'span_extension', span_2.start_char, span_2.end_char, span_2.label, span_2.kb_id)] == 'span_2 extension'
 
+    doc._.doc_extension == "doc extension"
+    doc[0]._.token_extension == "token extension"
+    span_1._.span_extension == 'span_1 extension'
+    span_2._.span_extension == 'span_2 extension'
+
     span_1.kb_id_ = "KB_ID"
     assert doc.user_data[('._.', 'span_extension', span_1.start_char, span_1.end_char, span_1.label, span_1.kb_id)] == 'span_1 extension'
     assert doc.user_data[('._.', 'span_extension', span_2.start_char, span_2.end_char, span_2.label, span_2.kb_id)] == 'span_2 extension'
+
+    doc._.doc_extension == "doc extension"
+    doc[0]._.token_extension == "token extension"
+    span_1._.span_extension == 'span_1 extension'
+    span_2._.span_extension == 'span_2 extension'
 
     assert doc.user_data[('._.', 'doc_extension', None, None)] == 'doc extension'
     assert doc.user_data[('._.', 'token_extension', 0, None)] == 'token extension'
@@ -206,3 +221,9 @@ def test_underscore_for_span(en_tokenizer) :
     span_2._.span_extension = 'updated span_2 extension'
     assert doc.user_data[('._.', 'span_extension', span_1.start_char, span_1.end_char, span_1.label, span_1.kb_id)] == 'span_1 extension'
     assert doc.user_data[('._.', 'span_extension', span_2.start_char, span_2.end_char, span_2.label, span_2.kb_id)] == 'updated span_2 extension'
+
+    doc._.doc_extension == "doc extension"
+    doc[0]._.token_extension == "token extension"
+    span_1._.span_extension == 'span_1 extension'
+    span_2._.span_extension == 'updated span_2 extension'
+

--- a/spacy/tests/doc/test_underscore.py
+++ b/spacy/tests/doc/test_underscore.py
@@ -171,3 +171,38 @@ def test_underscore_docstring(en_vocab):
     doc = Doc(en_vocab, words=["hello", "world"])
     assert test_method.__doc__ == "I am a docstring"
     assert doc._.test_docstrings.__doc__.rsplit(". ")[-1] == "I am a docstring"
+
+
+def test_underscore_for_span(en_tokenizer) :
+
+    Doc.set_extension(name='doc_extension', default=None)
+    Span.set_extension(name='span_extension', default=None)
+    Token.set_extension(name='token_extension', default=None)
+
+    text = 'Hello, world!'
+    doc = en_tokenizer(text)
+    span_1 = Span(doc, 0, 2, 'SPAN_1')
+    span_2 = Span(doc, 0, 2, 'SPAN_2')
+
+    doc._.doc_extension = "doc extension"
+    doc[0]._.token_extension = "token extension"
+    span_1._.span_extension = 'span_1 extension'
+    span_2._.span_extension =  'span_2 extension'
+
+    assert doc.user_data[('._.', 'span_extension', span_1.start_char, span_1.end_char, span_1.label, span_1.kb_id)] == 'span_1 extension'
+    assert doc.user_data[('._.', 'span_extension', span_2.start_char, span_2.end_char, span_2.label, span_2.kb_id)] == 'span_2 extension'
+
+    span_1.label_ = "NEW_LABEL"
+    assert doc.user_data[('._.', 'span_extension', span_1.start_char, span_1.end_char, span_1.label, span_1.kb_id)] == 'span_1 extension'
+    assert doc.user_data[('._.', 'span_extension', span_2.start_char, span_2.end_char, span_2.label, span_2.kb_id)] == 'span_2 extension'
+
+    span_1.kb_id_ = "KB_ID"
+    assert doc.user_data[('._.', 'span_extension', span_1.start_char, span_1.end_char, span_1.label, span_1.kb_id)] == 'span_1 extension'
+    assert doc.user_data[('._.', 'span_extension', span_2.start_char, span_2.end_char, span_2.label, span_2.kb_id)] == 'span_2 extension'
+
+    assert doc.user_data[('._.', 'doc_extension', None, None)] == 'doc extension'
+    assert doc.user_data[('._.', 'token_extension', 0, None)] == 'token extension'
+
+    span_2._.span_extension = 'updated span_2 extension'
+    assert doc.user_data[('._.', 'span_extension', span_1.start_char, span_1.end_char, span_1.label, span_1.kb_id)] == 'span_1 extension'
+    assert doc.user_data[('._.', 'span_extension', span_2.start_char, span_2.end_char, span_2.label, span_2.kb_id)] == 'updated span_2 extension'

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -215,7 +215,7 @@ cdef class Span:
     def _(self):
         """Custom extension attributes registered via `set_extension`."""
         return Underscore(Underscore.span_extensions, self,
-                          start=self.c.start_char, end=self.c.end_char)
+                          start=self.c.start_char, end=self.c.end_char, label = self.label, kb_id = self.kb_id)
 
     def as_doc(self, *, bint copy_user_data=False, array_head=None, array=None):
         """Create a `Doc` object with a copy of the `Span`'s data.
@@ -730,14 +730,22 @@ cdef class Span:
             return self.c.label
 
         def __set__(self, attr_t label):
+            old_label = self.c.label
             self.c.label = label
+            new = Underscore(Underscore.span_extensions, self, start=self.c.start_char, end=self.c.end_char, label = self.label, kb_id = self.kb_id)
+            old = Underscore(Underscore.span_extensions, self, start=self.c.start_char, end=self.c.end_char, label=old_label, kb_id=self.kb_id)
+            Underscore._replace_keys(old, new)
 
     property kb_id:
         def __get__(self):
             return self.c.kb_id
 
         def __set__(self, attr_t kb_id):
+            old_kb_id = self.c.kb_id
             self.c.kb_id = kb_id
+            new = Underscore(Underscore.span_extensions, self, start=self.c.start_char, end=self.c.end_char, label=self.label, kb_id=self.kb_id)
+            old = Underscore(Underscore.span_extensions, self, start=self.c.start_char, end=self.c.end_char, label=self.label, kb_id=old_kb_id)
+            Underscore._replace_keys(old, new)
 
     property ent_id:
         """RETURNS (uint64): The entity ID."""

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -730,22 +730,24 @@ cdef class Span:
             return self.c.label
 
         def __set__(self, attr_t label):
-            old_label = self.c.label
-            self.c.label = label
-            new = Underscore(Underscore.span_extensions, self, start=self.c.start_char, end=self.c.end_char, label = self.label, kb_id = self.kb_id)
-            old = Underscore(Underscore.span_extensions, self, start=self.c.start_char, end=self.c.end_char, label=old_label, kb_id=self.kb_id)
-            Underscore._replace_keys(old, new)
+            if label != self.c.label :
+                old_label = self.c.label
+                self.c.label = label
+                new = Underscore(Underscore.span_extensions, self, start=self.c.start_char, end=self.c.end_char, label = self.label, kb_id = self.kb_id)
+                old = Underscore(Underscore.span_extensions, self, start=self.c.start_char, end=self.c.end_char, label=old_label, kb_id=self.kb_id)
+                Underscore._replace_keys(old, new)
 
     property kb_id:
         def __get__(self):
             return self.c.kb_id
 
         def __set__(self, attr_t kb_id):
-            old_kb_id = self.c.kb_id
-            self.c.kb_id = kb_id
-            new = Underscore(Underscore.span_extensions, self, start=self.c.start_char, end=self.c.end_char, label=self.label, kb_id=self.kb_id)
-            old = Underscore(Underscore.span_extensions, self, start=self.c.start_char, end=self.c.end_char, label=self.label, kb_id=old_kb_id)
-            Underscore._replace_keys(old, new)
+            if kb_id != self.c.kb_id :
+                old_kb_id = self.c.kb_id
+                self.c.kb_id = kb_id
+                new = Underscore(Underscore.span_extensions, self, start=self.c.start_char, end=self.c.end_char, label=self.label, kb_id=self.kb_id)
+                old = Underscore(Underscore.span_extensions, self, start=self.c.start_char, end=self.c.end_char, label=self.label, kb_id=old_kb_id)
+                Underscore._replace_keys(old, new)
 
     property ent_id:
         """RETURNS (uint64): The entity ID."""

--- a/spacy/tokens/underscore.py
+++ b/spacy/tokens/underscore.py
@@ -11,7 +11,7 @@ class Underscore:
     span_extensions: Dict[Any, Any] = {}
     token_extensions: Dict[Any, Any] = {}
 
-    def __init__(self, extensions, obj, start=None, end=None):
+    def __init__(self, extensions, obj, start=None, end=None, label=None, kb_id=None):
         object.__setattr__(self, "_extensions", extensions)
         object.__setattr__(self, "_obj", obj)
         # Assumption is that for doc values, _start and _end will both be None
@@ -22,6 +22,12 @@ class Underscore:
         object.__setattr__(self, "_doc", obj.doc)
         object.__setattr__(self, "_start", start)
         object.__setattr__(self, "_end", end)
+        if label is not None or kb_id is not None:
+            # It is reasonably safe to assume that if label and kb_id are None,
+            # they were not passed to this function. Span.label and kb_id are
+            # converted to 0 in Span's c-tor and setters if they are None
+            object.__setattr__(self, "_label", label)
+            object.__setattr__(self, "_kb_id", kb_id)
 
     def __dir__(self):
         # Hack to enable autocomplete on custom extensions
@@ -75,7 +81,24 @@ class Underscore:
         return name in self._extensions
 
     def _get_key(self, name):
-        return ("._.", name, self._start, self._end)
+        if hasattr(self, "_label") :
+            return ("._.", name, self._start, self._end, self._label, self._kb_id)
+        else :
+            return ("._.", name, self._start, self._end)
+
+
+    @staticmethod
+    def _replace_keys(old_underscore, new_underscore):
+        """
+        This function is called by Span when its kb_id or label are re-assigned.
+        It checks if any user_data is stored for this span and replaces the keys
+        """
+        for name in old_underscore._extensions :
+            old_key = old_underscore._get_key(name)
+            new_key = new_underscore._get_key(name)
+            if old_key in old_underscore._doc.user_data and old_key != new_key:
+                old_underscore._doc.user_data[new_key] = old_underscore._doc.user_data.pop(old_key)
+
 
     @classmethod
     def get_state(cls):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->
Updated Underscore class to properly handle extension values for `Spans` with equal boundaries. 

Resolves issue https://github.com/explosion/spaCy/issues/9706


## Description
The change actually looks reasonably neat. Nothing changed for `Doc` or `Token`. The only thing that needed to be taken care of was the case when a `Span` that have data in `doc.user_data` had its `label` or `kb_id` updated. I also added a test.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
enhancement, new test

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
