### PR TITLE
Display warning when spacy.explain() finds no term

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -196,6 +196,9 @@ class Warnings(metaclass=ErrorsWithCodes):
             "surprising to you, make sure the Doc was processed using a model "
             "that supports span categorization, and check the `doc.spans[spans_key]` "
             "property manually if necessary.")
+    W118 = ("Term '{term}' not found in glossary. It may however be explained in documentation "
+            "for the corpora used to train the language. Please examine the contents of "
+            "`nlp.meta[\"sources\"]` where such documentation may be linked.")
 
 
 class Errors(metaclass=ErrorsWithCodes):

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -197,8 +197,8 @@ class Warnings(metaclass=ErrorsWithCodes):
             "that supports span categorization, and check the `doc.spans[spans_key]` "
             "property manually if necessary.")
     W118 = ("Term '{term}' not found in glossary. It may however be explained in documentation "
-            "for the corpora used to train the language. Please examine the contents of "
-            "`nlp.meta[\"sources\"]` where such documentation may be linked.")
+            "for the corpora used to train the language. Please check "
+            "`nlp.meta[\"sources\"]` for any relevant links.")
 
 
 class Errors(metaclass=ErrorsWithCodes):

--- a/spacy/glossary.py
+++ b/spacy/glossary.py
@@ -1,3 +1,7 @@
+import warnings
+from .errors import Warnings
+
+
 def explain(term):
     """Get a description for a given POS tag, dependency label or entity type.
 
@@ -11,6 +15,8 @@ def explain(term):
     """
     if term in GLOSSARY:
         return GLOSSARY[term]
+    else:
+        warnings.warn(Warnings.W118.format(term=term))
 
 
 GLOSSARY = {


### PR DESCRIPTION
## Description
`spacy.explain()` queries a glossary that is not exhaustive for all languages or token attributes. In many cases where it does not find a definition for a given abbreviation, the abbreviation will be defined in documentation for corpora used to train the model. When `spacy.explain()` returns no output, this PR causes a message to be displayed pointing the user to such corpus documentation.

### Types of change
Enhancement / new feature

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.