### PR TITLE
Tagger/morphologizer alignment performance optimizations

### DIFF
--- a/spacy/training/alignment_array.pyx
+++ b/spacy/training/alignment_array.pyx
@@ -6,24 +6,26 @@ import numpy
 cdef class AlignmentArray:
     """AlignmentArray is similar to Thinc's Ragged with two simplfications:
     indexing returns numpy arrays and this type can only be used for CPU arrays.
-    However, these changes make AlginmentArray more efficient for indexing in a
+    However, these changes make AlignmentArray more efficient for indexing in a
     tight loop."""
 
     __slots__ = []
 
     def __init__(self, alignment: List[List[int]]):
-        self._lengths = None
-        self._starts_ends = numpy.zeros(len(alignment) + 1, dtype="i")
-
         cdef int data_len = 0
         cdef int outer_len
         cdef int idx
+
+        starts_ends = [0] * (len(alignment) + 1)
         for idx, outer in enumerate(alignment):
             outer_len = len(outer)
-            self._starts_ends[idx + 1] = self._starts_ends[idx] + outer_len
+            starts_ends[idx + 1] = starts_ends[idx] + outer_len
             data_len += outer_len
 
+        self._lengths = None
+        self._starts_ends = numpy.asarray(starts_ends, dtype='i')
         self._data = numpy.empty(data_len, dtype="i")
+
         idx = 0
         for outer in alignment:
             for inner in outer:

--- a/spacy/training/example.pyx
+++ b/spacy/training/example.pyx
@@ -153,24 +153,74 @@ cdef class Example:
     def get_aligned(self, field, as_string=False):
         """Return an aligned array for a token attribute."""
         align = self.alignment.x2y
+        gold_values = self.reference.to_array([field])
+
+        def _vectorized():
+            # Fast path for Doc attributes/fields that are predominantly a single value,
+            # i.e., TAG, POS, MORPH.
+            x2y_single_toks = []
+            x2y_single_toks_i = []
+
+            x2y_multiple_toks = []
+            x2y_multiple_toks_i = []
+
+            # Gather indices of gold tokens aligned to the candidate tokens into two buckets.
+            #   Bucket 1: All tokens that have a one-to-one alignment.
+            #   Bucket 2: All tokens that have a one-to-many alignment.
+            for idx, token in enumerate(self.predicted):
+                aligned_gold_i = align[token.i]
+                if len(aligned_gold_i) == 1:
+                    x2y_single_toks.append(aligned_gold_i.item())
+                    x2y_single_toks_i.append(idx)
+                else:
+                    x2y_multiple_toks.append(aligned_gold_i)
+                    x2y_multiple_toks_i.append(idx)
+
+            # Map elements of the first bucket directly to the output array.
+            output = numpy.full(len(self.predicted), None)
+            output[x2y_single_toks_i] = gold_values[x2y_single_toks].squeeze()
+
+            # Collapse many-to-one alignments into one-to-one alignments if they
+            # share the same value. Map to None in all other cases.
+            for i in range(len(x2y_multiple_toks)):
+                aligned_gold_values = gold_values[x2y_multiple_toks[i]]
+
+                # If all aligned tokens have the same value, use it.
+                x2y_multiple_toks[i] = aligned_gold_values[0].item() \
+                    if len(set(list(aligned_gold_values))) == 1 else None
+
+            output[x2y_multiple_toks_i] = x2y_multiple_toks
+
+            return output.tolist()
+
+        def _non_vectorized():
+            # Slower path for fields that return multiple values (resulting
+            # in ragged arrays that cannot be vectorized trivially).
+            output = [None] * len(self.predicted)
+
+            for token in self.predicted:
+                aligned_gold_i = align[token.i]
+                values_org = gold_values[aligned_gold_i]
+                values = values_org.ravel()
+                if len(values) == 0:
+                    output[token.i] = None
+                elif len(values) == 1:
+                    output[token.i] = values.item()
+                elif len(set(list(values))) == 1:
+                    # If all aligned tokens have the same value, use it.
+                    output[token.i] = values[0].item()
+                else:
+                    output[token.i] = None
+
+            return output
+
 
         vocab = self.reference.vocab
-        gold_values = self.reference.to_array([field])
-        output = [None] * len(self.predicted)
-        for token in self.predicted:
-            values = gold_values[align[token.i]]
-            values = values.ravel()
-            if len(values) == 0:
-                output[token.i] = None
-            elif len(values) == 1:
-                output[token.i] = values.item()
-            elif len(set(list(values))) == 1:
-                # If all aligned tokens have the same value, use it.
-                output[token.i] = values[0].item()
-            else:
-                output[token.i] = None
+        output = _vectorized() if len(gold_values.shape) == 1 else _non_vectorized()
+
         if as_string and field not in ["ENT_IOB", "SENT_START"]:
             output = [vocab.strings[o] if o is not None else o for o in output]
+
         return output
 
     def get_aligned_parse(self, projectivize=True):

--- a/spacy/training/example.pyx
+++ b/spacy/training/example.pyx
@@ -163,10 +163,10 @@ cdef class Example:
             if len(values) == 0:
                 output[token.i] = None
             elif len(values) == 1:
-                output[token.i] = values[0]
+                output[token.i] = values.item()
             elif len(set(list(values))) == 1:
                 # If all aligned tokens have the same value, use it.
-                output[token.i] = values[0]
+                output[token.i] = values[0].item()
             else:
                 output[token.i] = None
         if as_string and field not in ["ENT_IOB", "SENT_START"]:


### PR DESCRIPTION
## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
* The offset calculation in `AlignmentArray` was incurring a lot of overhead as it was using single element index/add ops to populate the underlying `numpy` array, leading to a lot of interop chatter that invoked short-living array allocations, etc. Using a native Python list as an intermediate buffer removes this overhead, cutting down execution time by half.

* In `example.get_aligned`, indexing into the attribute array of aligned gold tokens yielded `numpy` arrays of unit length and `numpy` integer types (representing the attribute hashes). This was being passed to `StringStore` to retrieve the string value corresponding to the hash. 

  In the `StringStore.__getitem__` method, there exists a fast path where a LUT is used to check for/return special symbol. This was done by comparing the incoming input against the length of the ordered LUT. Under normal circumstances, this would be a high-throughput op, but since the values passed to this method were not native Python types, the generated C++ code ended up invoking the `numpy`-specific override for the internal `RichCompare` `PyObject` virtual function. This incurred a fair amount of overhead, which was further exacerbated by the calls not being vectorized.

  This overhead was eliminated by explicitly unwrapping unit-length arrays and coercing `numpy` integer types to native Python types before passing them to `StringStore`.

* Finally, the most likely case of alignment w.r.t the `TAG`, `POS`, and `DEP` resulted in candidate tokens forming a 1-to-1 correspondence with the gold tokens. This allowed for the implementation of a vectorized fast path.

### Before
![tag-morph-before](https://user-images.githubusercontent.com/214450/168264068-9d28de96-fa45-49f6-9782-82fe94d0e57b.png)

### After 
![tag-morph-after](https://user-images.githubusercontent.com/214450/168264084-c5ba4944-efcb-4961-837e-f77513195e19.png)
 
(The above figures do not include the parser loss speed-up from #10789) 

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->Performance enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
