### PR TITLE
fix the syntax for the slow/gpu test crons

### DIFF
--- a/.github/workflows/gputests.yml
+++ b/.github/workflows/gputests.yml
@@ -1,3 +1,5 @@
+name: Weekly GPU tests
+
 on:
   schedule:
     - cron: '0 1 * * MON'
@@ -15,5 +17,4 @@ jobs:
           PIPELINE: explosion-ai/spacy-slow-gpu-tests
           BRANCH: ${{ matrix.branch }}
           MESSAGE: ":github: Weekly GPU + slow tests - triggered from a GitHub Action"
-        secrets:
           BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.BUILDKITE_SECRET }}

--- a/.github/workflows/slowtests.yml
+++ b/.github/workflows/slowtests.yml
@@ -1,3 +1,5 @@
+name: Daily slow tests
+
 on:
   schedule:
     - cron: '0 0 * * *'
@@ -21,12 +23,10 @@ jobs:
           fi
 
       - name: Trigger buildkite build
-        needs: check_commits
-        if: needs.check_commits.outputs.run_tests == 'true'
+        if: steps.check_commits.outputs.run_tests == 'true'
         uses: buildkite/trigger-pipeline-action@v1.2.0
         env:
           PIPELINE: explosion-ai/spacy-slow-tests
           BRANCH: ${{ matrix.branch }}
           MESSAGE: ":github: Daily slow tests - triggered from a GitHub Action"
-        secrets:
           BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.BUILDKITE_SECRET }}


### PR DESCRIPTION
Based on this morning's [errors](https://github.com/explosion/spaCy/actions/runs/1815380183), hopefully fixing the syntax
