### PR TITLE
Reset entity-related attributes when an entity is removed

### DIFF
--- a/spacy/tests/doc/test_add_entities.py
+++ b/spacy/tests/doc/test_add_entities.py
@@ -45,6 +45,24 @@ def test_ents_reset(en_vocab):
     assert [t.ent_iob_ for t in doc] == orig_iobs
 
 
+def test_ent_remove(en_vocab):
+    """Ensure that removing entities clears token attributes"""
+    text = ["Louisiana", "Office", "of", "Conservation"]
+    doc = Doc(en_vocab, words=text)
+    entity = Span(doc, 0, 4, label=391)
+    doc.ents = [entity]
+    for tok in entity:
+        tok.ent_id_ = "TEST"
+
+    print(doc.ents)
+    for tok in doc:
+        print(tok, tok.ent_id)
+    doc.ents = []
+    for tok in doc:
+        print(tok, tok.ent_id)
+        assert tok.ent_id == 0
+
+
 def test_add_overlapping_entities(en_vocab):
     text = ["Louisiana", "Office", "of", "Conservation"]
     doc = Doc(en_vocab, words=text)

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -814,6 +814,8 @@ cdef class Doc:
             for i in range(self.length):
                 if i not in seen_tokens:
                     self.c[i].ent_type = 0
+                    self.c[i].ent_id = 0
+                    self.c[i].ent_kb_id = 0
                     if default == SetEntsDefault.outside:
                         self.c[i].ent_iob = 2
                     elif default == SetEntsDefault.missing:


### PR DESCRIPTION
Includes test.

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

If you have entities on a Doc, and filter the list to remove some entities, and then set the list of entities, `ent_id` and `ent_kb_id` values are not reset. This means that you can get non-entity tokens with those values, for example, which seems undesirable. 

This works as intended but is in draft because

1. We need to discuss if this is desired behavior
2. Docs probably need an update

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

bug fix?

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
