### PR TITLE
Remove daily/weekly tests for develop branch

### DIFF
--- a/.github/workflows/gputests.yml
+++ b/.github/workflows/gputests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [master, develop, v4]
+        branch: [master, v4]
     runs-on: ubuntu-latest
     steps:
       - name: Trigger buildkite build

--- a/.github/workflows/slowtests.yml
+++ b/.github/workflows/slowtests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [master, develop, v4]
+        branch: [master, v4]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION

## Description
`develop` will not be an active branch anymore in the near future, so canceling the daily/weekly tests to avoid spending unnecessary resources.

### Types of change
repo org, automated tests

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
