### PR TITLE
fix: Add missing comma to `examples.py`

### DIFF
--- a/spacy/lang/xx/examples.py
+++ b/spacy/lang/xx/examples.py
@@ -59,7 +59,7 @@ sentences = [
     "Czy w ciągu ostatnich 48 godzin spożyłeś leki zawierające paracetamol?",
     "Kto ma ochotę zapoznać się z innymi niż w książkach przygodami Muminków i ich przyjaciół, temu polecam komiks Tove Jansson „Muminki i morze”.",
     "Apple está querendo comprar uma startup do Reino Unido por 100 milhões de dólares.",
-    "Carros autônomos empurram a responsabilidade do seguro para os fabricantes.."
+    "Carros autônomos empurram a responsabilidade do seguro para os fabricantes..",
     "São Francisco considera banir os robôs de entrega que andam pelas calçadas.",
     "Londres é a maior cidade do Reino Unido.",
     # Translations from English:


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title. -->

## Description
* This comma has been most probably been left out unintentionally, leading to string concatenation between the two consecutive lines. This issue has been found automatically using a regular expression.

### Types of change
It's a small bugfix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
