### PR TITLE
Allow assets to be optional in spacy project

### DIFF
--- a/spacy/cli/project/assets.py
+++ b/spacy/cli/project/assets.py
@@ -25,7 +25,7 @@ def project_assets_cli(
     ctx: typer.Context,  # This is only used to read additional arguments
     project_dir: Path = Arg(Path.cwd(), help="Path to cloned project. Defaults to current working directory.", exists=True, file_okay=False),
     sparse_checkout: bool = Opt(False, "--sparse", "-S", help="Use sparse checkout for assets provided via Git, to only check out and clone the files needed. Requires Git v22.2+."),
-    extra: bool = Opt(False, "--extra", "-e", help="Download all assets, including those marked as optional.")
+    extra: bool = Opt(False, "--extra", "-e", help="Download all assets, including those marked as 'extra'.")
     # fmt: on
 ):
     """Fetch project assets like datasets and pretrained weights. Assets are

--- a/spacy/cli/project/assets.py
+++ b/spacy/cli/project/assets.py
@@ -63,11 +63,11 @@ def project_assets(
     assets = [
         asset
         for asset in config.get("assets", [])
-        if extra or not asset.get("optional", OPTIONAL_DEFAULT)
+        if extra or not asset.get("extra", OPTIONAL_DEFAULT)
     ]
     if not assets:
         msg.warn(
-            f"No assets specified in {PROJECT_FILE} (if assets are marked as optional, download them with --extra)",
+            f"No assets specified in {PROJECT_FILE} (if assets are marked as extra, download them with --extra)",
             exits=0,
         )
     msg.info(f"Fetching {len(assets)} asset(s)")

--- a/spacy/cli/project/assets.py
+++ b/spacy/cli/project/assets.py
@@ -21,7 +21,8 @@ def project_assets_cli(
     # fmt: off
     ctx: typer.Context,  # This is only used to read additional arguments
     project_dir: Path = Arg(Path.cwd(), help="Path to cloned project. Defaults to current working directory.", exists=True, file_okay=False),
-    sparse_checkout: bool = Opt(False, "--sparse", "-S", help="Use sparse checkout for assets provided via Git, to only check out and clone the files needed. Requires Git v22.2+.")
+    sparse_checkout: bool = Opt(False, "--sparse", "-S", help="Use sparse checkout for assets provided via Git, to only check out and clone the files needed. Requires Git v22.2+."),
+    download_all: bool = Opt(False, "--all", "-a", help="Download all assets, including those marked as optional.")
     # fmt: on
 ):
     """Fetch project assets like datasets and pretrained weights. Assets are
@@ -32,7 +33,12 @@ def project_assets_cli(
     DOCS: https://spacy.io/api/cli#project-assets
     """
     overrides = parse_config_overrides(ctx.args)
-    project_assets(project_dir, overrides=overrides, sparse_checkout=sparse_checkout)
+    project_assets(
+        project_dir,
+        overrides=overrides,
+        sparse_checkout=sparse_checkout,
+        download_all=download_all,
+    )
 
 
 def project_assets(
@@ -40,17 +46,29 @@ def project_assets(
     *,
     overrides: Dict[str, Any] = SimpleFrozenDict(),
     sparse_checkout: bool = False,
+    download_all: bool = False,
 ) -> None:
     """Fetch assets for a project using DVC if possible.
 
     project_dir (Path): Path to project directory.
+    sparse_checkout (bool): Use sparse checkout for assets provided via Git, to only check out and clone the files
+                            needed.
+    download_all (bool): Whether to download all assets, including those marked as optional.
     """
     project_path = ensure_path(project_dir)
     config = load_project_config(project_path, overrides=overrides)
-    assets = config.get("assets", {})
+    assets = [
+        asset
+        for asset in config.get("assets", [])
+        if download_all or not asset.get("optional", False)
+    ]
     if not assets:
-        msg.warn(f"No assets specified in {PROJECT_FILE}", exits=0)
+        msg.warn(
+            f"No assets specified in {PROJECT_FILE} (if assets are marked as optional, download them with --all)",
+            exits=0,
+        )
     msg.info(f"Fetching {len(assets)} asset(s)")
+
     for asset in assets:
         dest = (project_dir / asset["dest"]).resolve()
         checksum = asset.get("checksum")

--- a/spacy/cli/project/assets.py
+++ b/spacy/cli/project/assets.py
@@ -12,7 +12,7 @@ from .._util import project_cli, Arg, Opt, PROJECT_FILE, load_project_config
 from .._util import get_checksum, download_file, git_checkout, get_git_version
 from .._util import SimpleFrozenDict, parse_config_overrides
 
-# Whether assets are optional if 'optional' is not set.
+# Whether assets are extra if `extra` is not set.
 OPTIONAL_DEFAULT = False
 
 

--- a/spacy/cli/project/assets.py
+++ b/spacy/cli/project/assets.py
@@ -56,7 +56,7 @@ def project_assets(
     project_dir (Path): Path to project directory.
     sparse_checkout (bool): Use sparse checkout for assets provided via Git, to only check out and clone the files
                             needed.
-    extra (bool): Whether to download all assets, including those marked as optional.
+    extra (bool): Whether to download all assets, including those marked as 'extra'.
     """
     project_path = ensure_path(project_dir)
     config = load_project_config(project_path, overrides=overrides)

--- a/spacy/cli/project/assets.py
+++ b/spacy/cli/project/assets.py
@@ -56,7 +56,7 @@ def project_assets(
     project_dir (Path): Path to project directory.
     sparse_checkout (bool): Use sparse checkout for assets provided via Git, to only check out and clone the files
                             needed.
-    download_all (bool): Whether to download all assets, including those marked as optional.
+    extra (bool): Whether to download all assets, including those marked as optional.
     """
     project_path = ensure_path(project_dir)
     config = load_project_config(project_path, overrides=overrides)

--- a/spacy/cli/project/assets.py
+++ b/spacy/cli/project/assets.py
@@ -25,7 +25,7 @@ def project_assets_cli(
     ctx: typer.Context,  # This is only used to read additional arguments
     project_dir: Path = Arg(Path.cwd(), help="Path to cloned project. Defaults to current working directory.", exists=True, file_okay=False),
     sparse_checkout: bool = Opt(False, "--sparse", "-S", help="Use sparse checkout for assets provided via Git, to only check out and clone the files needed. Requires Git v22.2+."),
-    download_all: bool = Opt(False, "--all", "-a", help="Download all assets, including those marked as optional.")
+    extra: bool = Opt(False, "--extra", "-e", help="Download all assets, including those marked as optional.")
     # fmt: on
 ):
     """Fetch project assets like datasets and pretrained weights. Assets are
@@ -40,7 +40,7 @@ def project_assets_cli(
         project_dir,
         overrides=overrides,
         sparse_checkout=sparse_checkout,
-        download_all=download_all,
+        extra=extra,
     )
 
 
@@ -49,7 +49,7 @@ def project_assets(
     *,
     overrides: Dict[str, Any] = SimpleFrozenDict(),
     sparse_checkout: bool = False,
-    download_all: bool = False,
+    extra: bool = False,
 ) -> None:
     """Fetch assets for a project using DVC if possible.
 
@@ -63,7 +63,7 @@ def project_assets(
     assets = [
         asset
         for asset in config.get("assets", [])
-        if download_all or not asset.get("optional", OPTIONAL_DEFAULT)
+        if extra or not asset.get("optional", OPTIONAL_DEFAULT)
     ]
     if not assets:
         msg.warn(

--- a/spacy/cli/project/assets.py
+++ b/spacy/cli/project/assets.py
@@ -13,7 +13,7 @@ from .._util import get_checksum, download_file, git_checkout, get_git_version
 from .._util import SimpleFrozenDict, parse_config_overrides
 
 # Whether assets are extra if `extra` is not set.
-OPTIONAL_DEFAULT = False
+EXTRA_DEFAULT = False
 
 
 @project_cli.command(
@@ -63,7 +63,7 @@ def project_assets(
     assets = [
         asset
         for asset in config.get("assets", [])
-        if extra or not asset.get("extra", OPTIONAL_DEFAULT)
+        if extra or not asset.get("extra", EXTRA_DEFAULT)
     ]
     if not assets:
         msg.warn(

--- a/spacy/cli/project/assets.py
+++ b/spacy/cli/project/assets.py
@@ -12,6 +12,9 @@ from .._util import project_cli, Arg, Opt, PROJECT_FILE, load_project_config
 from .._util import get_checksum, download_file, git_checkout, get_git_version
 from .._util import SimpleFrozenDict, parse_config_overrides
 
+# Whether assets are optional if 'optional' is not set.
+OPTIONAL_DEFAULT = False
+
 
 @project_cli.command(
     "assets",
@@ -60,7 +63,7 @@ def project_assets(
     assets = [
         asset
         for asset in config.get("assets", [])
-        if download_all or not asset.get("optional", False)
+        if download_all or not asset.get("optional", OPTIONAL_DEFAULT)
     ]
     if not assets:
         msg.warn(

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -355,7 +355,7 @@ def test_project_config_validation_full():
             },
             {
                 "dest": "z",
-                "optional": False,
+                "extra": False,
                 "url": "https://example.com",
                 "checksum": "63373dd656daa1fd3043ce166a59474c",
             },

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -341,7 +341,7 @@ def test_project_config_validation_full():
         "assets": [
             {
                 "dest": "x",
-                "optional": True,
+                "extra": True,
                 "url": "https://example.com",
                 "checksum": "63373dd656daa1fd3043ce166a59474c",
             },

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -341,6 +341,7 @@ def test_project_config_validation_full():
         "assets": [
             {
                 "dest": "x",
+                "optional": True,
                 "url": "https://example.com",
                 "checksum": "63373dd656daa1fd3043ce166a59474c",
             },
@@ -352,6 +353,12 @@ def test_project_config_validation_full():
                     "path": "y",
                 },
             },
+            {
+                "dest": "z",
+                "optional": False,
+                "url": "https://example.com",
+                "checksum": "63373dd656daa1fd3043ce166a59474c",
+            }
         ],
         "commands": [
             {

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -358,7 +358,7 @@ def test_project_config_validation_full():
                 "optional": False,
                 "url": "https://example.com",
                 "checksum": "63373dd656daa1fd3043ce166a59474c",
-            }
+            },
         ],
         "commands": [
             {

--- a/website/docs/usage/projects.md
+++ b/website/docs/usage/projects.md
@@ -109,9 +109,9 @@ checkout" feature to avoid downloading the whole repository.
 
 Sometimes your project configuration may include large assets that you don't
 necessarily want to download every time you run `spacy project assets`. That's
-why assets can be marked as [`optional`](#data-assets-url) - by default,
-optional assets are not downloaded. If they are to be included in the download,
-run `spacy project assets --extra`.
+why assets can be marked as [`extra`](#data-assets-url) - by default, these
+assets are not downloaded. If they should be, run
+`spacy project assets --extra`.
 
 ### 3. Run a command {#run}
 
@@ -268,7 +268,7 @@ dependencies to use certain protocols.
 >     checksum: '63373dd656daa1fd3043ce166a59474c'
 >   # Optional download from Google Cloud Storage bucket
 >   - dest: 'assets/development.spacy'
->     optional: True
+>     extra: True
 >     url: 'gs://your-bucket/corpora'
 >     checksum: '5113dc04e03f079525edd8df3f4f39e3'
 > ```
@@ -276,7 +276,7 @@ dependencies to use certain protocols.
 | Name          | Description                                                                                                                                                                      |
 | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `dest`        | The destination path to save the downloaded asset to (relative to the project directory), including the file name.                                                               |
-| `optional`    | Optional flag determining whether this is an optional asset. False by default. Optional assets are only downloaded if `spacy project assets` is run with `--extra`.              |
+| `extra`       | Optional flag determining whether this asset is downloaded only if `spacy project assets` is run with `--extra`. `False` by default.                                             |
 | `url`         | The URL to download from, using the respective protocol.                                                                                                                         |
 | `checksum`    | Optional checksum of the file. If provided, it will be used to verify that the file matches and downloads will be skipped if a local file with the same checksum already exists. |
 | `description` | Optional asset description, used in [auto-generated docs](#custom-docs).                                                                                                         |

--- a/website/docs/usage/projects.md
+++ b/website/docs/usage/projects.md
@@ -94,9 +94,8 @@ also use any private repo you have access to with Git.
 Assets are data files your project needs – for example, the training and
 evaluation data or pretrained vectors and embeddings to initialize your model
 with. Each project template comes with a `project.yml` that defines the assets
-to download and where to put them. The
-[`spacy project assets`](/api/cli#project-assets) will fetch the project assets
-for you:
+to download and where to put them. The [`spacy project assets`](/api/cli#run)
+will fetch the project assets for you:
 
 ```cli
 $ cd some_example_project
@@ -107,6 +106,12 @@ Asset URLs can be a number of different protocols: HTTP, HTTPS, FTP, SSH, and
 even cloud storage such as GCS and S3. You can also fetch assets using git, by
 replacing the `url` string with a `git` block. spaCy will use Git's "sparse
 checkout" feature to avoid downloading the whole repository.
+
+Sometimes your project configuration may include large assets that you don't
+necessarily want to download every time you run `spacy project assets`. That's
+why assets can be marked as [`optional`](#data-assets-url) - by default,
+optional assets are not downloaded. If they are to be included in the download,
+run `spacy project assets --extra`.
 
 ### 3. Run a command {#run}
 
@@ -215,9 +220,9 @@ pipelines.
 
 > #### Tip: Multi-line YAML syntax for long values
 >
-> YAML has [multi-line syntax](https://yaml-multiline.info/) that can be 
-> helpful for readability with longer values such as project descriptions or 
-> commands that take several arguments.
+> YAML has [multi-line syntax](https://yaml-multiline.info/) that can be helpful
+> for readability with longer values such as project descriptions or commands
+> that take several arguments.
 
 ```yaml
 %%GITHUB_PROJECTS/pipelines/tagger_parser_ud/project.yml
@@ -261,8 +266,9 @@ dependencies to use certain protocols.
 >   - dest: 'assets/training.spacy'
 >     url: 'https://example.com/data.spacy'
 >     checksum: '63373dd656daa1fd3043ce166a59474c'
->   # Download from Google Cloud Storage bucket
+>   # Optional download from Google Cloud Storage bucket
 >   - dest: 'assets/development.spacy'
+>     optional: True
 >     url: 'gs://your-bucket/corpora'
 >     checksum: '5113dc04e03f079525edd8df3f4f39e3'
 > ```
@@ -270,6 +276,7 @@ dependencies to use certain protocols.
 | Name          | Description                                                                                                                                                                      |
 | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `dest`        | The destination path to save the downloaded asset to (relative to the project directory), including the file name.                                                               |
+| `optional`    | Optional flag determining whether this is an optional asset. False by default. Optional assets are only downloaded if `spacy project assets` is run with `--extra`.              |
 | `url`         | The URL to download from, using the respective protocol.                                                                                                                         |
 | `checksum`    | Optional checksum of the file. If provided, it will be used to verify that the file matches and downloads will be skipped if a local file with the same checksum already exists. |
 | `description` | Optional asset description, used in [auto-generated docs](#custom-docs).                                                                                                         |
@@ -294,12 +301,12 @@ files you need and not the whole repo.
 >     description: 'The training data (5000 examples)'
 > ```
 
-| Name          | Description                                                                                                                                                                                          |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dest`        | The destination path to save the downloaded asset to (relative to the project directory), including the file name.                                                                                   |
+| Name          | Description                                                                                                                                                                                                                           |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dest`        | The destination path to save the downloaded asset to (relative to the project directory), including the file name.                                                                                                                    |
 | `git`         | `repo`: The URL of the repo to download from.<br />`path`: Path of the file or directory to download, relative to the repo root. "" specifies the root directory.<br />`branch`: The branch to download from. Defaults to `"master"`. |
-| `checksum`    | Optional checksum of the file. If provided, it will be used to verify that the file matches and downloads will be skipped if a local file with the same checksum already exists.                     |
-| `description` | Optional asset description, used in [auto-generated docs](#custom-docs).                                                                                                                             |
+| `checksum`    | Optional checksum of the file. If provided, it will be used to verify that the file matches and downloads will be skipped if a local file with the same checksum already exists.                                                      |
+| `description` | Optional asset description, used in [auto-generated docs](#custom-docs).                                                                                                                                                              |
 
 #### Working with private assets {#data-asets-private}
 


### PR DESCRIPTION
## Goals

Allow assets in spaCy projects to be downloaded optionally.

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
- Assets can be marked as `optional`. If `optional` is not set, it is assumed to be `False`. Example:
```yaml
assets:
  - dest: "assets/${vars.treebank}"
    optional: True
    git:
      repo: "https://github.com/UniversalDependencies/${vars.treebank}"
      branch: "master"
      path: ""
```
- New argument for `spacy project assets`: `--all` (`-a`). If this is set, all assets - including those marked as `optional` - are downloaded. Otherwise `optional` assets are ignored.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
New feature

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
