### PR TITLE
Docker Image for Website Dev

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:11.15.0 
+
+WORKDIR /spacy-io
+
+RUN npm install -g gatsby-cli@2.7.4
+
+COPY package.json .
+COPY package-lock.json . 
+
+RUN npm install
+
+# This is so the installed node_modules will be up one directory
+# from where a user mounts files, so that they don't accidentally mount
+# their own node_modules from a different build
+# https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders
+WORKDIR /spacy-io/website/

--- a/website/README.md
+++ b/website/README.md
@@ -554,7 +554,7 @@ extensions for your code editor. The
 [`.prettierrc`](https://github.com/explosion/spaCy/tree/master/website/.prettierrc)
 file in the root defines the settings used in this codebase.
 
-## Building & Developing the Site with Docker {#docker}
+## Building & developing the site with Docker {#docker}
 Sometimes it's hard to get a local environment working due to rapid updates to node dependencies,
 so it may be easier to use docker for building the docs.
 

--- a/website/README.md
+++ b/website/README.md
@@ -554,6 +554,40 @@ extensions for your code editor. The
 [`.prettierrc`](https://github.com/explosion/spaCy/tree/master/website/.prettierrc)
 file in the root defines the settings used in this codebase.
 
+## Building & Developing the Site with Docker {#docker}
+Sometimes it's hard to get a local environment working due to rapid updates to node dependencies,
+so it may be easier to use docker for building the docs.
+
+If you'd like to do this,
+**be sure you do *not* include your local `node_modules` folder**,
+since there are some dependencies that need to be built for the image system. 
+Rename it before using.
+
+```bash
+docker run -it \
+  -v $(pwd):/spacy-io/website \
+  -p 8000:8000 \
+  ghcr.io/explosion/spacy-io \
+  gatsby develop -H 0.0.0.0
+```
+
+This will allow you to access the built website at http://0.0.0.0:8000/ 
+in your browser, and still edit code in your editor while having the site 
+reflect those changes.
+
+**Note**: On M1 Macs you may need to the image tagged `arm64` (`ghcr.io/explosion/spacy-io:arm64`),
+otherwise you'll see `qemu` segfault during the build.
+
+### Building the Docker Image {#docker-build}
+
+If you'd like to build the image locally, you can do so like this:
+
+```bash
+docker build -t spacy-io .
+```
+
+This will take some time, so if you want to use the prebuilt image you'll save a bit of time.
+
 ## Markdown reference {#markdown}
 
 All page content and page meta lives in the `.md` files in the `/docs`

--- a/website/README.md
+++ b/website/README.md
@@ -575,8 +575,10 @@ This will allow you to access the built website at http://0.0.0.0:8000/
 in your browser, and still edit code in your editor while having the site 
 reflect those changes.
 
-**Note**: On M1 Macs you may need to the image tagged `arm64` (`ghcr.io/explosion/spacy-io:arm64`),
-otherwise you'll see `qemu` segfault during the build.
+**Note**: If you're working on a Mac with an M1 processor, 
+you might see segfault errors from `qemu` if you use the default image. 
+To fix this use the arm64 tagged image in the docker run command 
+(ghcr.io/explosion/spacy-io:arm64).
 
 ### Building the Docker image {#docker-build}
 

--- a/website/README.md
+++ b/website/README.md
@@ -578,7 +578,7 @@ reflect those changes.
 **Note**: On M1 Macs you may need to the image tagged `arm64` (`ghcr.io/explosion/spacy-io:arm64`),
 otherwise you'll see `qemu` segfault during the build.
 
-### Building the Docker Image {#docker-build}
+### Building the Docker image {#docker-build}
 
 If you'd like to build the image locally, you can do so like this:
 

--- a/website/README.md
+++ b/website/README.md
@@ -577,7 +577,7 @@ reflect those changes.
 
 **Note**: If you're working on a Mac with an M1 processor, 
 you might see segfault errors from `qemu` if you use the default image. 
-To fix this use the arm64 tagged image in the docker run command 
+To fix this use the `arm64` tagged image in the `docker run` command 
 (ghcr.io/explosion/spacy-io:arm64).
 
 ### Building the Docker image {#docker-build}


### PR DESCRIPTION
Adds a `Dockerfile` for a repeatable build of the website with a working version of node/npm and instructions for accessing the images through the github container registry for others to use.

### Types of change
Documentation

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
