### PR TITLE
displacy: avoid overlapping arcs in manual mode

### DIFF
--- a/spacy/displacy/render.py
+++ b/spacy/displacy/render.py
@@ -270,7 +270,7 @@ class DependencyRenderer:
         RETURNS (str): Rendered SVG markup.
         """
         self.levels = self.get_levels(arcs)
-        self.highest_level = len(self.levels)
+        self.highest_level = max(self.levels.values(), default=0)
         self.offset_y = self.distance / 2 * self.highest_level + self.arrow_stroke
         self.width = self.offset_x + len(words) * self.distance
         self.height = self.offset_y + 3 * self.word_spacing
@@ -330,7 +330,7 @@ class DependencyRenderer:
         if start < 0 or end < 0:
             error_args = dict(start=start, end=end, label=label, dir=direction)
             raise ValueError(Errors.E157.format(**error_args))
-        level = self.levels.index(end - start) + 1
+        level = self.levels[(start, end, label)]
         x_start = self.offset_x + start * self.distance + self.arrow_spacing
         if self.direction == "rtl":
             x_start = self.width - x_start
@@ -346,7 +346,7 @@ class DependencyRenderer:
         y_curve = self.offset_y - level * self.distance / 2
         if self.compact:
             y_curve = self.offset_y - level * self.distance / 6
-        if y_curve == 0 and len(self.levels) > 5:
+        if y_curve == 0 and max(self.levels.values(), default=0) > 5:
             y_curve = -self.distance
         arrowhead = self.get_arrowhead(direction, x_start, y, x_end)
         arc = self.get_arc(x_start, y, y_curve, x_end)
@@ -395,10 +395,21 @@ class DependencyRenderer:
         Used to calculate arrow heights dynamically and without wasting space.
 
         args (list): Individual arcs and their start, end, direction and label.
-        RETURNS (list): Arc levels sorted from lowest to highest.
+        RETURNS (dict): Arc levels keyed by (start, end, label).
         """
-        levels = set(map(lambda arc: arc["end"] - arc["start"], arcs))
-        return sorted(list(levels))
+        length = max([arc["end"] for arc in arcs], default=0)
+        max_level = [0] * length
+        levels = {}
+
+        for arc in sorted(arcs, key=lambda arc: arc["end"] - arc["start"]):
+            level = max(max_level[arc["start"] : arc["end"]]) + 1
+
+            for i in range(arc["start"], arc["end"]):
+                max_level[i] = level
+
+            levels[(arc["start"], arc["end"], arc["label"])] = level
+
+        return levels
 
 
 class EntityRenderer:

--- a/spacy/displacy/render.py
+++ b/spacy/displacy/render.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 import uuid
 import itertools
 
@@ -390,7 +390,7 @@ class DependencyRenderer:
             p1, p2, p3 = (end, end + self.arrow_width - 2, end - self.arrow_width + 2)
         return f"M{p1},{y + 2} L{p2},{y - self.arrow_width} {p3},{y - self.arrow_width}"
 
-    def get_levels(self, arcs: List[Dict[str, Any]]) -> List[int]:
+    def get_levels(self, arcs: List[Dict[str, Any]]) -> Dict[Tuple[int, int, str], int]:
         """Calculate available arc height "levels".
         Used to calculate arrow heights dynamically and without wasting space.
 

--- a/spacy/displacy/render.py
+++ b/spacy/displacy/render.py
@@ -400,15 +400,11 @@ class DependencyRenderer:
         length = max([arc["end"] for arc in arcs], default=0)
         max_level = [0] * length
         levels = {}
-
         for arc in sorted(arcs, key=lambda arc: arc["end"] - arc["start"]):
             level = max(max_level[arc["start"] : arc["end"]]) + 1
-
             for i in range(arc["start"], arc["end"]):
                 max_level[i] = level
-
             levels[(arc["start"], arc["end"], arc["label"])] = level
-
         return levels
 
 

--- a/spacy/tests/test_displacy.py
+++ b/spacy/tests/test_displacy.py
@@ -8,6 +8,26 @@ from spacy.lang.fa import Persian
 from spacy.tokens import Span, Doc
 
 
+@pytest.mark.issue(5447)
+def test_issue5447():
+    """Test that overlapping arcs get separate levels."""
+    renderer = DependencyRenderer()
+    words = [
+        {"text": "This", "tag": "DT"},
+        {"text": "is", "tag": "VBZ"},
+        {"text": "a", "tag": "DT"},
+        {"text": "sentence.", "tag": "NN"},
+    ]
+    arcs = [
+        {"start": 0, "end": 1, "label": "nsubj", "dir": "left"},
+        {"start": 2, "end": 3, "label": "det", "dir": "left"},
+        {"start": 2, "end": 3, "label": "overlap", "dir": "left"},
+        {"start": 1, "end": 3, "label": "attr", "dir": "left"},
+    ]
+    html = renderer.render([{"words": words, "arcs": arcs}])
+    assert renderer.highest_level == 3
+
+
 @pytest.mark.issue(2361)
 def test_issue2361(de_vocab):
     """Test if < is escaped when rendering"""


### PR DESCRIPTION
displacy: avoid overlapping arcs in manual mode

Resolves #5447

## Description
Two arcs with the same start and end index will currently display as overlapped. I think this will only occur in manual mode (see issue above). The fix keys the levels assigned to the arcs by `(start, end, label)` (instead of `end-start`). Each arc is compared to the current levels across its span, stored in the list `max_level`.

(I was in two minds about submitting this PR - it takes a nice one-liner and turns it into a chunk of code for a fringe use-case... Happy for ideas for improvements or to drop it entirely 😄).

### Types of change
This PR is a bug fix for #5447.

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
