### PR TITLE
removing print statements from the test suite

### DIFF
--- a/spacy/tests/lang/tr/test_tokenizer.py
+++ b/spacy/tests/lang/tr/test_tokenizer.py
@@ -694,5 +694,4 @@ TESTS = ABBREV_TESTS + URL_TESTS + NUMBER_TESTS + PUNCT_TESTS + GENERAL_TESTS
 def test_tr_tokenizer_handles_allcases(tr_tokenizer, text, expected_tokens):
     tokens = tr_tokenizer(text)
     token_list = [token.text for token in tokens if not token.is_space]
-    print(token_list)
     assert expected_tokens == token_list

--- a/spacy/tests/pipeline/test_morphologizer.py
+++ b/spacy/tests/pipeline/test_morphologizer.py
@@ -184,7 +184,7 @@ def test_overfitting_IO():
                 token.pos_ = ""
             token.set_morph(None)
     optimizer = nlp.initialize(get_examples=lambda: train_examples)
-    print(nlp.get_pipe("morphologizer").labels)
+    assert nlp.get_pipe("morphologizer").labels is not None
     for i in range(50):
         losses = {}
         nlp.update(train_examples, sgd=optimizer, losses=losses)

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -217,7 +217,6 @@ def test_cli_converters_conllu_to_docs_subtokens():
     sent = converted[0]["paragraphs"][0]["sentences"][0]
     assert len(sent["tokens"]) == 4
     tokens = sent["tokens"]
-    print(tokens)
     assert [t["orth"] for t in tokens] == ["Dommer", "FE", "avstår", "."]
     assert [t["tag"] for t in tokens] == [
         "NOUN__Definite=Ind|Gender=Masc|Number=Sing",


### PR DESCRIPTION
## Description
Removing `print` statements from the test suite - likely remnants from debugging efforts :-)

### Types of change
fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
