### PR TITLE
Update Tokenizer documentation 

### DIFF
--- a/spacy/tokenizer.pyx
+++ b/spacy/tokenizer.pyx
@@ -45,10 +45,12 @@ cdef class Tokenizer:
             `re.compile(string).search` to match suffixes.
         `infix_finditer` (callable): A function matching the signature of
             `re.compile(string).finditer` to find infixes.
-        token_match (callable): A boolean function matching strings to be
+        token_match (callable): A function matching the signature of
+            `re.compile(string).match`, for matching strings to be
             recognized as tokens.
-        url_match (callable): A boolean function matching strings to be
-            recognized as tokens after considering prefixes and suffixes.
+        url_match (callable): A function matching the signature of
+            `re.compile(string).match`, for matching strings to be
+            recognized as urls.
 
         EXAMPLE:
             >>> tokenizer = Tokenizer(nlp.vocab)


### PR DESCRIPTION
Update the description of `token_match` and `url_match` arguments for Tokenizer
Currently the callables are described as 

> A boolean function

which is not enough as those functions would be serialized with `_get_regex_pattern`. 

## Description
Description changed to match the correct requirement - result of `re.compile(string).match`

### Types of change
a change to the documentation

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [X] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [X] My changes don't require a change to the documentation, or if they do, I've added all required information.
