### PR TITLE
Add `path.mkdir` to custom component examples of `to_disk`

### DIFF
--- a/website/docs/usage/processing-pipelines.md
+++ b/website/docs/usage/processing-pipelines.md
@@ -1083,12 +1083,15 @@ on [serialization methods](/usage/saving-loading/#serialization-methods).
 ```python
 ### Custom serialization methods {highlight="6-7,9-11"}
 import srsly
+from spacy.util import ensure_path
 
 class AcronymComponent:
     # other methods here...
 
     def to_disk(self, path, exclude=tuple()):
-        path.mkdir()
+        path = ensure_path(path)
+        if not path.exists():
+            path.mkdir()
         srsly.write_json(path / "data.json", self.data)
 
     def from_disk(self, path, exclude=tuple()):

--- a/website/docs/usage/processing-pipelines.md
+++ b/website/docs/usage/processing-pipelines.md
@@ -1081,7 +1081,7 @@ on [serialization methods](/usage/saving-loading/#serialization-methods).
 > directory.
 
 ```python
-### Custom serialization methods {highlight="6-7,9-11"}
+### Custom serialization methods {highlight="7-11,13-15"}
 import srsly
 from spacy.util import ensure_path
 

--- a/website/docs/usage/processing-pipelines.md
+++ b/website/docs/usage/processing-pipelines.md
@@ -1088,6 +1088,7 @@ class AcronymComponent:
     # other methods here...
 
     def to_disk(self, path, exclude=tuple()):
+        path.mkdir()
         srsly.write_json(path / "data.json", self.data)
 
     def from_disk(self, path, exclude=tuple()):

--- a/website/docs/usage/saving-loading.md
+++ b/website/docs/usage/saving-loading.md
@@ -202,7 +202,7 @@ the data to and from a JSON file.
 > rules _with_ the component data.
 
 ```python
-### {highlight="14-19,21-26"}
+### {highlight="16-23,25-30"}
 from spacy.util import ensure_path
 
 @Language.factory("my_component")

--- a/website/docs/usage/saving-loading.md
+++ b/website/docs/usage/saving-loading.md
@@ -218,6 +218,7 @@ class CustomComponent:
 
     def to_disk(self, path, exclude=tuple()):
         # This will receive the directory path + /my_component
+        path.mkdir()
         data_path = path / "data.json"
         with data_path.open("w", encoding="utf8") as f:
             f.write(json.dumps(self.data))
@@ -468,6 +469,7 @@ component exposes a `to_disk` method, it will be called with the disk path.
 
 ```python
 def to_disk(self, path, exclude=tuple()):
+    path.mkdir()
     snek_path = path / "snek.txt"
     with snek_path.open("w", encoding="utf8") as snek_file:
         snek_file.write(self.snek)

--- a/website/docs/usage/saving-loading.md
+++ b/website/docs/usage/saving-loading.md
@@ -202,7 +202,9 @@ the data to and from a JSON file.
 > rules _with_ the component data.
 
 ```python
-### {highlight="14-18,20-25"}
+### {highlight="14-19,21-26"}
+from spacy.util import ensure_path
+
 @Language.factory("my_component")
 class CustomComponent:
     def __init__(self):
@@ -218,7 +220,9 @@ class CustomComponent:
 
     def to_disk(self, path, exclude=tuple()):
         # This will receive the directory path + /my_component
-        path.mkdir()
+        path = ensure_path(path)
+        if not path.exists():
+            path.mkdir()
         data_path = path / "data.json"
         with data_path.open("w", encoding="utf8") as f:
             f.write(json.dumps(self.data))
@@ -468,8 +472,12 @@ pipeline package. When you save out a pipeline using `nlp.to_disk` and the
 component exposes a `to_disk` method, it will be called with the disk path.
 
 ```python
+from spacy.util import ensure_path
+
 def to_disk(self, path, exclude=tuple()):
-    path.mkdir()
+    path = ensure_path(path)
+    if not path.exists():
+        path.mkdir()
     snek_path = path / "snek.txt"
     with snek_path.open("w", encoding="utf8") as snek_file:
         snek_file.write(self.snek)


### PR DESCRIPTION
Updates docs to add `path.mkdir()` to the custom component examples that include a `to_disk` method.

### Types of change
Documentation

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
