### PR TITLE
Complete doc about accessing context in pipeline components

### DIFF
--- a/website/docs/usage/processing-pipelines.md
+++ b/website/docs/usage/processing-pipelines.md
@@ -95,7 +95,8 @@ You can use the `as_tuples` option to pass additional context along with each
 doc when using [`nlp.pipe`](/api/language#pipe). If `as_tuples` is `True`, then
 the input should be a sequence of `(text, context)` tuples and the output will
 be a sequence of `(doc, context)` tuples. For example, you can pass metadata in
-the context and save it in a [custom attribute](#custom-components-attributes):
+the context and save it in a [custom attribute](#custom-components-attributes)
+or retrieve it from a custom component using the `doc._context` attribute:
 
 ```python
 ### {executable="true"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

Accessing the contexts given as tuples to `nlp.pipe([(text1, context1), (text2, context2)])` from inside
a component is possible using the `doc._context` attribute but this feature is not documented.

For example:

```
import spacy
from spacy.language import Language

@Language.component("info_component")
def print_context(doc):
    print(f"Doc context", doc._context)
    return doc

text_tuples = [
    ("This is the first text.", {"text_id": "text1"}),
    ("This is the second text.", {"text_id": "text2"})
]

nlp = spacy.load("en_core_web_sm")
nlp.add_pipe("print_context", name="print_context")
doc_tuples = nlp.pipe(text_tuples, as_tuples=True)

docs = list(nlp.pipe(doc_tuples))
```

## Description

Document the `doc._context` feature.

### Types of change
Change to the documentation

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
