### PR TITLE
Fix Entity Linker with tokenization mismatches (fix #9575)

### DIFF
--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -363,8 +363,7 @@ class EntityLinker(TrainablePipe):
             out = self.model.ops.alloc2f(*sentence_encodings.shape)
             return 0, out
 
-        if (selected_encodings.shape != entity_encodings.shape and
-                selected_encodings.size > 0 and entity_encodings.size > 0):
+        if selected_encodings.shape != entity_encodings.shape:
             err = Errors.E147.format(
                 method="get_loss", msg="gold entities do not match up"
             )

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -234,10 +234,10 @@ class EntityLinker(TrainablePipe):
         nO = self.kb.entity_vector_length
         doc_sample = []
         vector_sample = []
-        for example in islice(get_examples(), 10):
-            doc = example.x
+        for eg in islice(get_examples(), 10):
+            doc = eg.x
             if self.use_gold_ents:
-                ents, _ = example.get_aligned_ents_and_ner()
+                ents, _ = eg.get_aligned_ents_and_ner()
                 doc.ents = ents
             doc_sample.append(doc)
             vector_sample.append(self.model.ops.alloc1f(nO))

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -358,6 +358,11 @@ class EntityLinker(TrainablePipe):
         entity_encodings = self.model.ops.asarray(entity_encodings, dtype="float32")
         selected_encodings = sentence_encodings[keep_ents]
 
+        # if there are no matches, short circuit
+        if not keep_ents:
+            out = self.model.ops.alloc2f(*sentence_encodings.shape)
+            return 0, out
+
         if (selected_encodings.shape != entity_encodings.shape and
                 selected_encodings.size > 0 and entity_encodings.size > 0):
             err = Errors.E147.format(

--- a/spacy/tests/pipeline/test_entity_linker.py
+++ b/spacy/tests/pipeline/test_entity_linker.py
@@ -14,7 +14,7 @@ from spacy.pipeline.legacy import EntityLinker_v1
 from spacy.pipeline.tok2vec import DEFAULT_TOK2VEC_MODEL
 from spacy.scorer import Scorer
 from spacy.tests.util import make_tempdir
-from spacy.tokens import Span
+from spacy.tokens import Span, Doc
 from spacy.training import Example
 from spacy.util import ensure_path
 from spacy.vocab import Vocab
@@ -1070,4 +1070,33 @@ def test_no_gold_ents(patterns):
     nlp.add_pipe("sentencizer", first=True)
 
     # this will run the pipeline on the examples and shouldn't crash
+    results = nlp.evaluate(train_examples)
+
+def test_tokenization_mismatch():
+    # https://github.com/explosion/spaCy/issues/9575
+    nlp = English()
+    # include a matching entity so that update isn't skipped
+    doc1 = Doc(nlp.vocab, words=["Kirby", "123456"], spaces=[True, False], ents=["B-CHARACTER", "B-CARDINAL"])
+    doc2 = Doc(nlp.vocab, words=["Kirby", "123", "456"], spaces=[True, False, False], ents=["B-CHARACTER", "B-CARDINAL", "B-CARDINAL"])
+
+    eg = Example(doc1, doc2)
+    train_examples = [eg]
+    vector_length = 3
+
+    def create_kb(vocab):
+        # create placeholder KB
+        mykb = KnowledgeBase(vocab, entity_vector_length=vector_length)
+        mykb.add_entity(entity="Q613241", freq=12, entity_vector=[6, -4, 3])
+        mykb.add_alias("Kirby", ["Q613241"], [0.9])
+        return mykb
+
+    entity_linker = nlp.add_pipe("entity_linker", last=True)
+    entity_linker.set_kb(create_kb)
+
+    optimizer = nlp.initialize(get_examples=lambda: train_examples)
+    for i in range(2):
+        losses = {}
+        nlp.update(train_examples, sgd=optimizer, losses=losses)
+
+    nlp.add_pipe("sentencizer", first=True)
     results = nlp.evaluate(train_examples)

--- a/spacy/tests/pipeline/test_entity_linker.py
+++ b/spacy/tests/pipeline/test_entity_linker.py
@@ -1072,8 +1072,8 @@ def test_no_gold_ents(patterns):
     # this will run the pipeline on the examples and shouldn't crash
     results = nlp.evaluate(train_examples)
 
+@pytest.mark.issue(9575)
 def test_tokenization_mismatch():
-    # https://github.com/explosion/spaCy/issues/9575
     nlp = English()
     # include a matching entity so that update isn't skipped
     doc1 = Doc(nlp.vocab, words=["Kirby", "123456"], spaces=[True, False], ents=["B-CHARACTER", "B-CARDINAL"])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

As outlined in #9575, the Entity Linker has issues when tokenization differs between gold and predicted Docs. This was separate from the issue addressed with the recent fix for tok2vec issues, so this PR should address it. 

The main issue is that while KB IDs are taken aligned to tokens in the predicted Doc, they are indexed into using entity token indices from the gold Doc. This means if there was any change in the tokenization before the token in question, the tokens won't line up, which can result in nonsense or IndexErrors. 

Right now this PR just has a failing test; the fix is in progress. 

My basic strategy for fixing this is to use the `get_matching_ents` function introduced in the previous NEL fix PR to get aligned entities. That should give correct results all cases,  but may be more strict than the previous behavior, since previously KB IDs were taken from entities with a matching first token rather than matching the whole span.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
bugfix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
