### PR TITLE
hook up meta in load_model_from_config

### DIFF
--- a/spacy/util.py
+++ b/spacy/util.py
@@ -485,13 +485,16 @@ def load_model_from_path(
     config_path = model_path / "config.cfg"
     overrides = dict_to_dot(config)
     config = load_config(config_path, overrides=overrides)
-    nlp = load_model_from_config(config, vocab=vocab, disable=disable, exclude=exclude)
+    nlp = load_model_from_config(
+        config, vocab=vocab, disable=disable, exclude=exclude, meta=meta
+    )
     return nlp.from_disk(model_path, exclude=exclude, overrides=overrides)
 
 
 def load_model_from_config(
     config: Union[Dict[str, Any], Config],
     *,
+    meta: Dict[str, Any] = SimpleFrozenDict(),
     vocab: Union["Vocab", bool] = True,
     disable: Iterable[str] = SimpleFrozenList(),
     exclude: Iterable[str] = SimpleFrozenList(),
@@ -529,6 +532,7 @@ def load_model_from_config(
         exclude=exclude,
         auto_fill=auto_fill,
         validate=validate,
+        meta=meta,
     )
     return nlp
 


### PR DESCRIPTION


## Description
Even though it was in the docstring, `load_model_from_config` wasn't taking in a `meta` argument, which meant that `load_model_from_path` wasn't using the input arg `meta` either.

### Types of change
bug fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
