### PR TITLE
Pin mypy to 0.910 until there is a compatible pydantic version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ pytest-timeout>=1.3.0,<2.0.0
 mock>=2.0.0,<3.0.0
 flake8>=3.8.0,<3.10.0
 hypothesis>=3.27.0,<7.0.0
-mypy>=0.910
+mypy==0.910
 types-dataclasses>=0.1.3; python_version < "3.7"
 types-mock>=0.1.1
 types-requests


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Since mypy 0.920 was released, mypy fails with:

```
setup.cfg:140: error: Error importing plugin "pydantic.mypy": cannot import name 'TypeVarDef' from 'mypy.types' (/Users/daniel/.pyenv/versions/torch-1.10/lib/python3.9/site-packages/mypy/types.cpython-39-darwin.so)
```

It seems that we need to wait for a version of pydantic that is compatible
with this new mypy release. So, pin the mypy version for the time being.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
