### PR TITLE
Rename FACILITY to FAC in color list

### DIFF
--- a/spacy/displacy/render.py
+++ b/spacy/displacy/render.py
@@ -18,7 +18,7 @@ DEFAULT_LABEL_COLORS = {
     "LOC": "#ff9561",
     "PERSON": "#aa9cfc",
     "NORP": "#c887fb",
-    "FACILITY": "#9cc9cc",
+    "FAC": "#9cc9cc",
     "EVENT": "#ffeb80",
     "LAW": "#ff8197",
     "LANGUAGE": "#ff8197",


### PR DESCRIPTION
displaCy's color list includes FACILITY instead of FAC, but the English models use FAC. (Based on the presence of FACILITY in some places maybe it used to be the other way?) 

This change makes the colors match the model.
<!--- Provide a general summary of your changes in the title. -->

I noticed this because of #10042, which I think is reporting this issue.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
