### PR TITLE
Update documentation for displacy style kwargs

### DIFF
--- a/website/docs/api/top-level.md
+++ b/website/docs/api/top-level.md
@@ -239,7 +239,7 @@ browser. Will run a simple web server.
 | Name      | Description                                                                                                                                                       |
 | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `docs`    | Document(s) or span(s) to visualize. ~~Union[Iterable[Union[Doc, Span]], Doc, Span]~~                                                                             |
-| `style`   | Visualization style, `"dep"`, `"span"` <Tag variant="new">3.3</Tag> or `"ent"`. Defaults to `"dep"`. ~~str~~                                                                                             |
+| `style`   | Visualization style, `"dep"`, `"ent"` or `"span"` <Tag variant="new">3.3</Tag>. Defaults to `"dep"`. ~~str~~                                                                                             |
 | `page`    | Render markup as full HTML page. Defaults to `True`. ~~bool~~                                                                                                     |
 | `minify`  | Minify HTML markup. Defaults to `False`. ~~bool~~                                                                                                                 |
 | `options` | [Visualizer-specific options](#displacy_options), e.g. colors. ~~Dict[str, Any]~~                                                                                 |
@@ -264,7 +264,7 @@ Render a dependency parse tree or named entity visualization.
 | Name        | Description                                                                                                                                                                            |
 | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `docs`      | Document(s) or span(s) to visualize. ~~Union[Iterable[Union[Doc, Span, dict]], Doc, Span, dict]~~                                                                                      |
-| `style`     | Visualization style, `"dep"`, `"span"` <Tag variant="new">3.3</Tag> or `"ent"`. Defaults to `"dep"`. ~~str~~                                                                                                                  |
+| `style`     | Visualization style,`"dep"`, `"ent"` or `"span"` <Tag variant="new">3.3</Tag>. Defaults to `"dep"`. ~~str~~                                                                                                                  |
 | `page`      | Render markup as full HTML page. Defaults to `True`. ~~bool~~                                                                                                                          |
 | `minify`    | Minify HTML markup. Defaults to `False`. ~~bool~~                                                                                                                                      |
 | `options`   | [Visualizer-specific options](#displacy_options), e.g. colors. ~~Dict[str, Any]~~                                                                                                      |

--- a/website/docs/api/top-level.md
+++ b/website/docs/api/top-level.md
@@ -239,7 +239,7 @@ browser. Will run a simple web server.
 | Name      | Description                                                                                                                                                       |
 | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `docs`    | Document(s) or span(s) to visualize. ~~Union[Iterable[Union[Doc, Span]], Doc, Span]~~                                                                             |
-| `style`   | Visualization style, `"dep"` or `"ent"`. Defaults to `"dep"`. ~~str~~                                                                                             |
+| `style`   | Visualization style, `"dep"`, `"span"` <Tag variant="new">3.3</Tag> or `"ent"`. Defaults to `"dep"`. ~~str~~                                                                                             |
 | `page`    | Render markup as full HTML page. Defaults to `True`. ~~bool~~                                                                                                     |
 | `minify`  | Minify HTML markup. Defaults to `False`. ~~bool~~                                                                                                                 |
 | `options` | [Visualizer-specific options](#displacy_options), e.g. colors. ~~Dict[str, Any]~~                                                                                 |
@@ -264,7 +264,7 @@ Render a dependency parse tree or named entity visualization.
 | Name        | Description                                                                                                                                                                            |
 | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `docs`      | Document(s) or span(s) to visualize. ~~Union[Iterable[Union[Doc, Span, dict]], Doc, Span, dict]~~                                                                                      |
-| `style`     | Visualization style, `"dep"` or `"ent"`. Defaults to `"dep"`. ~~str~~                                                                                                                  |
+| `style`     | Visualization style, `"dep"`, `"span"` <Tag variant="new">3.3</Tag> or `"ent"`. Defaults to `"dep"`. ~~str~~                                                                                                                  |
 | `page`      | Render markup as full HTML page. Defaults to `True`. ~~bool~~                                                                                                                          |
 | `minify`    | Minify HTML markup. Defaults to `False`. ~~bool~~                                                                                                                                      |
 | `options`   | [Visualizer-specific options](#displacy_options), e.g. colors. ~~Dict[str, Any]~~                                                                                                      |


### PR DESCRIPTION
## Description
Added `"span"` to the accepted values for the visualization styles in the `displacy.serve` and `displacy.render` top-level functions. The `"span"` style is new as of spaCy 3.3, so I added the "new" tag for that option only. The `"span"` visualization style is listed between the `"dep"` and `"ent"` visualization styles to avoid the appearance of the "new" tag applying to all visualization styles while maintaining the default-value-first convention.

### Types of change
Update documentation

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
