### PR TITLE
Fixed example for spacy_syllables

### DIFF
--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -3212,7 +3212,7 @@
                 "",
                 "assert nlp.pipe_names == [\"tok2vec\", \"tagger\", \"syllables\", \"parser\",  \"attribute_ruler\", \"lemmatizer\", \"ner\"]",
                 "doc = nlp(\"terribly long\")",
-                "data = [(token.text, token..syllables, token..syllables_count) for token in doc]",
+                "data = [(token.text, token._.syllables, token._.syllables_count) for token in doc]",
                 "assert data == [(\"terribly\", [\"ter\", \"ri\", \"bly\"], 3), (\"long\", [\"long\"], 1)]"
             ],
             "thumb": "https://raw.githubusercontent.com/sloev/spacy-syllables/master/logo.png",


### PR DESCRIPTION
There was a typo in the example for the spacy_syllables project.

## Description
the underscore was missing and as a result, example code could not be run

### Types of change
fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
