### PR TITLE
Fix PhraseMatcher remove overlapping terms

### DIFF
--- a/spacy/matcher/phrasematcher.pyx
+++ b/spacy/matcher/phrasematcher.pyx
@@ -118,6 +118,8 @@ cdef class PhraseMatcher:
                     # if token is not found, break out of the loop
                     current_node = NULL
                     break
+            path_nodes.push_back(current_node)
+            path_keys.push_back(self._terminal_hash)
             # remove the tokens from trie node if there are no other
             # keywords with them
             result = map_get(current_node, self._terminal_hash)

--- a/spacy/tests/matcher/test_phrase_matcher.py
+++ b/spacy/tests/matcher/test_phrase_matcher.py
@@ -122,6 +122,23 @@ def test_issue6839(en_vocab):
     assert matches
 
 
+@pytest.mark.issue(10643)
+def test_issue10643(en_vocab):
+    """Ensure overlapping terms can be removed from PhraseMatcher"""
+
+    # words = ["Only", "save", "out", "the", "binary", "data", "for", "the", "individual", "components", "."]
+    # doc = Doc(en_vocab, words=words)
+    terms = [Doc(en_vocab, words=["binary"]), Doc(en_vocab, words=["binary", "data"])]
+    matcher = PhraseMatcher(en_vocab)
+    for match_id, term in enumerate(terms):
+        matcher.add(str(match_id), [term])
+    # matches = matcher(doc)
+    for match_id in range(len(terms)):
+        matcher.remove(str(match_id))
+
+    assert len(matcher) == 0
+
+
 def test_matcher_phrase_matcher(en_vocab):
     doc = Doc(en_vocab, words=["I", "like", "Google", "Now", "best"])
     # intermediate phrase

--- a/spacy/tests/matcher/test_phrase_matcher.py
+++ b/spacy/tests/matcher/test_phrase_matcher.py
@@ -126,17 +126,30 @@ def test_issue6839(en_vocab):
 def test_issue10643(en_vocab):
     """Ensure overlapping terms can be removed from PhraseMatcher"""
 
-    # words = ["Only", "save", "out", "the", "binary", "data", "for", "the", "individual", "components", "."]
-    # doc = Doc(en_vocab, words=words)
-    terms = [Doc(en_vocab, words=["binary"]), Doc(en_vocab, words=["binary", "data"])]
+    # fmt: off
+    words = ["Only", "save", "out", "the", "binary", "data", "for", "the", "individual", "components", "."]
+    # fmt: on
+    doc = Doc(en_vocab, words=words)
+    terms = {
+        "0": Doc(en_vocab, words=["binary"]),
+        "1": Doc(en_vocab, words=["binary", "data"]),
+    }
     matcher = PhraseMatcher(en_vocab)
-    for match_id, term in enumerate(terms):
-        matcher.add(str(match_id), [term])
-    # matches = matcher(doc)
-    for match_id in range(len(terms)):
-        matcher.remove(str(match_id))
+    for match_id, term in terms.items():
+        matcher.add(match_id, [term])
 
+    matches = matcher(doc)
+    assert matches == [(en_vocab.strings["0"], 4, 5), (en_vocab.strings["1"], 4, 6)]
+
+    matcher.remove("0")
+    assert len(matcher) == 1
+    new_matches = matcher(doc)
+    assert new_matches == [(en_vocab.strings["1"], 4, 6)]
+
+    matcher.remove("1")
     assert len(matcher) == 0
+    no_matches = matcher(doc)
+    assert not no_matches
 
 
 def test_matcher_phrase_matcher(en_vocab):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->
## Fix PhraseMatcher remove overlapping terms
When removing keywords from a `PhraseMatcher`, the node after the last token was not considered a `path_node`. 
On line 140, we check if the current node contains other successors, and remove it if it doesn't.
```python
if node_pointer.filled == 1:
    # remove node
else:
    # keep node
```
If we don't include the node after the last token, we never check, if there are tokens of other keywords following this token.  As a result, removing the shorter of two overlapping keywords resulted in the removal of both terms.

The illustration below shows the issue using the terms of the newly added test case.

```mermaid
graph LR
    id1(self.c_map)-- binary --> id2( )
    id2 -- "self._terminal_hash" --> id3( )
    id2 -- "data" --> id4( )
    id4 -- "self._terminal_hash" --> id5( )

    subgraph "path_nodes (fixed)"
    id2
        subgraph "path_nodes (master)"
        id1
        end
    end
``` 

### Types of change
Fix issue #10643.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
