### PR TITLE
Have SpanGroups.setdefault always return the set SpanGroup value

### DIFF
--- a/spacy/tests/doc/test_span_group.py
+++ b/spacy/tests/doc/test_span_group.py
@@ -119,6 +119,18 @@ def test_span_group_set_item(doc, other_doc):
         span_group[index] = span
 
 
+@pytest.mark.issue(10670)
+def test_issue10670(en_tokenizer):
+    # Start with a doc that we know has no 'test' SpanGroup
+    doc = en_tokenizer("0 1 2 3 4 5 6")
+    span1 = doc[0:1]
+    span2 = doc[1:2]
+    doc.spans.setdefault("test", []).append(span1)
+    assert set(doc.spans["test"]) == {span1}
+    doc.spans.setdefault("test", []).append(span2)
+    assert set(doc.spans["test"]) == {span1, span2}
+
+
 def test_span_group_has_overlap(doc):
     span_group = doc.spans["SPANS"]
     assert span_group.has_overlap


### PR DESCRIPTION
## Description

Resolves #10670

This changes the behavior so that `SpanGroups.setdefault` will no longer return a non-`SpanGroup` default value passed to setdefault() (if the given key is not present in the SpanGroups); setdefault() will now always return the SpanGroup object that was set as the value for the given key.

### Implementation discussion

The current implementation is open for review. There were a few options that came to mind to resolve #10670, given the current definition of SpanGroups, and each has advantages and disadvantages.

1. One option is to leave `SpanGroups.__setitem__` defined as-is, and to define `SpanGroups.setdefault` as:
```python
def setdefault(
    self, key: str, default: Union[SpanGroup, Iterable["Span"]] = tuple()
) -> SpanGroup:
    if key in self:
        return self[key]
    self[key] = default
    return self[key]
```
This is similar to the underlying `MutableMapping.setdefault`, but it requires performing an additional `__getitem__()` to return the (`SpanGroup`) value that was actually set--since `SpanGroups.__setitem__` may alter the provided value to make it a SpanGroup.

2. To avoid the additional `__getitem__()`, another option would be to essentially have the functionality of `__setitem__`, but also return the SpanGroup value that was set. One way to do this is:
```python
def _setitem(
    self, key: str, value: Union[SpanGroup, Iterable["Span"]]
) -> SpanGroup:
    if not is instance(value, SpanGroup):
        value = self._make_span_group(key, value)
    assert value.doc is self.doc_ref()
    UserDict.__setitem__(self, key, value)
    return value

def __setitem__( ...same signature... ):
    self._setitem(key, value)

def setdefault( ...same signature as in option 1... ):
    if key in self:
        return self[key]
    return self._setitem(key, default)
```
Here, `_setitem` is basically the existing implementation of `__setitem__` with a `return value` tacked on. It does have the benefit of maintaining \_\_setitem\_\_'s current signature, though I'm not particularly keen on having each call to `__setitem__()` simply wrap another function call, particularly since I assume `setdefault()` will be called less frequently than \_\_setitem\_\_(). Alternatively, the current \_\_setitem\_\_ code could basically be duplicated within setdefault, but code duplication has its own issues.

3. (Have I warmed you up to having a \_\_setitem\_\_() return a value?)
Another way to get the same effect as the prior option would just have the existing \_\_setitem\_\_ return a `SpanGroup` itself, instead of `None`. Then `setdefault` would include `return self.__setitem__(key, default)`.

This latter option is the one I've implemented in this pull request's initial commit. Having any class's `__setitem__` return a non-None value is certainly unusual from my experience, but it seemed like it might be an appropriate solution for SpanGroups, when compared against the other options I considered. Every value within a SpanGroups object is always going to be a `SpanGroup`, and I *think* it's reasonable to expect that user code up until this point has not attempted to make use of \_\_setitem\_\_()'s (`None`) return value.
Going forward with this, a risk would then be having user code that uses/relies on SpanGroups.\_\_setitem\_\_ returning its set value. But for `SpanGroups` specifically, maybe that would be an acceptable behavior to maintain.

Note: To accommodate the latter option, I've included a "`type: ignore[override]`", as mypy has rightly pointed out that the `UserDict`/`MutableMapping`'s \_\_setitem\_\_ definitions return `None` and not `SpanGroup`.

Other notes:
1. I've set the default value for `setdefault` to be `tuple()`, since we accept `Iterable[Span]` values, and this would be transformed into an empty `SpanGroup`. I know `SimpleFrozenList()` is used in similar contexts, but I saw an existing `tuple()` default arg in SpanGroups' module and went with that.
2. I avoided using a `try/except` statement in `SpanGroups.setdefault`, as is done in `MutableMapping.setdefault`, because the spaCy developers' guide stated a preference for explicit condition checks.

### Types of change
Bug fix and/or design change/enhancement

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

Let me know what you think. I know there are other options that would satisfy #10670, but given SpanGroups' current definition, the ones I mentioned above seemed like more-or-less viable choices.