### PR TITLE
Speed up the StateC::L feature function

### DIFF
--- a/spacy/pipeline/_parser_internals/_state.pxd
+++ b/spacy/pipeline/_parser_internals/_state.pxd
@@ -188,20 +188,17 @@ cdef cppclass StateC:
 
         # Work backwards through left-arcs to find the arc at the
         # requested index more quickly.
-        cdef int child = -1
         cdef size_t child_index = 0
         it = this._left_arcs.const_rbegin()
-        while it != this._left_arcs.rend() and child_index != idx:
+        while it != this._left_arcs.rend():
             arc = deref(it)
             if arc.head == head and arc.child != -1 and arc.child < head:
-                child = arc.child
                 child_index += 1
+                if child_index == idx:
+                    return arc.child
             incr(it)
 
-        if child_index == idx:
-            return child
-        else:
-            return -1
+        return -1
 
     int R(int head, int idx) nogil const:
         if idx < 1 or this._right_arcs.size() == 0:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

`StateC::L` gets the n-th most-recent left-arc with a particular head.

Before this change, `StateC::L` would construct a vector of all left-arcs
with the given head and then pick the n-th most recent from that vector.
Since the number of left-arcs strongly correlates with the doc length
and the feature is constructed for every transition, this can make
transition-parsing quadratic.

With this change `StateC::L`:

- Searches left-arcs backwards.
- Stops early when the n-th matching transition is found.
- Does not construct a vector (reducing memory pressure).

This change doesn't avoid the linear search when the transition that is
queried does not occur in the left-arcs. Regardless, performance
improves quite a bit with very long docs (benchmarked by repeating
a Wikipedia paragraph N times):

Before:

```
   N  Time

 400   3.3
 800   5.4
1600  11.6
3200  30.7
```

After:

```
   N  Time

 400   3.2
 800   5.0
1600   9.5
3200  23.2
```

We can probably do better with more tailored data structures, but I
first wanted to make a low-impact PR.

Found while investigating #9858.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Performance improvement.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.