### PR TITLE
Fix type of lexeme.rank

### DIFF
--- a/spacy/lexeme.pyi
+++ b/spacy/lexeme.pyi
@@ -19,7 +19,7 @@ class Lexeme:
     @property
     def vector_norm(self) -> float: ...
     vector: Floats1d
-    rank: str
+    rank: int
     sentiment: float
     @property
     def orth_(self) -> str: ...


### PR DESCRIPTION

## Description
On recent PRs, the CI is failing over a `lexeme.rank` assignement. I actually think the CI is right, and that the `pyi` file is wrong, though I don't understand why we didn't see this error before and why it only occurs in older Python versions.

Anyway, let's see if this fix makes the CI happy, because I can't reproduce the original error locally.

### Types of change
bug fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
