### PR TITLE
Check for assets with size of 0 bytes

### DIFF
--- a/spacy/cli/project/assets.py
+++ b/spacy/cli/project/assets.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Optional
 from pathlib import Path
 from wasabi import msg
+import os
 import re
 import shutil
 import requests
@@ -129,10 +130,17 @@ def fetch_asset(
         the asset failed.
     """
     dest_path = (project_path / dest).resolve()
-    if dest_path.exists() and checksum:
+    if dest_path.exists():
         # If there's already a file, check for checksum
-        if checksum == get_checksum(dest_path):
-            msg.good(f"Skipping download with matching checksum: {dest}")
+        if checksum:
+            if checksum == get_checksum(dest_path):
+                msg.good(f"Skipping download with matching checksum: {dest}")
+                return
+        else:
+            # If there's not a checksum, make sure the file is a possibly valid size
+            if os.path.getsize(dest_path) == 0:
+                os.remove(dest_path)
+                msg.warn(f"Asset exists but with size of 0 bytes, deleting: {dest}")
     # We might as well support the user here and create parent directories in
     # case the asset dir isn't listed as a dir to create in the project.yml
     if not dest_path.parent.exists():

--- a/spacy/cli/project/assets.py
+++ b/spacy/cli/project/assets.py
@@ -139,8 +139,8 @@ def fetch_asset(
         else:
             # If there's not a checksum, make sure the file is a possibly valid size
             if os.path.getsize(dest_path) == 0:
-                os.remove(dest_path)
                 msg.warn(f"Asset exists but with size of 0 bytes, deleting: {dest}")
+                os.remove(dest_path)
     # We might as well support the user here and create parent directories in
     # case the asset dir isn't listed as a dir to create in the project.yml
     if not dest_path.parent.exists():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
I ran into an issue where, if downloading an asset (without a checksum) failed in a way that left a 0-byte file on disk, the next run of `spacy project assets` would assume the asset doesn't need to be redownloaded. 0-byte files are probably never what we want, so if that's the case, let's delete it so it will reattempt the download (and warn the user):

![Screen Shot 2022-01-11 at 15 42 13](https://user-images.githubusercontent.com/397565/148954339-e8971f99-c660-43c3-8a13-e8003750d0ab.png)

### Types of change
Bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
