### PR TITLE
Displacy serve entity linking support without `manual=True` support.

### DIFF
--- a/spacy/displacy/__init__.py
+++ b/spacy/displacy/__init__.py
@@ -184,8 +184,12 @@ def parse_ents(doc: Doc, options: Dict[str, Any] = {}) -> Dict[str, Any]:
     doc (Doc): Document do parse.
     RETURNS (dict): Generated entities keyed by text (original text) and ents.
     """
+    kb_url_format_template = options.get("kb_url_format_template", None)
     ents = [
-        {"start": ent.start_char, "end": ent.end_char, "label": ent.label_}
+        {"start": ent.start_char, "end": ent.end_char, "label": ent.label_,
+         "kb_id": ent.kb_id_ if ent.kb_id_ else "",
+         "kb_url": kb_url_format_template.format(ent.kb_id_) if kb_url_format_template else "#"
+        }
         for ent in doc.ents
     ]
     if not ents:

--- a/spacy/displacy/__init__.py
+++ b/spacy/displacy/__init__.py
@@ -181,7 +181,8 @@ def parse_deps(orig_doc: Doc, options: Dict[str, Any] = {}) -> Dict[str, Any]:
 def parse_ents(doc: Doc, options: Dict[str, Any] = {}) -> Dict[str, Any]:
     """Generate named entities in [{start: i, end: i, label: 'label'}] format.
 
-    doc (Doc): Document do parse.
+    doc (Doc): Document to parse.
+    options (Dict[str, Any]): NER-specific visualisation options.
     RETURNS (dict): Generated entities keyed by text (original text) and ents.
     """
     kb_url_format_template = options.get("kb_url_format_template", None)

--- a/spacy/displacy/__init__.py
+++ b/spacy/displacy/__init__.py
@@ -186,9 +186,14 @@ def parse_ents(doc: Doc, options: Dict[str, Any] = {}) -> Dict[str, Any]:
     """
     kb_url_format_template = options.get("kb_url_format_template", None)
     ents = [
-        {"start": ent.start_char, "end": ent.end_char, "label": ent.label_,
-         "kb_id": ent.kb_id_ if ent.kb_id_ else "",
-         "kb_url": kb_url_format_template.format(ent.kb_id_) if kb_url_format_template else "#"
+        {
+            "start": ent.start_char,
+            "end": ent.end_char,
+            "label": ent.label_,
+            "kb_id": ent.kb_id_ if ent.kb_id_ else "",
+            "kb_url": kb_url_format_template.format(ent.kb_id_)
+            if kb_url_format_template
+            else "#",
         }
         for ent in doc.ents
     ]

--- a/spacy/displacy/__init__.py
+++ b/spacy/displacy/__init__.py
@@ -185,16 +185,14 @@ def parse_ents(doc: Doc, options: Dict[str, Any] = {}) -> Dict[str, Any]:
     options (Dict[str, Any]): NER-specific visualisation options.
     RETURNS (dict): Generated entities keyed by text (original text) and ents.
     """
-    kb_url_format_template = options.get("kb_url_format_template", None)
+    kb_url_template = options.get("kb_url_template", None)
     ents = [
         {
             "start": ent.start_char,
             "end": ent.end_char,
             "label": ent.label_,
             "kb_id": ent.kb_id_ if ent.kb_id_ else "",
-            "kb_url": kb_url_format_template.format(ent.kb_id_)
-            if kb_url_format_template
-            else "#",
+            "kb_url": kb_url_template.format(ent.kb_id_) if kb_url_template else "#",
         }
         for ent in doc.ents
     ]

--- a/spacy/tests/test_displacy.py
+++ b/spacy/tests/test_displacy.py
@@ -12,7 +12,25 @@ def test_displacy_parse_ents(en_vocab):
     ents = displacy.parse_ents(doc)
     assert isinstance(ents, dict)
     assert ents["text"] == "But Google is starting from behind "
-    assert ents["ents"] == [{"start": 4, "end": 10, "label": "ORG"}]
+    assert ents["ents"] == [{"start": 4, "end": 10, "label": "ORG", "kb_id": "", "kb_url": "#"}]
+
+    doc.ents = [Span(doc, 1, 2, label=doc.vocab.strings["ORG"], kb_id="Q95")]
+    ents = displacy.parse_ents(doc)
+    assert isinstance(ents, dict)
+    assert ents["text"] == "But Google is starting from behind "
+    assert ents["ents"] == [{"start": 4, "end": 10, "label": "ORG", "kb_id": "Q95", "kb_url": "#"}]
+
+
+def test_displacy_parse_ents_with_kb_id_options(en_vocab):
+    """Test that named entities with kb_id on a Doc are converted into displaCy's format."""
+    doc = Doc(en_vocab, words=["But", "Google", "is", "starting", "from", "behind"])
+    doc.ents = [Span(doc, 1, 2, label=doc.vocab.strings["ORG"], kb_id="Q95")]
+
+    ents = displacy.parse_ents(doc, {"kb_url_format_template": "https://www.wikidata.org/wiki/{}"})
+    assert isinstance(ents, dict)
+    assert ents["text"] == "But Google is starting from behind "
+    assert ents["ents"] == [{"start": 4, "end": 10, "label": "ORG",
+                             "kb_id": "Q95", "kb_url": "https://www.wikidata.org/wiki/Q95"}]
 
 
 def test_displacy_parse_deps(en_vocab):

--- a/spacy/tests/test_displacy.py
+++ b/spacy/tests/test_displacy.py
@@ -32,7 +32,7 @@ def test_displacy_parse_ents_with_kb_id_options(en_vocab):
     doc.ents = [Span(doc, 1, 2, label=doc.vocab.strings["ORG"], kb_id="Q95")]
 
     ents = displacy.parse_ents(
-        doc, {"kb_url_format_template": "https://www.wikidata.org/wiki/{}"}
+        doc, {"kb_url_template": "https://www.wikidata.org/wiki/{}"}
     )
     assert isinstance(ents, dict)
     assert ents["text"] == "But Google is starting from behind "

--- a/spacy/tests/test_displacy.py
+++ b/spacy/tests/test_displacy.py
@@ -1,8 +1,9 @@
 import pytest
+
 from spacy import displacy
 from spacy.displacy.render import DependencyRenderer, EntityRenderer
-from spacy.tokens import Span, Doc
 from spacy.lang.fa import Persian
+from spacy.tokens import Span, Doc
 
 
 def test_displacy_parse_ents(en_vocab):
@@ -12,13 +13,17 @@ def test_displacy_parse_ents(en_vocab):
     ents = displacy.parse_ents(doc)
     assert isinstance(ents, dict)
     assert ents["text"] == "But Google is starting from behind "
-    assert ents["ents"] == [{"start": 4, "end": 10, "label": "ORG", "kb_id": "", "kb_url": "#"}]
+    assert ents["ents"] == [
+        {"start": 4, "end": 10, "label": "ORG", "kb_id": "", "kb_url": "#"}
+    ]
 
     doc.ents = [Span(doc, 1, 2, label=doc.vocab.strings["ORG"], kb_id="Q95")]
     ents = displacy.parse_ents(doc)
     assert isinstance(ents, dict)
     assert ents["text"] == "But Google is starting from behind "
-    assert ents["ents"] == [{"start": 4, "end": 10, "label": "ORG", "kb_id": "Q95", "kb_url": "#"}]
+    assert ents["ents"] == [
+        {"start": 4, "end": 10, "label": "ORG", "kb_id": "Q95", "kb_url": "#"}
+    ]
 
 
 def test_displacy_parse_ents_with_kb_id_options(en_vocab):
@@ -26,11 +31,20 @@ def test_displacy_parse_ents_with_kb_id_options(en_vocab):
     doc = Doc(en_vocab, words=["But", "Google", "is", "starting", "from", "behind"])
     doc.ents = [Span(doc, 1, 2, label=doc.vocab.strings["ORG"], kb_id="Q95")]
 
-    ents = displacy.parse_ents(doc, {"kb_url_format_template": "https://www.wikidata.org/wiki/{}"})
+    ents = displacy.parse_ents(
+        doc, {"kb_url_format_template": "https://www.wikidata.org/wiki/{}"}
+    )
     assert isinstance(ents, dict)
     assert ents["text"] == "But Google is starting from behind "
-    assert ents["ents"] == [{"start": 4, "end": 10, "label": "ORG",
-                             "kb_id": "Q95", "kb_url": "https://www.wikidata.org/wiki/Q95"}]
+    assert ents["ents"] == [
+        {
+            "start": 4,
+            "end": 10,
+            "label": "ORG",
+            "kb_id": "Q95",
+            "kb_url": "https://www.wikidata.org/wiki/Q95",
+        }
+    ]
 
 
 def test_displacy_parse_deps(en_vocab):

--- a/website/docs/api/top-level.md
+++ b/website/docs/api/top-level.md
@@ -329,7 +329,7 @@ to add custom labels and their colors automatically.
 
 By default, displaCy links to `#` for entities without a `kb_id` set on their span. 
 If you wish to link an entity to their URL then consider using the `kb_url_template`
-option from above. For e.g. If the `kb_id` on a span is `Q95` and this is a Wikidata 
+option from above. For example if the `kb_id` on a span is `Q95` and this is a Wikidata 
 identifier then this option can be set to `https://www.wikidata.org/wiki/{}`.
 Clicking on your entity in the rendered HTML should redirect you to their Wikidata page,
 in this case `https://www.wikidata.org/wiki/Q95`.

--- a/website/docs/api/top-level.md
+++ b/website/docs/api/top-level.md
@@ -313,12 +313,12 @@ If a setting is not present in the options, the default value will be used.
 > displacy.serve(doc, style="ent", options=options)
 > ```
 
-| Name                                    | Description                                                                                                                                                                                                                                 |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ents`                                  | Entity types to highlight or `None` for all types (default). ~~Optional[List[str]]~~                                                                                                                                                        |
-| `colors`                                | Color overrides. Entity types should be mapped to color names or values. ~~Dict[str, str]~~                                                                                                                                                 |
-| `template` <Tag variant="new">2.2</Tag> | Optional template to overwrite the HTML used to render entity spans. Should be a format string and can use `{bg}`, `{text}` and `{label}`. See [`templates.py`](%%GITHUB_SPACY/spacy/displacy/templates.py) for examples. ~~Optional[str]~~ |
-| `kb_url_template`                       | Optional template to construct the KB url for the entity to link to. Expects a python f-string format with single field to fill in. ~~Optional[str]~~                                                                                       |
+| Name                                             | Description                                                                                                                                                                                                                                 |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ents`                                           | Entity types to highlight or `None` for all types (default). ~~Optional[List[str]]~~                                                                                                                                                        |
+| `colors`                                         | Color overrides. Entity types should be mapped to color names or values. ~~Dict[str, str]~~                                                                                                                                                 |
+| `template` <Tag variant="new">2.2</Tag>          | Optional template to overwrite the HTML used to render entity spans. Should be a format string and can use `{bg}`, `{text}` and `{label}`. See [`templates.py`](%%GITHUB_SPACY/spacy/displacy/templates.py) for examples. ~~Optional[str]~~ |
+| `kb_url_template` <Tag variant="new">3.2.1</Tag> | Optional template to construct the KB url for the entity to link to. Expects a python f-string format with single field to fill in. ~~Optional[str]~~                                                                                       |
 
 By default, displaCy comes with colors for all entity types used by
 [spaCy's trained pipelines](/models). If you're using custom entity types, you
@@ -327,12 +327,13 @@ or pipeline package can also expose a
 [`spacy_displacy_colors` entry point](/usage/saving-loading#entry-points-displacy)
 to add custom labels and their colors automatically.
 
-By default, displaCy links to `#` for entities without a `kb_id` set on their span. 
-If you wish to link an entity to their URL then consider using the `kb_url_template`
-option from above. For example if the `kb_id` on a span is `Q95` and this is a Wikidata 
-identifier then this option can be set to `https://www.wikidata.org/wiki/{}`.
-Clicking on your entity in the rendered HTML should redirect you to their Wikidata page,
-in this case `https://www.wikidata.org/wiki/Q95`.
+By default, displaCy links to `#` for entities without a `kb_id` set on their
+span. If you wish to link an entity to their URL then consider using the
+`kb_url_template` option from above. For example if the `kb_id` on a span is
+`Q95` and this is a Wikidata identifier then this option can be set to
+`https://www.wikidata.org/wiki/{}`. Clicking on your entity in the rendered HTML
+should redirect you to their Wikidata page, in this case
+`https://www.wikidata.org/wiki/Q95`.
 
 ## registry {#registry source="spacy/util.py" new="3"}
 
@@ -420,10 +421,10 @@ finished. To log each training step, a
 and the accuracy scores on the development set.
 
 The built-in, default logger is the ConsoleLogger, which prints results to the
-console in tabular format. The 
+console in tabular format. The
 [spacy-loggers](https://github.com/explosion/spacy-loggers) package, included as
-a dependency of spaCy, enables other loggers: currently it provides one that sends
-results to a [Weights & Biases](https://www.wandb.com/) dashboard.
+a dependency of spaCy, enables other loggers: currently it provides one that
+sends results to a [Weights & Biases](https://www.wandb.com/) dashboard.
 
 Instead of using one of the built-in loggers, you can
 [implement your own](/usage/training#custom-logging).
@@ -473,7 +474,6 @@ Note that the cumulative loss keeps increasing within one epoch, but should
 start decreasing across epochs.
 
  </Accordion>
-
 
 ## Readers {#readers}
 

--- a/website/docs/api/top-level.md
+++ b/website/docs/api/top-level.md
@@ -332,7 +332,7 @@ If you wish to link an entity to their URL then consider using the `kb_url_templ
 option from above. For e.g. If the `kb_id` on a span is `Q95` and this is a Wikidata 
 identifier then this option can be set to `https://www.wikidata.org/wiki/{}`.
 Clicking on your entity in the rendered HTML should redirect you to their Wikidata page,
-in this case `https://www.wikidata.org/wiki/Q95`
+in this case `https://www.wikidata.org/wiki/Q95`.
 
 ## registry {#registry source="spacy/util.py" new="3"}
 

--- a/website/docs/api/top-level.md
+++ b/website/docs/api/top-level.md
@@ -318,6 +318,7 @@ If a setting is not present in the options, the default value will be used.
 | `ents`                                  | Entity types to highlight or `None` for all types (default). ~~Optional[List[str]]~~                                                                                                                                                        |
 | `colors`                                | Color overrides. Entity types should be mapped to color names or values. ~~Dict[str, str]~~                                                                                                                                                 |
 | `template` <Tag variant="new">2.2</Tag> | Optional template to overwrite the HTML used to render entity spans. Should be a format string and can use `{bg}`, `{text}` and `{label}`. See [`templates.py`](%%GITHUB_SPACY/spacy/displacy/templates.py) for examples. ~~Optional[str]~~ |
+| `kb_url_template`                       | Optional template to construct the KB url for the entity to link to. Expects a python f-string format with single field to fill in. ~~Optional[str]~~                                                                                       |
 
 By default, displaCy comes with colors for all entity types used by
 [spaCy's trained pipelines](/models). If you're using custom entity types, you
@@ -325,6 +326,13 @@ can use the `colors` setting to add your own colors for them. Your application
 or pipeline package can also expose a
 [`spacy_displacy_colors` entry point](/usage/saving-loading#entry-points-displacy)
 to add custom labels and their colors automatically.
+
+By default, displaCy links to `#` for entities without a `kb_id` set on their span. 
+If you wish to link an entity to their URL then consider using the `kb_url_template`
+option from above. For e.g. If the `kb_id` on a span is `Q95` and this is a Wikidata 
+identifier then this option can be set to `https://www.wikidata.org/wiki/{}`.
+Clicking on your entity in the rendered HTML should redirect you to their Wikidata page,
+in this case `https://www.wikidata.org/wiki/Q95`
 
 ## registry {#registry source="spacy/util.py" new="3"}
 


### PR DESCRIPTION
The PR adds support for visualizing kb_id on entities when run via displacy.serve

## Description
The PR adds support for visualizing kb_id on entities when run via displacy.serve. The recent changes from [PR 9199](https://github.com/explosion/spaCy/pull/9199) only address rendered html produced with the `manual=True` option set. I believe the same should also be afforded when passing `Doc` objects with entities that have the `kb_id` set. 

For the `kb_url` to be set, one can pass the `kb_url_format_template` (can be named better?) in the `options` argument of `displace.serve`. If not set, `kb_url` defaults to `#` similar to the setting in the above linked PR. Please suggest if there is a better way to do this.

### Types of change
Enhancement

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
