### PR TITLE
Strong & weak Doc reference in Span

### DIFF
--- a/spacy/tests/doc/test_span_group.py
+++ b/spacy/tests/doc/test_span_group.py
@@ -1,0 +1,17 @@
+import pytest
+from spacy.tokens import Span
+
+@pytest.fixture
+def doc(en_tokenizer):
+    text = "0 1 2 3 4 5 6"
+    doc = en_tokenizer(text)
+    doc.spans['SPANS'] = [Span(doc, 0, 3, 'LABEL', kb_id = 'KB_ID'), Span(doc, 0, 4, 'LABEL', kb_id = 'KB_ID')]
+    return doc
+
+def test_span_group_assignment(doc) :
+    span_group = doc.spans['SPANS']
+    span = span_group[0]
+    span.label_ = 'NEW_LABEL'
+    span.kb_id_ = 'NEW_KB_ID'
+    assert span_group[0].label_ == 'NEW_LABEL'
+    assert span_group[0].kb_id_ == 'NEW_KB_ID'

--- a/spacy/tokens/span.pxd
+++ b/spacy/tokens/span.pxd
@@ -6,7 +6,9 @@ from ..structs cimport SpanC
 
 
 cdef class Span:
-    cdef readonly Doc doc
+    #cdef readonly Doc doc
+    cdef Doc _doc
+    cdef object _doc_ref
     cdef SpanC c
     cdef public _vector
     cdef public _vector_norm

--- a/spacy/tokens/span_group.pxd
+++ b/spacy/tokens/span_group.pxd
@@ -1,10 +1,12 @@
 from libcpp.vector cimport vector
-from ..structs cimport SpanC
+#from ..structs cimport SpanC
+from .span cimport Span
 
 cdef class SpanGroup:
     cdef public object _doc_ref
     cdef public str name
     cdef public dict attrs
-    cdef vector[SpanC] c
+    #cdef vector[SpanC] c
+    cdef list spans
 
-    cdef void push_back(self, SpanC span) nogil
+    #cdef void push_back(self, SpanC span) nogil


### PR DESCRIPTION
Changed `SpanGroup` to store spans in a python list. Have `Span` class contain a strong and a weak references to its `Doc`. Once `Span` is added to a `SpanGroup`, its strong reference is deleted to allow proper garbage collection. The weak reference is still there and `span.doc` works seamlessly. Once a `Span` is returned to the outside world, its strong reference is restored.

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Sorry, people, if I am being too overwhelming. I use `SpanGroups` a lot, and I would love to get it right. I like this solution better than `shared_ptr` because it is cleaner. But, on the other hand, having underlying container in a C-structure and being able to manipulate it in C doesn't hurt :)

The main change is in `span.pyx`:
```python
    @property
    def doc(self) -> Doc :
        if self._doc is not None :
            return self._doc
        else :
            doc = self._doc_ref()
            if doc is None :
                raise RuntimeError(Errors.E865)
            return doc

    def _set_doc(self):
        doc = self._doc_ref()
        if doc is None :
            raise RuntimeError(Errors.E865)
        self._doc = doc

    def _release_doc(self) :
        self._doc = None
```
`SpanGroup` calls `_release_doc()` when adding spans, and `_set_doc` in `__getter__`.

There is a syntactic drawback of this solution, that only affects cython methods that access `Span.doc`. I didn't manage to be able to make `Span.doc` property an inline C method, even though the documentation states that it is possible:
https://cython.readthedocs.io/en/latest/src/userguide/extension_types.html#c-inline-properties
So, to access `Span.doc`'s C structures, one would need to declare `cdef Doc doc = span.doc` first. and then access doc's cython stuff. This is not horrible, and is more efficient when `span.doc` is accessed in loops now when it is a property vs a cdef variable.

Another issue is this:

```python
    doc = nlp('Hello, world!')
    span_1 = Span(doc, 0, 2, 'SPAN_1')

    doc.spans['SPANS'] = [span_1] # Here, span_1 loses its strong reference to Doc because it is added to SpanGroup
    span_group = doc.spans['SPANS']

    del doc
    span_1.doc  ## Throws E865 even though span_1 is in the current scope
```
This issue can be dealt with either by documenting this behavior so that people understand, or create copies of `Spans` when adding them to `SpanGroup` and documenting that.

  Another useful application of this change to `Span` class is storing spans in `Underscore`. As I mentioned somewhere before, somehow garbage collection works even now, probably because `user_data` is a `dict`. I'm not very well familiar with python gc's internals and didn't really investigate this. But having smth like this:
  ```python
    def span_extension_setter(span, other_span) :
        other_span._release_doc()
        span._._value = other_span
    def span_extension_getter(span) :
        span._._value._set_doc()
        return span._._value
  ```
would ensure that spans assigned to `Underscore` do not cause GC issues.

The code I checked in is not 100% cleaned up, it is a proof of a concept. It you decide to go ahead with it,  I will do it properly. Don't want to waste time.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
