### PR TITLE
Vectorize `example.get_aligned_parses`

### DIFF
--- a/spacy/training/example.pyx
+++ b/spacy/training/example.pyx
@@ -1,5 +1,5 @@
 from collections.abc import Iterable as IterableInstance
-import numpy as np
+import numpy
 from murmurhash.mrmr cimport hash64
 
 from ..tokens.doc cimport Doc
@@ -189,31 +189,31 @@ cdef class Example:
             deps = [d if has_deps[i] else deps[i] for i, d in enumerate(proj_deps)]
 
         # Select all candidate tokens that are aligned to a single gold token.
-        c2g_single_toks = np.where(cand_to_gold.lengths == 1)[0]
+        c2g_single_toks = numpy.where(cand_to_gold.lengths == 1)[0]
 
         # Fetch all aligned gold token incides.
         if c2g_single_toks.shape == cand_to_gold.lengths.shape:
             # This the most likely case.
             gold_i = cand_to_gold[0:cand_to_gold.lengths.shape[0]].squeeze()
         else:
-            gold_i = np.vectorize(lambda x: cand_to_gold[int(x)][0])(c2g_single_toks).squeeze()
+            gold_i = numpy.vectorize(lambda x: cand_to_gold[int(x)][0])(c2g_single_toks).squeeze()
 
         # Fetch indices of all gold heads for the aligned gold tokens.
-        heads = np.asarray(heads, dtype='i')
+        heads = numpy.asarray(heads, dtype='i')
         gold_head_i = heads[gold_i]
 
         # Select all gold tokens that are heads of the previously selected 
         # gold tokens (and are aligned to a single candidate token).
         g2c_len_heads = gold_to_cand.lengths[gold_head_i]
-        g2c_len_heads = np.where(g2c_len_heads == 1)[0]
-        g2c_i = np.vectorize(lambda x: gold_to_cand[int(x)][0])(gold_head_i[g2c_len_heads]).squeeze()
+        g2c_len_heads = numpy.where(g2c_len_heads == 1)[0]
+        g2c_i = numpy.vectorize(lambda x: gold_to_cand[int(x)][0])(gold_head_i[g2c_len_heads]).squeeze()
 
         # Update head/dep alignments with the above.
-        aligned_heads = np.full((self.x.length), None)
+        aligned_heads = numpy.full((self.x.length), None)
         aligned_heads[c2g_single_toks[g2c_len_heads]] = g2c_i
 
-        deps = np.asarray(deps)
-        aligned_deps = np.full((self.x.length), None)
+        deps = numpy.asarray(deps)
+        aligned_deps = numpy.full((self.x.length), None)
         aligned_deps[c2g_single_toks] = deps[gold_i]
 
         return aligned_heads.tolist(), aligned_deps.tolist()
@@ -394,7 +394,7 @@ def _annot2array(vocab, tok_annot, doc_annot):
                 types = set([type(v) for v in value])
                 raise TypeError(Errors.E969.format(field=key, types=types)) from None
             values.append([vocab.strings.add(v) for v in value])
-    array = np.asarray(values, dtype="uint64")
+    array = numpy.asarray(values, dtype="uint64")
     return attrs, array.T
 
 

--- a/spacy/training/example.pyx
+++ b/spacy/training/example.pyx
@@ -194,7 +194,7 @@ cdef class Example:
         # Fetch all aligned gold token incides.
         if c2g_single_toks.shape == cand_to_gold.lengths.shape:
             # This the most likely case.
-            gold_i = cand_to_gold[0:cand_to_gold.lengths.shape[0]].squeeze()
+            gold_i = cand_to_gold[:].squeeze()
         else:
             gold_i = numpy.vectorize(lambda x: cand_to_gold[int(x)][0])(c2g_single_toks).squeeze()
 

--- a/spacy/training/example.pyx
+++ b/spacy/training/example.pyx
@@ -216,7 +216,7 @@ cdef class Example:
         aligned_deps = np.full((self.x.length), None)
         aligned_deps[c2g_single_toks] = deps[gold_i]
 
-        return aligned_heads, aligned_deps
+        return aligned_heads.tolist(), aligned_deps.tolist()
 
     def get_aligned_sent_starts(self):
         """Get list of SENT_START attributes aligned to the predicted tokenization.


### PR DESCRIPTION
## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Previously, we were aligning heads and dependencies between candidate and gold tokens by manually iterating over elements in the example/alignment array. This wasn't optimal as it didn't leverage `numpy`'s vectorization. This PR rewrites the alignment code with `numpy` ops, reducing parser loss calculation time by ~45-50 ms per mini-batch.

### Before vectorization
![parse-align-no-vec](https://user-images.githubusercontent.com/214450/168049411-efad9af5-f15c-4df3-b0fc-e7b966c576d8.png)

### After vectorization
![parse-align-vec](https://user-images.githubusercontent.com/214450/168044469-c37fed16-a0aa-4fc7-95f0-24ee56e45912.png)


### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->Performance enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
