### PR TITLE
Better errors for has_annotation and Matcher

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -914,9 +914,7 @@ class Errors(metaclass=ErrorsWithCodes):
     E1034 = ("Node index {i} out of bounds ({length})")
     E1035 = ("Token index {i} out of bounds ({length})")
     E1036 = ("Cannot index into NoneNode")
-    E1037 = ("\"{attr}\" is not a valid value for attr.\n"
-             "Please consult https://spacy.io/api/token#attributes "
-             "for more information!")
+    E1037 = ("Invalid attribute value '{attr}'.")
 
 # Deprecated model shortcuts, only used in errors and warnings
 OLD_MODEL_SHORTCUTS = {

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -914,7 +914,9 @@ class Errors(metaclass=ErrorsWithCodes):
     E1034 = ("Node index {i} out of bounds ({length})")
     E1035 = ("Token index {i} out of bounds ({length})")
     E1036 = ("Cannot index into NoneNode")
-
+    E1037 = ("\"{attr}\" is not a valid value for attr.\n"
+             "Please consult https://spacy.io/api/token#attributes "
+             "for more information!")
 
 # Deprecated model shortcuts, only used in errors and warnings
 OLD_MODEL_SHORTCUTS = {

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -445,10 +445,10 @@ class Errors(metaclass=ErrorsWithCodes):
             "same, but found '{nlp}' and '{vocab}' respectively.")
     E152 = ("The attribute {attr} is not supported for token patterns. "
             "Please use the option `validate=True` with the Matcher, PhraseMatcher, "
-            "or EntityRuler for more details.")
+            "EntityRuler or AttributeRuler for more details.")
     E153 = ("The value type {vtype} is not supported for token patterns. "
             "Please use the option validate=True with Matcher, PhraseMatcher, "
-            "or EntityRuler for more details.")
+            "EntityRuler or AttributeRuler for more details.")
     E154 = ("One of the attributes or values is not supported for token "
             "patterns. Please use the option `validate=True` with the Matcher, "
             "PhraseMatcher, or EntityRuler for more details.")

--- a/spacy/matcher/matcher.pyx
+++ b/spacy/matcher/matcher.pyx
@@ -786,6 +786,7 @@ def _preprocess_pattern(token_specs, vocab, extensions_table, extra_predicates):
 def _get_attr_values(spec, string_store):
     attr_values = []
     for attr, value in spec.items():
+        input_attr = attr
         if isinstance(attr, str):
             attr = attr.upper()
             if attr == '_':
@@ -814,7 +815,7 @@ def _get_attr_values(spec, string_store):
             attr_values.append((attr, value))
         else:
             # should be caught in validation
-            raise ValueError(Errors.E152.format(attr=attr))
+            raise ValueError(Errors.E152.format(attr=input_attr))
     return attr_values
 
 

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -426,9 +426,7 @@ cdef class Doc:
         attr = intify_attr(attr)
         if attr is None:
             raise ValueError(
-                f"\"{input_attr}\" is not a valid value for attr.\n"
-                "Please consult https://spacy.io/api/token#attributes "
-                "for more information!"
+                Errors.E1037.format(attr=input_attr)
             )
         # adjust attributes
         if attr == HEAD:

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -414,6 +414,7 @@ cdef class Doc:
         """
 
         # empty docs are always annotated
+        input_attr = attr
         if self.length == 0:
             return True
         cdef int i
@@ -423,6 +424,12 @@ cdef class Doc:
         elif attr == "IS_SENT_END" or attr == self.vocab.strings["IS_SENT_END"]:
             attr = SENT_START
         attr = intify_attr(attr)
+        if attr is None:
+            raise ValueError(
+                f"\"{input_attr}\" is not a valid value for attr.\n"
+                "Please consult https://spacy.io/api/token#attributes "
+                "for more information!"
+            )
         # adjust attributes
         if attr == HEAD:
             # HEAD does not have an unset state, so rely on DEP


### PR DESCRIPTION
More informative errors when wrong `Doc` attribute is provided

## Description
Noticed that when providing a wrong attribute to `Doc.has_annotation` the error does not get caught and the `None` returned by `intify_attr` propagates down to leading to a cryptic message:

```
~/spaCy/spacy/tokens/doc.pyx in genexpr()

TypeError: an integer is required

```

The `Matcher` object handles this user error, but it first assigns `None` with `attr = IDS.get(attr)` and then tells the user that `None` is an invalid input. This PR stores the `input_attr = attr` early on and then reports the error with the input rather than `None`.  

### Types of change
Small fix to the error messages.

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
