### PR TITLE
Add a few docs to the default_config.cfg

### DIFF
--- a/spacy/default_config.cfg
+++ b/spacy/default_config.cfg
@@ -75,6 +75,7 @@ patience = 1600
 # memory and shuffled within the training loop. -1 means stream train corpus
 # rather than loading in memory with no shuffling within the training loop.
 max_epochs = 0
+# Maximum number of update steps to train for. 0 means an unlimited number of steps.
 max_steps = 20000
 eval_frequency = 200
 # Control how scores are printed and checkpoints are evaluated.

--- a/spacy/default_config.cfg
+++ b/spacy/default_config.cfg
@@ -68,7 +68,8 @@ seed = ${system.seed}
 gpu_allocator = ${system.gpu_allocator}
 dropout = 0.1
 accumulate_gradient = 1
-# Controls early-stopping. 0 disables early stopping.
+# Controls early-stopping, i.e., the number of steps to continue without
+# improvement before stopping. 0 disables early stopping.
 patience = 1600
 # Number of epochs. 0 means unlimited. If >= 0, train corpus is loaded once in
 # memory and shuffled within the training loop. -1 means stream train corpus


### PR DESCRIPTION
Added a few lines of explanation for `patience`, `max_epochs`, and `max_steps`. 

## Description

Even if their definitions are defined in the [config training docs](https://spacy.io/api/data-formats#config-training) and [FAQ](https://github.com/explosion/spaCy/discussions/8226) it's not the first thing they encounter. Usually, [this training config page](https://spacy.io/usage/training#config) is what they see. I just copied over some definitions to the config file itself. 

Ref: #7450 #7465


### Types of change

Doc change

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
