### PR TITLE
Handle Cyrillic combining diacritics

### DIFF
--- a/spacy/lang/bg/__init__.py
+++ b/spacy/lang/bg/__init__.py
@@ -2,6 +2,7 @@ from .stop_words import STOP_WORDS
 from .tokenizer_exceptions import TOKENIZER_EXCEPTIONS
 from .lex_attrs import LEX_ATTRS
 from ..tokenizer_exceptions import BASE_EXCEPTIONS
+from ..punctuation import CYRILLIC_TOKENIZER_INFIXES
 
 from ...language import Language, BaseDefaults
 from ...attrs import LANG
@@ -16,6 +17,7 @@ class BulgarianDefaults(BaseDefaults):
 
     stop_words = STOP_WORDS
     tokenizer_exceptions = update_exc(BASE_EXCEPTIONS, TOKENIZER_EXCEPTIONS)
+    infixes = CYRILLIC_TOKENIZER_INFIXES
 
 
 class Bulgarian(Language):

--- a/spacy/lang/char_classes.py
+++ b/spacy/lang/char_classes.py
@@ -258,6 +258,10 @@ ALPHA = group_chars(
 ALPHA_LOWER = group_chars(_lower + _uncased)
 ALPHA_UPPER = group_chars(_upper + _uncased)
 
+_combining_diacritics = r"\u0300-\u036f"
+
+COMBINING_DIACRITICS = _combining_diacritics
+
 _units = (
     "km km² km³ m m² m³ dm dm² dm³ cm cm² cm³ mm mm² mm³ ha µm nm yd in ft "
     "kg g mg µg t lb oz m/s km/h kmh mph hPa Pa mbar mb MB kb KB gb GB tb "

--- a/spacy/lang/punctuation.py
+++ b/spacy/lang/punctuation.py
@@ -1,5 +1,5 @@
 from .char_classes import LIST_PUNCT, LIST_ELLIPSES, LIST_QUOTES, LIST_CURRENCY
-from .char_classes import LIST_ICONS, HYPHENS, CURRENCY, UNITS
+from .char_classes import LIST_ICONS, HYPHENS, CURRENCY, UNITS, COMBINING_DIACRITICS
 from .char_classes import CONCAT_QUOTES, ALPHA_LOWER, ALPHA_UPPER, ALPHA, PUNCT
 
 
@@ -39,8 +39,20 @@ TOKENIZER_INFIXES = (
         r"(?<=[{al}{q}])\.(?=[{au}{q}])".format(
             al=ALPHA_LOWER, au=ALPHA_UPPER, q=CONCAT_QUOTES
         ),
-        r"(?<=[{a}]),(?=[{a}])".format(a=ALPHA),
+        r"(?<=[{a}])(?:{p})(?=[{a}])".format(a=ALPHA, p=PUNCT),
         r"(?<=[{a}])(?:{h})(?=[{a}])".format(a=ALPHA, h=HYPHENS),
         r"(?<=[{a}0-9])[:<>=/](?=[{a}])".format(a=ALPHA),
     ]
 )
+
+
+# Some languages written with the Cyrillic alphabet permit the use of diacritics
+# to mark stressed syllables in words where stress is distinctive. Such languages
+# should use 'CYRILLIC_TOKENIZER_INFIXES' in place of 'TOKENIZER_INFIXES.
+CYRILLIC_TOKENIZER_INFIXES = list(TOKENIZER_INFIXES) + [
+    r"(?<=[{a}][{d}])\.".format(a=ALPHA, d=COMBINING_DIACRITICS),
+    r"(?<=[{a}][{d}])(?:{p})(?=[{a}])".format(a=ALPHA, d=COMBINING_DIACRITICS, p=PUNCT),
+    r"(?<=[{a}][{d}])(?:{h})(?=[{a}])".format(
+        a=ALPHA, d=COMBINING_DIACRITICS, h=HYPHENS
+    ),
+]

--- a/spacy/lang/ru/__init__.py
+++ b/spacy/lang/ru/__init__.py
@@ -1,10 +1,12 @@
 from typing import Optional, Callable
+from numpy import indices
 from thinc.api import Model
 
 from .stop_words import STOP_WORDS
 from .tokenizer_exceptions import TOKENIZER_EXCEPTIONS
 from .lex_attrs import LEX_ATTRS
 from .lemmatizer import RussianLemmatizer
+from ..punctuation import CYRILLIC_TOKENIZER_INFIXES
 from ...language import Language, BaseDefaults
 
 
@@ -12,6 +14,7 @@ class RussianDefaults(BaseDefaults):
     tokenizer_exceptions = TOKENIZER_EXCEPTIONS
     lex_attr_getters = LEX_ATTRS
     stop_words = STOP_WORDS
+    infixes = CYRILLIC_TOKENIZER_INFIXES
 
 
 class Russian(Language):

--- a/spacy/lang/uk/__init__.py
+++ b/spacy/lang/uk/__init__.py
@@ -6,6 +6,7 @@ from .tokenizer_exceptions import TOKENIZER_EXCEPTIONS
 from .stop_words import STOP_WORDS
 from .lex_attrs import LEX_ATTRS
 from .lemmatizer import UkrainianLemmatizer
+from ..punctuation import CYRILLIC_TOKENIZER_INFIXES
 from ...language import Language, BaseDefaults
 
 
@@ -13,6 +14,7 @@ class UkrainianDefaults(BaseDefaults):
     tokenizer_exceptions = TOKENIZER_EXCEPTIONS
     lex_attr_getters = LEX_ATTRS
     stop_words = STOP_WORDS
+    infixes = CYRILLIC_TOKENIZER_INFIXES
 
 
 class Ukrainian(Language):

--- a/spacy/tests/lang/bg/test_tokenizer.py
+++ b/spacy/tests/lang/bg/test_tokenizer.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+def test_bg_tokenizer_handles_final_diacritics(bg_tokenizer):
+    text = "Ня̀маше яйца̀. Ня̀маше яйца̀."
+    tokens = bg_tokenizer(text)
+    assert tokens[1].text == "яйца̀"
+    assert tokens[2].text == "."

--- a/spacy/tests/lang/ru/test_tokenizer.py
+++ b/spacy/tests/lang/ru/test_tokenizer.py
@@ -1,3 +1,4 @@
+from string import punctuation
 import pytest
 
 
@@ -122,3 +123,25 @@ def test_ru_tokenizer_splits_bracket_period(ru_tokenizer):
     text = "(Раз, два, три, проверка)."
     tokens = ru_tokenizer(text)
     assert tokens[len(tokens) - 1].text == "."
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "рекоменду́я подда́ть жару́. Самого́ Баргамота",
+        "РЕКОМЕНДУ́Я ПОДДА́ТЬ ЖАРУ́. САМОГО́ БАРГАМОТА",
+        "рекоменду̍я подда̍ть жару̍. Самого̍ Баргамота",
+        "рекоменду̍я подда̍ть жару̍,самого̍ Баргамота",
+        "рекоменду̍я подда̍ть жару̍:самого̍ Баргамота",
+        "рекоменду̍я подда̍ть жару̍:самого̍ Баргамота",
+        "рекоменду̍я подда̍ть жару̍. самого̍ Баргамота",
+        "рекоменду̍я подда̍ть жару̍, самого̍ Баргамота",
+        "рекоменду̍я подда̍ть жару̍: самого̍ Баргамота",
+        "рекоменду̍я подда̍ть жару̍: самого̍ Баргамота",
+        "рекоменду̍я подда̍ть жару̍-самого̍ Баргамота",
+    ],
+)
+def test_ru_tokenizer_handles_final_diacritics(ru_tokenizer, text):
+    tokens = ru_tokenizer(text)
+    assert tokens[2].text in ("жару́", "ЖАРУ́", "жару̍")
+    assert tokens[3].text in punctuation

--- a/spacy/tests/lang/uk/test_tokenizer.py
+++ b/spacy/tests/lang/uk/test_tokenizer.py
@@ -140,3 +140,10 @@ def test_uk_tokenizer_splits_bracket_period(uk_tokenizer):
     text = "(Раз, два, три, проверка)."
     tokens = uk_tokenizer(text)
     assert tokens[len(tokens) - 1].text == "."
+
+
+def test_uk_tokenizer_handles_final_diacritics(uk_tokenizer):
+    text = "Хлібі́в не було́. Хлібі́в не було́."
+    tokens = uk_tokenizer(text)
+    assert tokens[2].text == "було́"
+    assert tokens[3].text == "."


### PR DESCRIPTION
## Description
Some languages that are written in the Cyrillic alphabet permit the use of diacritic marks (́á à a̍) to mark the stressed syllable in words where the stress is distinctive. Unlike in the Latin alphabet, there are often no separate Unicode points for Cyrillic accented vowels; instead, the standard Cyrillic letter is followed by a letter from the Unicode block [Combining Diacritical Marks](https://unicode-table.com/en/blocks/combining-diacritical-marks/).

This PR adds support for these marks to the tokenizers for Russian, Ukrainian and Bulgarian. Because this functionality is potentially useful for any language written in Cyrillic with distinctive prosodic stress — including languages not yet supported — it has been implemented in such a way that the feature can easily be added to further languages without copying code.

### Types of change
Bugfix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
