### PR TITLE
Fix special tokenization cases not applied when adjacent to an infix #10086

### DIFF
--- a/spacy/tests/tokenizer/test_tokenizer.py
+++ b/spacy/tests/tokenizer/test_tokenizer.py
@@ -13,6 +13,16 @@ from spacy.vocab import Vocab
 from spacy.symbols import ORTH
 
 
+@pytest.mark.issue(10086)
+def test_issue10086():
+    """Test special case works when part of infix substring."""
+    text = "No--don't see"
+    tokenizer = English().tokenizer
+    doc = tokenizer(text)
+    assert "n't" in [w.text for w in doc]
+    assert "do" in [w.text for w in doc]
+
+
 @pytest.mark.issue(743)
 def test_issue743():
     doc = Doc(Vocab(), ["hello", "world"])

--- a/spacy/tokenizer.pyx
+++ b/spacy/tokenizer.pyx
@@ -602,8 +602,7 @@ cdef class Tokenizer:
             self.mem.free(stale_special)
         self._rules[string] = substrings
         self._flush_cache()
-        if self.find_prefix(string) or self.find_infix(string) or self.find_suffix(string) or " " in string:
-            self._special_matcher.add(string, None, self._tokenize_affixes(string, False))
+        self._special_matcher.add(string, None, self._tokenize_affixes(string, False))
 
     def _reload_special_cases(self):
         self._flush_cache()


### PR DESCRIPTION
## Description
Fix tokenizer special cases not being applied when adjacent to an infix. Removes a condition checking that tokenization special cases contain a prefix, suffix, infix, or `" "` prior to adding the case to the tokenizer's `_special_matcher` PhraseMatcher. This condition only impacted the second pass for special tokenization rules, so it caused some special tokenization rules to be skipped when they were adjacent to an infix while they were applied correctly otherwise.

If there is a different preferred way of correcting this behavior, then please feel free to alter or reject this PR.

### Types of change
Bug fix.

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
