### PR TITLE
add floret to static vectors docs

### DIFF
--- a/website/docs/usage/embeddings-transformers.md
+++ b/website/docs/usage/embeddings-transformers.md
@@ -530,7 +530,8 @@ models, which can **improve the accuracy** of your components.
 Word vectors in spaCy are "static" in the sense that they are not learned
 parameters of the statistical models, and spaCy itself does not feature any
 algorithms for learning word vector tables. You can train a word vectors table
-using tools such as [Gensim](https://radimrehurek.com/gensim/),
+using tools such as [floret](https://github.com/explosion/floret),
+[Gensim](https://radimrehurek.com/gensim/),
 [FastText](https://fasttext.cc/) or
 [GloVe](https://nlp.stanford.edu/projects/glove/), or download existing
 pretrained vectors. The [`init vectors`](/api/cli#init-vectors) command lets you


### PR DESCRIPTION
Adds a link to [floret](https://github.com/explosion/floret) in the static vectors section of the docs.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
