### PR TITLE
Handle "_" value for token pos in conllu data

### DIFF
--- a/spacy/training/converters/conllu_to_docs.py
+++ b/spacy/training/converters/conllu_to_docs.py
@@ -188,11 +188,10 @@ def conllu_sentence_to_doc(
         id_ = int(id_) - 1
         head = (int(head) - 1) if head not in ("0", "_") else id_
         tag = pos if tag == "_" else tag
+        pos = pos if pos != "_" else ""
         morph = morph if morph != "_" else ""
         dep = "ROOT" if dep == "root" else dep
         lemmas.append(lemma)
-        if pos == "_":
-            pos = ""
         poses.append(pos)
         tags.append(tag)
         morphs.append(morph)

--- a/spacy/training/converters/conllu_to_docs.py
+++ b/spacy/training/converters/conllu_to_docs.py
@@ -191,6 +191,8 @@ def conllu_sentence_to_doc(
         morph = morph if morph != "_" else ""
         dep = "ROOT" if dep == "root" else dep
         lemmas.append(lemma)
+        if pos == "_":
+            pos = ""
         poses.append(pos)
         tags.append(tag)
         morphs.append(morph)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
If a conllu file has no data for a token's part of speech, `conllu_sentence_to_doc()` throws an error that `'_'` is not a valid upos value.  
 To allow tokens with no pos data, this PR changes the "_" to "" to allow pos assignment during `spacy convert` from conllu. It's a small change that will help our users with less than complete and polished treebanks. 

### Types of change
Handles an exception when UD has a upos value of `"_"`.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
