### PR TITLE
bugfix parser labels

### DIFF
--- a/spacy/tests/training/test_rehearse.py
+++ b/spacy/tests/training/test_rehearse.py
@@ -181,7 +181,7 @@ def _optimize(nlp, component: str, data: List, rehearse: bool):
     elif component == "tagger":
         _add_tagger_label(pipe, data)
     elif component == "parser":
-        _add_tagger_label(pipe, data)
+        _add_parser_label(pipe, data)
     elif component == "textcat_multilabel":
         _add_textcat_label(pipe, data)
     else:


### PR DESCRIPTION
Small bugfix to the rehearse test

## Description
In the `parser` test loop the `tagger` labels were added by accident.

### Types of change
One liner bugfix

## Checklist

- [x ] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ x] I ran the tests, and all new and existing tests passed.
- [ x] My changes don't require a change to the documentation, or if they do, I've added all required information.
