### PR TITLE
Temporary mypy workaround

### DIFF
--- a/spacy/ml/staticvectors.py
+++ b/spacy/ml/staticvectors.py
@@ -40,7 +40,8 @@ def forward(
     if not token_count:
         return _handle_empty(model.ops, model.get_dim("nO"))
     key_attr: int = model.attrs["key_attr"]
-    keys: Ints1d = model.ops.flatten(
+    # temporary workaround to allow Thinc PR #599
+    keys: Ints1d = model.ops.flatten(  # type: ignore[assignment]
         cast(Sequence, [doc.to_array(key_attr) for doc in docs])
     )
     vocab: Vocab = docs[0].vocab


### PR DESCRIPTION
## Description
https://github.com/explosion/thinc/pull/599 will fix a range of typing issues. It is intended to follow up with a similar spaCy PR. However, the Thinc PR causes a typing problem in spaCy to be picked up by mypy/pydantic that was not flagged up until now. This PR temporarily suppresses the warning using a `#type: ignore` statement.

### Types of change
Temporary workaround

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
