### PR TITLE
Clean up loggers docs

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -566,9 +566,6 @@ class Errors(metaclass=ErrorsWithCodes):
     E879 = ("Unexpected type for 'spans' data. Provide a dictionary mapping keys to "
             "a list of spans, with each span represented by a tuple (start_char, end_char). "
             "The tuple can be optionally extended with a label and a KB ID.")
-    E880 = ("The 'wandb' library could not be found - did you install it? "
-            "Alternatively, specify the 'ConsoleLogger' in the 'training.logger' "
-            "config section, instead of the 'WandbLogger'.")
     E884 = ("The pipeline could not be initialized because the vectors "
             "could not be found at '{vectors}'. If your pipeline was already "
             "initialized/trained before, call 'resume_training' instead of 'initialize', "

--- a/website/docs/api/legacy.md
+++ b/website/docs/api/legacy.md
@@ -248,23 +248,6 @@ the others, but may not be as accurate, especially if texts are short.
 
 ## Loggers {#loggers}
 
-These functions are available from `@spacy.registry.loggers`.
+Logging utilities for spaCy are implemented in the [`spacy-loggers`](https://github.com/explosion/spacy-loggers) repo, and the functions are typically available from `@spacy.registry.loggers`.
 
-### spacy.WandbLogger.v1 {#WandbLogger_v1}
-
-The first version of the [`WandbLogger`](/api/top-level#WandbLogger) did not yet
-support the `log_dataset_dir` and `model_log_interval` arguments.
-
-> #### Example config
->
-> ```ini
-> [training.logger]
-> @loggers = "spacy.WandbLogger.v1"
-> project_name = "monitor_spacy_training"
-> remove_config_values = ["paths.train", "paths.dev", "corpora.train.path", "corpora.dev.path"]
-> ```
->
-> | Name                   | Description                                                                                                                           |
-> | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-> | `project_name`         | The name of the project in the Weights & Biases interface. The project will be created automatically if it doesn't exist yet. ~~str~~ |
-> | `remove_config_values` | A list of values to include from the config before it is uploaded to W&B (default: empty). ~~List[str]~~                              |
+More documentation can be found in that repo's [readme](https://github.com/explosion/spacy-loggers/blob/main/README.md) file.

--- a/website/docs/api/top-level.md
+++ b/website/docs/api/top-level.md
@@ -423,7 +423,7 @@ and the accuracy scores on the development set.
 The built-in, default logger is the ConsoleLogger, which prints results to the
 console in tabular format. The
 [spacy-loggers](https://github.com/explosion/spacy-loggers) package, included as
-a dependency of spaCy, enables other loggers: currently it provides one that
+a dependency of spaCy, enables other loggers, such as one that
 sends results to a [Weights & Biases](https://www.wandb.com/) dashboard.
 
 Instead of using one of the built-in loggers, you can


### PR DESCRIPTION

## Description
Further cleanup after we previously moved the logger functionality to https://github.com/explosion/spacy-loggers

### Types of change
docs fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
