### PR TITLE
Add github actions for slow and gpu tests

### DIFF
--- a/.github/workflows/gputests.yml
+++ b/.github/workflows/gputests.yml
@@ -1,0 +1,19 @@
+on:
+  schedule:
+    - cron: '0 0 * * 1'
+
+jobs:
+  weekly-gputests:
+    strategy:
+      matrix:
+        branch: [master, develop, v4]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger buildkite build
+        uses: buildkite/trigger-pipeline-action@v1.2.0
+        env:
+          PIPELINE: explosion-ai/spacy-gpu-test-suite
+          BRANCH: ${{ matrix.branch }}
+          MESSAGE: ":github: Weekly GPU tests - triggered from a GitHub Action"
+        secrets:
+          BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.BUILDKITE_SECRET }}

--- a/.github/workflows/gputests.yml
+++ b/.github/workflows/gputests.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: '0 0 * * 1'
+    - cron: '0 1 * * MON'
 
 jobs:
   weekly-gputests:
@@ -12,8 +12,8 @@ jobs:
       - name: Trigger buildkite build
         uses: buildkite/trigger-pipeline-action@v1.2.0
         env:
-          PIPELINE: explosion-ai/spacy-gpu-test-suite
+          PIPELINE: explosion-ai/spacy-slow-gpu-tests
           BRANCH: ${{ matrix.branch }}
-          MESSAGE: ":github: Weekly GPU tests - triggered from a GitHub Action"
+          MESSAGE: ":github: Weekly GPU + slow tests - triggered from a GitHub Action"
         secrets:
           BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.BUILDKITE_SECRET }}

--- a/.github/workflows/slowtests.yml
+++ b/.github/workflows/slowtests.yml
@@ -1,0 +1,19 @@
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  daily-slowtests:
+    strategy:
+      matrix:
+        branch: [master, develop, v4]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger buildkite build
+        uses: buildkite/trigger-pipeline-action@v1.2.0
+        env:
+          PIPELINE: explosion-ai/spacy-slow-tests
+          BRANCH: ${{ matrix.branch }}
+          MESSAGE: ":github: Daily slow tests - triggered from a GitHub Action"
+        secrets:
+          BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.BUILDKITE_SECRET }}

--- a/.github/workflows/slowtests.yml
+++ b/.github/workflows/slowtests.yml
@@ -9,7 +9,20 @@ jobs:
         branch: [master, develop, v4]
     runs-on: ubuntu-latest
     steps:
+      - name: Get commits from past 24 hours
+        id: check_commits
+        run: |
+          today=$(date '+%Y-%m-%d %H:%M:%S')
+          yesterday=$(date -v-1d '+%Y-%m-%d %H:%M:%S')
+          if git log --after=$yesterday --before=$today | grep commit ; then
+            echo "::set-output name=run_tests::true"
+          else
+            echo "::set-output name=run_tests::false"
+          fi
+
       - name: Trigger buildkite build
+        needs: check_commits
+        if: needs.check_commits.outputs.run_tests == 'true'
         uses: buildkite/trigger-pipeline-action@v1.2.0
         env:
           PIPELINE: explosion-ai/spacy-slow-tests


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
Adds two github actions to trigger matrices of automated buildkite builds on the `master`, `develop`, and `v4` branches - daily for slow tests, weekly for GPU tests

### Types of change
Tests only

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
