### PR TITLE
oov confusion fix

### DIFF
--- a/website/docs/models/index.md
+++ b/website/docs/models/index.md
@@ -115,7 +115,7 @@ The Finnish, Korean and Swedish `md` and `lg` pipelines use
 running a trained pipeline on texts and working with [`Doc`](/api/doc) objects,
 you shouldn't notice any difference with floret vectors. With floret vectors no
 tokens are out-of-vocabulary, so [`Token.is_oov`](/api/token#attributes) will
-return `True` for all tokens.
+return `False` for all tokens.
 
 If you access vectors directly for similarity comparisons, there are a few
 differences because floret vectors don't include a fixed word list like the


### PR DESCRIPTION
Small edit to the docs at https://spacy.io/models. 

## Description
Floret vectors compute representations for all strings and as such there are never out-of-vocabulary vectors. This means for all `Token` objects the `is_oov` attribute is always `False`. The docs said its `True`, but the implementation is correct and it does output `False`.

### Types of change
Mini doc fix

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
