### PR TITLE
displaCy: Avoid increasing levels for identical arcs

### DIFF
--- a/spacy/displacy/render.py
+++ b/spacy/displacy/render.py
@@ -397,6 +397,7 @@ class DependencyRenderer:
         args (list): Individual arcs and their start, end, direction and label.
         RETURNS (dict): Arc levels keyed by (start, end, label).
         """
+        arcs = [dict(t) for t in {tuple(arc.items()) for arc in arcs}]
         length = max([arc["end"] for arc in arcs], default=0)
         max_level = [0] * length
         levels = {}

--- a/spacy/tests/test_displacy.py
+++ b/spacy/tests/test_displacy.py
@@ -8,26 +8,6 @@ from spacy.lang.fa import Persian
 from spacy.tokens import Span, Doc
 
 
-@pytest.mark.issue(5447)
-def test_issue5447():
-    """Test that overlapping arcs get separate levels."""
-    renderer = DependencyRenderer()
-    words = [
-        {"text": "This", "tag": "DT"},
-        {"text": "is", "tag": "VBZ"},
-        {"text": "a", "tag": "DT"},
-        {"text": "sentence.", "tag": "NN"},
-    ]
-    arcs = [
-        {"start": 0, "end": 1, "label": "nsubj", "dir": "left"},
-        {"start": 2, "end": 3, "label": "det", "dir": "left"},
-        {"start": 2, "end": 3, "label": "overlap", "dir": "left"},
-        {"start": 1, "end": 3, "label": "attr", "dir": "left"},
-    ]
-    html = renderer.render([{"words": words, "arcs": arcs}])
-    assert renderer.highest_level == 3
-
-
 @pytest.mark.issue(2361)
 def test_issue2361(de_vocab):
     """Test if < is escaped when rendering"""
@@ -101,6 +81,27 @@ def test_issue3882(en_vocab):
     doc = Doc(en_vocab, words=["Hello", "world"], deps=["dep", "dep"])
     doc.user_data["test"] = set()
     displacy.parse_deps(doc)
+
+
+@pytest.mark.issue(5447)
+def test_issue5447():
+    """Test that overlapping arcs get separate levels, unless they're identical."""
+    renderer = DependencyRenderer()
+    words = [
+        {"text": "This", "tag": "DT"},
+        {"text": "is", "tag": "VBZ"},
+        {"text": "a", "tag": "DT"},
+        {"text": "sentence.", "tag": "NN"},
+    ]
+    arcs = [
+        {"start": 0, "end": 1, "label": "nsubj", "dir": "left"},
+        {"start": 2, "end": 3, "label": "det", "dir": "left"},
+        {"start": 2, "end": 3, "label": "overlap", "dir": "left"},
+        {"start": 2, "end": 3, "label": "overlap", "dir": "left"},
+        {"start": 1, "end": 3, "label": "attr", "dir": "left"},
+    ]
+    renderer.render([{"words": words, "arcs": arcs}])
+    assert renderer.highest_level == 3
 
 
 @pytest.mark.issue(5838)


### PR DESCRIPTION
## Description
Identical arcs (`(start, end, label)`) would increase the levels, wasting space. Avoid this by filtering or taking the set of arcs prior to determining levels.

This is a follow-up PR to #10534 (see [comment](https://github.com/explosion/spaCy/pull/10534#issuecomment-1088148892)).

I amended the existing test for #5447 to include an identical arc, as well as moved that test so that it sits in order with the other numbered tests 🔢 .

### Types of change
Bug fix ⚡ 

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
