### PR TITLE
Add shuffle parameter to Corpus API docs

### DIFF
--- a/website/docs/api/corpus.md
+++ b/website/docs/api/corpus.md
@@ -44,6 +44,7 @@ streaming.
 | `max_length`    | Maximum document length. Longer documents will be split into sentences, if sentence boundaries are available. Defaults to `0` for no limit. ~~int~~                                                                                                                                      |
 | `limit`         | Limit corpus to a subset of examples, e.g. for debugging. Defaults to `0` for no limit. ~~int~~                                                                                                                                                                                          |
 | `augmenter`     | Apply some simply data augmentation, where we replace tokens with variations. This is especially useful for punctuation and case replacement, to help generalize beyond corpora that don't have smart-quotes, or only have smart quotes, etc. Defaults to `None`. ~~Optional[Callable]~~ |
+| `shuffle`       | Whether to shuffle the examples. Defaults to `False`. |
 
 ```python
 %%GITHUB_SPACY/spacy/training/corpus.py
@@ -79,6 +80,7 @@ train/test skew.
 | `max_length`    | Maximum document length. Longer documents will be split into sentences, if sentence boundaries are available. Defaults to `0` for no limit. ~~int~~ |
 | `limit`         | Limit corpus to a subset of examples, e.g. for debugging. Defaults to `0` for no limit. ~~int~~                                                     |
 | `augmenter`     | Optional data augmentation callback. ~~Callable[[Language, Example], Iterable[Example]]~~                                                           |
+| `shuffle`       | Whether to shuffle the examples. Defaults to `False`. ~~bool~~                                                                                      |
 
 ## Corpus.\_\_call\_\_ {#call tag="method"}
 

--- a/website/docs/api/corpus.md
+++ b/website/docs/api/corpus.md
@@ -44,7 +44,6 @@ streaming.
 | `max_length`    | Maximum document length. Longer documents will be split into sentences, if sentence boundaries are available. Defaults to `0` for no limit. ~~int~~                                                                                                                                      |
 | `limit`         | Limit corpus to a subset of examples, e.g. for debugging. Defaults to `0` for no limit. ~~int~~                                                                                                                                                                                          |
 | `augmenter`     | Apply some simply data augmentation, where we replace tokens with variations. This is especially useful for punctuation and case replacement, to help generalize beyond corpora that don't have smart-quotes, or only have smart quotes, etc. Defaults to `None`. ~~Optional[Callable]~~ |
-| `shuffle`       | Whether to shuffle the examples. Defaults to `False`. |
 
 ```python
 %%GITHUB_SPACY/spacy/training/corpus.py


### PR DESCRIPTION
Update docs for `Corpus` to include the `shuffle` parameter (cf. https://github.com/explosion/spaCy/blob/master/spacy/training/corpus.py#L103)

### Types of change

Documentation change

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
