### PR TITLE
Update typing hints

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ include_package_data = true
 python_requires = >=3.6
 setup_requires =
     cython>=0.25,<3.0
-    numpy>=1.15.0
+    numpy>=1.21.0
     # We also need our Cython packages here to compile against
     cymem>=2.0.2,<2.1.0
     preshed>=3.0.2,<3.1.0
@@ -55,7 +55,7 @@ install_requires =
     pathy>=0.3.5
     # Third-party dependencies
     tqdm>=4.38.0,<5.0.0
-    numpy>=1.15.0
+    numpy>=1.21.0
     requests>=2.13.0,<3.0.0
     pydantic>=1.7.4,!=1.8,!=1.8.1,<1.9.0
     jinja2

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ include_package_data = true
 python_requires = >=3.6
 setup_requires =
     cython>=0.25,<3.0
-    numpy>=1.21.0
+    numpy>=1.15.0
     # We also need our Cython packages here to compile against
     cymem>=2.0.2,<2.1.0
     preshed>=3.0.2,<3.1.0
@@ -55,7 +55,7 @@ install_requires =
     pathy>=0.3.5
     # Third-party dependencies
     tqdm>=4.38.0,<5.0.0
-    numpy>=1.21.0
+    numpy>=1.15.0
     requests>=2.13.0,<3.0.0
     pydantic>=1.7.4,!=1.8,!=1.8.1,<1.9.0
     jinja2

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -522,7 +522,7 @@ class Language:
         requires: Iterable[str] = SimpleFrozenList(),
         retokenizes: bool = False,
         func: Optional["Pipe"] = None,
-    ) -> Callable:
+    ) -> Callable[..., Any]:
         """Register a new pipeline component. Can be used for stateless function
         components that don't require a separate factory. Can be used as a
         decorator on a function or classmethod, or called as a function with the

--- a/spacy/matcher/dependencymatcher.pyi
+++ b/spacy/matcher/dependencymatcher.pyi
@@ -1,0 +1,56 @@
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from spacy.vocab import Vocab
+from spacy.matcher.matcher import Matcher
+from spacy.tokens.doc import Doc
+from spacy.tokens.span import Span
+
+class DependencyMatcher:
+    """Match dependency parse tree based on pattern rules."""
+
+    _patterns: Dict[str, List[Any]]
+    _raw_patterns: Dict[str, List[Any]]
+    _tokens_to_key: Dict[str, List[Any]]
+    _root: Dict[str, List[Any]]
+    _tree: Dict[str, List[Any]]
+    _callbacks: Dict[Any, Callable[[DependencyMatcher, Doc, int, List[Tuple[int, List[int]]]], Any]]
+    _ops: Dict[str, Any]
+    vocab: Vocab
+    _matcher: Matcher
+    def __init__(self, vocab: Vocab, *, validate: bool = ...) -> None: ...
+    def __reduce__(
+        self,
+    ) -> Tuple[
+        Callable[[Vocab, Dict[str, Any], Dict[str, Callable[..., Any]]], DependencyMatcher],
+        Tuple[
+            Vocab,
+            Dict[str, List[Any]],
+            Dict[
+                str,
+                Callable[[DependencyMatcher, Doc, int, List[Tuple[int, List[int]]]], Any],
+            ],
+        ],
+        None,
+        None,
+    ]: ...
+    def __len__(self) -> int: ...
+    def __contains__(self, key: Union[str, int]) -> bool: ...
+    def add(
+        self,
+        key: Union[str, int],
+        patterns: List[List[Dict[str, Any]]],
+        *,
+        on_match: Optional[Callable[[DependencyMatcher, Doc, int, List[Tuple[int, List[int]]]], Any]] = ...
+    ) -> None: ...
+    def has_key(self, key: Union[str, int]) -> bool: ...
+    def get(
+        self, key: Union[str, int], default: Optional[Any] = ...
+    ) -> Tuple[
+        Optional[Callable[[DependencyMatcher, Doc, int, List[Tuple[int, List[int]]]], Any]],
+        List[List[Dict[str, Any]]],
+    ]: ...
+    def remove(self, key: Union[str, int]) -> None: ...
+    def __call__(self, doclike: Union[Doc, Span]) -> List[Tuple[int, List[int]]]: ...
+
+def unpickle_matcher(
+    vocab: Vocab, patterns: Dict[str, Any], callbacks: Dict[str, Callable[..., Any]]
+) -> DependencyMatcher: ...

--- a/spacy/matcher/dependencymatcher.pyi
+++ b/spacy/matcher/dependencymatcher.pyi
@@ -1,8 +1,8 @@
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
-from spacy.vocab import Vocab
-from spacy.matcher.matcher import Matcher
-from spacy.tokens.doc import Doc
-from spacy.tokens.span import Span
+from .matcher import Matcher
+from ..vocab import Vocab
+from ..tokens.doc import Doc
+from ..tokens.span import Span
 
 class DependencyMatcher:
     """Match dependency parse tree based on pattern rules."""
@@ -12,7 +12,9 @@ class DependencyMatcher:
     _tokens_to_key: Dict[str, List[Any]]
     _root: Dict[str, List[Any]]
     _tree: Dict[str, List[Any]]
-    _callbacks: Dict[Any, Callable[[DependencyMatcher, Doc, int, List[Tuple[int, List[int]]]], Any]]
+    _callbacks: Dict[
+        Any, Callable[[DependencyMatcher, Doc, int, List[Tuple[int, List[int]]]], Any]
+    ]
     _ops: Dict[str, Any]
     vocab: Vocab
     _matcher: Matcher
@@ -20,13 +22,17 @@ class DependencyMatcher:
     def __reduce__(
         self,
     ) -> Tuple[
-        Callable[[Vocab, Dict[str, Any], Dict[str, Callable[..., Any]]], DependencyMatcher],
+        Callable[
+            [Vocab, Dict[str, Any], Dict[str, Callable[..., Any]]], DependencyMatcher
+        ],
         Tuple[
             Vocab,
             Dict[str, List[Any]],
             Dict[
                 str,
-                Callable[[DependencyMatcher, Doc, int, List[Tuple[int, List[int]]]], Any],
+                Callable[
+                    [DependencyMatcher, Doc, int, List[Tuple[int, List[int]]]], Any
+                ],
             ],
         ],
         None,
@@ -39,13 +45,17 @@ class DependencyMatcher:
         key: Union[str, int],
         patterns: List[List[Dict[str, Any]]],
         *,
-        on_match: Optional[Callable[[DependencyMatcher, Doc, int, List[Tuple[int, List[int]]]], Any]] = ...
+        on_match: Optional[
+            Callable[[DependencyMatcher, Doc, int, List[Tuple[int, List[int]]]], Any]
+        ] = ...
     ) -> None: ...
     def has_key(self, key: Union[str, int]) -> bool: ...
     def get(
         self, key: Union[str, int], default: Optional[Any] = ...
     ) -> Tuple[
-        Optional[Callable[[DependencyMatcher, Doc, int, List[Tuple[int, List[int]]]], Any]],
+        Optional[
+            Callable[[DependencyMatcher, Doc, int, List[Tuple[int, List[int]]]], Any]
+        ],
         List[List[Dict[str, Any]]],
     ]: ...
     def remove(self, key: Union[str, int]) -> None: ...

--- a/spacy/matcher/matcher.pyi
+++ b/spacy/matcher/matcher.pyi
@@ -1,4 +1,16 @@
-from typing import Any, List, Dict, Literal, Tuple, Optional, Callable, Union, Iterator, Iterable, overload
+from typing import (
+    Any,
+    List,
+    Dict,
+    Tuple,
+    Optional,
+    Callable,
+    Union,
+    Iterator,
+    Iterable,
+    overload,
+)
+from ..compat import Literal
 from ..vocab import Vocab
 from ..tokens import Doc, Span
 
@@ -12,7 +24,9 @@ class Matcher:
         key: Union[str, int],
         patterns: List[List[Dict[str, Any]]],
         *,
-        on_match: Optional[Callable[[Matcher, Doc, int, List[Tuple[Any, ...]]], Any]] = ...,
+        on_match: Optional[
+            Callable[[Matcher, Doc, int, List[Tuple[Any, ...]]], Any]
+        ] = ...,
         greedy: Optional[str] = ...
     ) -> None: ...
     def remove(self, key: str) -> None: ...
@@ -26,7 +40,9 @@ class Matcher:
         batch_size: int = ...,
         return_matches: bool = ...,
         as_tuples: bool = ...,
-    ) -> Union[Iterator[Tuple[Tuple[Doc, Any], Any]], Iterator[Tuple[Doc, Any]], Iterator[Doc]]: ...
+    ) -> Union[
+        Iterator[Tuple[Tuple[Doc, Any], Any]], Iterator[Tuple[Doc, Any]], Iterator[Doc]
+    ]: ...
     @overload
     def __call__(
         self,

--- a/spacy/matcher/matcher.pyi
+++ b/spacy/matcher/matcher.pyi
@@ -1,15 +1,5 @@
-from typing import (
-    Any,
-    List,
-    Dict,
-    Tuple,
-    Optional,
-    Callable,
-    Union,
-    Iterator,
-    Iterable,
-    overload,
-)
+from typing import Any, List, Dict, Tuple, Optional, Callable, Union
+from typing import Iterator, Iterable, overload
 from ..compat import Literal
 from ..vocab import Vocab
 from ..tokens import Doc, Span

--- a/spacy/matcher/matcher.pyi
+++ b/spacy/matcher/matcher.pyi
@@ -1,4 +1,4 @@
-from typing import Any, List, Dict, Tuple, Optional, Callable, Union, Iterator, Iterable
+from typing import Any, List, Dict, Literal, Tuple, Optional, Callable, Union, Iterator, Iterable, overload
 from ..vocab import Vocab
 from ..tokens import Doc, Span
 
@@ -12,9 +12,7 @@ class Matcher:
         key: Union[str, int],
         patterns: List[List[Dict[str, Any]]],
         *,
-        on_match: Optional[
-            Callable[[Matcher, Doc, int, List[Tuple[Any, ...]]], Any]
-        ] = ...,
+        on_match: Optional[Callable[[Matcher, Doc, int, List[Tuple[Any, ...]]], Any]] = ...,
         greedy: Optional[str] = ...
     ) -> None: ...
     def remove(self, key: str) -> None: ...
@@ -28,15 +26,23 @@ class Matcher:
         batch_size: int = ...,
         return_matches: bool = ...,
         as_tuples: bool = ...,
-    ) -> Union[
-        Iterator[Tuple[Tuple[Doc, Any], Any]], Iterator[Tuple[Doc, Any]], Iterator[Doc]
-    ]: ...
+    ) -> Union[Iterator[Tuple[Tuple[Doc, Any], Any]], Iterator[Tuple[Doc, Any]], Iterator[Doc]]: ...
+    @overload
     def __call__(
         self,
         doclike: Union[Doc, Span],
         *,
-        as_spans: bool = ...,
+        as_spans: Literal[False] = ...,
         allow_missing: bool = ...,
         with_alignments: bool = ...
-    ) -> Union[List[Tuple[int, int, int]], List[Span]]: ...
+    ) -> List[Tuple[int, int, int]]: ...
+    @overload
+    def __call__(
+        self,
+        doclike: Union[Doc, Span],
+        *,
+        as_spans: Literal[True],
+        allow_missing: bool = ...,
+        with_alignments: bool = ...
+    ) -> List[Span]: ...
     def _normalize_key(self, key: Any) -> Any: ...

--- a/spacy/matcher/phrasematcher.pyi
+++ b/spacy/matcher/phrasematcher.pyi
@@ -1,6 +1,6 @@
-from typing import List, Literal, Tuple, Union, Optional, Callable, Any, Dict, overload
-
-from . import Matcher
+from typing import List, Tuple, Union, Optional, Callable, Any, Dict, overload
+from ..compat import Literal
+from .matcher import Matcher
 from ..vocab import Vocab
 from ..tokens import Doc, Span
 

--- a/spacy/matcher/phrasematcher.pyi
+++ b/spacy/matcher/phrasematcher.pyi
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Union, Optional, Callable, Any, Dict
+from typing import List, Literal, Tuple, Union, Optional, Callable, Any, Dict, overload
 
 from . import Matcher
 from ..vocab import Vocab
@@ -21,9 +21,17 @@ class PhraseMatcher:
         ] = ...,
     ) -> None: ...
     def remove(self, key: str) -> None: ...
+    @overload
     def __call__(
         self,
         doclike: Union[Doc, Span],
         *,
-        as_spans: bool = ...,
-    ) -> Union[List[Tuple[int, int, int]], List[Span]]: ...
+        as_spans: Literal[False] = ...,
+    ) -> List[Tuple[int, int, int]]: ...
+    @overload
+    def __call__(
+        self,
+        doclike: Union[Doc, Span],
+        *,
+        as_spans: Literal[True],
+    ) -> List[Span]: ...

--- a/spacy/tokens/doc.pyi
+++ b/spacy/tokens/doc.pyi
@@ -11,7 +11,6 @@ from ..vocab import Vocab
 from .underscore import Underscore
 from pathlib import Path
 import numpy as np
-import numpy.typing as npt
 
 class DocMethod(Protocol):
     def __call__(self: Doc, *args: Any, **kwargs: Any) -> Any: ...  # type: ignore[misc]
@@ -27,7 +26,7 @@ class Doc:
     user_hooks: Dict[str, Callable[..., Any]]
     user_token_hooks: Dict[str, Callable[..., Any]]
     user_span_hooks: Dict[str, Callable[..., Any]]
-    tensor: npt.NDArray[np.float_]
+    tensor: np.ndarray[Any, np.dtype[np.float_]]
     user_data: Dict[str, Any]
     has_unknown_spaces: bool
     _context: Any
@@ -145,7 +144,7 @@ class Doc:
     ) -> Doc: ...
     def to_array(
         self, py_attr_ids: Union[int, str, List[Union[int, str]]]
-    ) -> npt.NDArray[np.float_]: ...
+    ) -> np.ndarray[Any, np.dtype[np.float_]]: ...
     @staticmethod
     def from_docs(
         docs: List[Doc],

--- a/spacy/tokens/doc.pyi
+++ b/spacy/tokens/doc.pyi
@@ -10,7 +10,8 @@ from ..lexeme import Lexeme
 from ..vocab import Vocab
 from .underscore import Underscore
 from pathlib import Path
-import numpy
+import numpy as np
+import numpy.typing as npt
 
 class DocMethod(Protocol):
     def __call__(self: Doc, *args: Any, **kwargs: Any) -> Any: ...  # type: ignore[misc]
@@ -26,7 +27,7 @@ class Doc:
     user_hooks: Dict[str, Callable[..., Any]]
     user_token_hooks: Dict[str, Callable[..., Any]]
     user_span_hooks: Dict[str, Callable[..., Any]]
-    tensor: numpy.ndarray
+    tensor: npt.NDArray[np.float_]
     user_data: Dict[str, Any]
     has_unknown_spaces: bool
     _context: Any
@@ -144,7 +145,7 @@ class Doc:
     ) -> Doc: ...
     def to_array(
         self, py_attr_ids: Union[int, str, List[Union[int, str]]]
-    ) -> numpy.ndarray: ...
+    ) -> npt.NDArray[np.float_]: ...
     @staticmethod
     def from_docs(
         docs: List[Doc],

--- a/spacy/tokens/underscore.py
+++ b/spacy/tokens/underscore.py
@@ -1,9 +1,12 @@
-from typing import Dict, Any, List, Optional, Tuple, Union
+from typing import Dict, Any, List, Optional, Tuple, Union, TYPE_CHECKING
 import functools
 import copy
-from . import Doc, Span, Token
-
 from ..errors import Errors
+
+if TYPE_CHECKING:
+    from .doc import Doc
+    from .span import Span
+    from .token import Token
 
 
 class Underscore:
@@ -12,14 +15,14 @@ class Underscore:
     span_extensions: Dict[Any, Any] = {}
     token_extensions: Dict[Any, Any] = {}
     _extensions: Dict[str, Any]
-    _obj: Union[Doc, Span, Token]
+    _obj: Union["Doc", "Span", "Token"]
     _start: Optional[int]
     _end: Optional[int]
 
     def __init__(
         self,
         extensions: Dict[str, Any],
-        obj: Union[Doc, Span, Token],
+        obj: Union["Doc", "Span", "Token"],
         start: Optional[int] = None,
         end: Optional[int] = None,
     ):

--- a/spacy/tokens/underscore.py
+++ b/spacy/tokens/underscore.py
@@ -67,7 +67,7 @@ class Underscore:
                 return new_default
             return default
 
-    def __setattr__(self, name: str, value: Any) -> Optional[Any]:
+    def __setattr__(self, name: str, value: Any):
         if name not in self._extensions:
             raise AttributeError(Errors.E047.format(name=name))
         default, method, getter, setter = self._extensions[name]
@@ -76,7 +76,7 @@ class Underscore:
         else:
             self._doc.user_data[self._get_key(name)] = value
 
-    def set(self, name: str, value: Any) -> Optional[Any]:
+    def set(self, name: str, value: Any):
         return self.__setattr__(name, value)
 
     def get(self, name: str) -> Any:
@@ -93,7 +93,9 @@ class Underscore:
         return cls.token_extensions, cls.span_extensions, cls.doc_extensions
 
     @classmethod
-    def load_state(cls, state: Tuple[Dict[Any, Any], Dict[Any, Any], Dict[Any, Any]]) -> None:
+    def load_state(
+        cls, state: Tuple[Dict[Any, Any], Dict[Any, Any], Dict[Any, Any]]
+    ) -> None:
         cls.token_extensions, cls.span_extensions, cls.doc_extensions = state
 
 

--- a/spacy/tokens/underscore.py
+++ b/spacy/tokens/underscore.py
@@ -1,6 +1,7 @@
-from typing import Dict, Any
+from typing import Dict, Any, List, Optional, Tuple, Union
 import functools
 import copy
+from . import Doc, Span, Token
 
 from ..errors import Errors
 
@@ -10,8 +11,18 @@ class Underscore:
     doc_extensions: Dict[Any, Any] = {}
     span_extensions: Dict[Any, Any] = {}
     token_extensions: Dict[Any, Any] = {}
+    _extensions: Dict[str, Any]
+    _obj: Union[Doc, Span, Token]
+    _start: Optional[int]
+    _end: Optional[int]
 
-    def __init__(self, extensions, obj, start=None, end=None):
+    def __init__(
+        self,
+        extensions: Dict[str, Any],
+        obj: Union[Doc, Span, Token],
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+    ):
         object.__setattr__(self, "_extensions", extensions)
         object.__setattr__(self, "_obj", obj)
         # Assumption is that for doc values, _start and _end will both be None
@@ -23,12 +34,12 @@ class Underscore:
         object.__setattr__(self, "_start", start)
         object.__setattr__(self, "_end", end)
 
-    def __dir__(self):
+    def __dir__(self) -> List[str]:
         # Hack to enable autocomplete on custom extensions
         extensions = list(self._extensions.keys())
         return ["set", "get", "has"] + extensions
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         if name not in self._extensions:
             raise AttributeError(Errors.E046.format(name=name))
         default, method, getter, setter = self._extensions[name]
@@ -56,7 +67,7 @@ class Underscore:
                 return new_default
             return default
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name: str, value: Any) -> Optional[Any]:
         if name not in self._extensions:
             raise AttributeError(Errors.E047.format(name=name))
         default, method, getter, setter = self._extensions[name]
@@ -65,28 +76,28 @@ class Underscore:
         else:
             self._doc.user_data[self._get_key(name)] = value
 
-    def set(self, name, value):
+    def set(self, name: str, value: Any) -> Optional[Any]:
         return self.__setattr__(name, value)
 
-    def get(self, name):
+    def get(self, name: str) -> Any:
         return self.__getattr__(name)
 
-    def has(self, name):
+    def has(self, name: str) -> bool:
         return name in self._extensions
 
-    def _get_key(self, name):
+    def _get_key(self, name: str) -> Tuple[str, str, Optional[int], Optional[int]]:
         return ("._.", name, self._start, self._end)
 
     @classmethod
-    def get_state(cls):
+    def get_state(cls) -> Tuple[Dict[Any, Any], Dict[Any, Any], Dict[Any, Any]]:
         return cls.token_extensions, cls.span_extensions, cls.doc_extensions
 
     @classmethod
-    def load_state(cls, state):
+    def load_state(cls, state: Tuple[Dict[Any, Any], Dict[Any, Any], Dict[Any, Any]]) -> None:
         cls.token_extensions, cls.span_extensions, cls.doc_extensions = state
 
 
-def get_ext_args(**kwargs):
+def get_ext_args(**kwargs: Any):
     """Validate and convert arguments. Reused in Doc, Token and Span."""
     default = kwargs.get("default")
     getter = kwargs.get("getter")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->
This PR is a follow up on #8427. Improves typing hints for `Matcher`, `PhraseMatcher`, `Language` and `Doc`, and adds new ones for `Underscore` extensions and `DependencyMatcher`.

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Typing hints for the following classes have been created/updated:
### `- Matcher` and `PhraseMatcher`
Overloaded return type of `Matcher.__call__()` depending on whether `as_spans` is `True` or `False`.

### `- Language`
Fixed return type for `Language.component()` decorator.

### `- Doc`
Fixed `np.ndarray` type for `Doc.tensor`.

### `- DependencyMatcher`
Adds typing hint support for `DependencyMatcher`.

### `- Underscore`
Treats underscore extension values as `Any` types. Typing hints for underscore extensions were not set before and all accesses to `Object._.extension` were of type `Unknown`. With the current implementation, access to any extension returns an object of type `Any`, so the user can redefine the type upon retrieval, e.g.
```Python
from typing import List
from spacy.tokens import Span

if not Span.has_extension("myext"):
  Span.set_extension("myext", default=None)

def update_extension(span: Span):
  if span._.myext is None:
    span._.myext = []
  strlist: List[str] = span._.myext # This will not trigger a type check error anymore
  strlist.append("whatever")
```

  

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Enhancement of typing hints compatibility.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
