### PR TITLE
Clarify Span.ents documentation

### DIFF
--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -471,8 +471,9 @@ cdef class Span:
 
     @property
     def ents(self):
-        """The named entities in the span. Returns a tuple of named entity
-        `Span` objects, if the entity recognizer has been applied.
+        """The named entities in the span. It only includes entities that fall
+        completely within the span. Returns a tuple of named entity `Span`
+        objects, if the entity recognizer has been applied.
 
         RETURNS (tuple): Entities in the span, one `Span` per entity.
 

--- a/website/docs/api/span.md
+++ b/website/docs/api/span.md
@@ -257,8 +257,8 @@ shape `(N, M)`, where `N` is the length of the document. The values will be
 
 ## Span.ents {#ents tag="property" new="2.0.13" model="ner"}
 
-The named entities in the span. Returns a tuple of named entity `Span` objects,
-if the entity recognizer has been applied.
+The named entities that fall completely within the span. Returns a tuple of
+`Span` objects.
 
 > #### Example
 >


### PR DESCRIPTION
Ref: #10135

## Description

Retain current behaviour. Span.ents will only include entities within
said span. You can't get tokens outside of the original span.

### Types of change

Documentation update

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
