### PR TITLE
Add guards around torch import for coref

### DIFF
--- a/spacy/ml/models/__init__.py
+++ b/spacy/ml/models/__init__.py
@@ -1,5 +1,3 @@
-from .coref import * #noqa
-from .span_predictor import * #noqa
 from .entity_linker import *  # noqa
 from .multi_task import *  # noqa
 from .parser import *  # noqa
@@ -7,3 +5,12 @@ from .spancat import *  # noqa
 from .tagger import *  # noqa
 from .textcat import *  # noqa
 from .tok2vec import *  # noqa
+
+# some models require Torch
+try:
+    import torch
+    from .coref import * #noqa
+    from .span_predictor import * #noqa
+except ImportError:
+    pass
+

--- a/spacy/ml/models/__init__.py
+++ b/spacy/ml/models/__init__.py
@@ -7,10 +7,8 @@ from .textcat import *  # noqa
 from .tok2vec import *  # noqa
 
 # some models require Torch
-try:
-    import torch
+from thinc.util import has_torch
+if has_torch:
     from .coref import * #noqa
     from .span_predictor import * #noqa
-except ImportError:
-    pass
 

--- a/spacy/ml/models/coref.py
+++ b/spacy/ml/models/coref.py
@@ -8,7 +8,6 @@ from thinc.util import xp2torch, torch2xp
 
 from ...tokens import Doc
 from ...util import registry
-from .coref_util import add_dummy
 
 
 @registry.architectures("spacy.Coref.v1")
@@ -184,6 +183,22 @@ class CorefScorer(torch.nn.Module):
 
         coref_scores = torch.cat(a_scores_lst, dim=0)
         return coref_scores, top_indices
+
+
+# Note this function is kept here to keep a torch dep out of coref_util.
+def add_dummy(tensor: torch.Tensor, eps: bool = False):
+    """Prepends zeros (or a very small value if eps is True)
+    to the first (not zeroth) dimension of tensor.
+    """
+    kwargs = dict(device=tensor.device, dtype=tensor.dtype)
+    shape: List[int] = list(tensor.shape)
+    shape[1] = 1
+    if not eps:
+        dummy = torch.zeros(shape, **kwargs)  # type: ignore
+    else:
+        dummy = torch.full(shape, EPSILON, **kwargs)  # type: ignore
+    output = torch.cat((dummy, tensor), dim=1)
+    return output
 
 
 class AnaphoricityScorer(torch.nn.Module):

--- a/spacy/ml/models/coref.py
+++ b/spacy/ml/models/coref.py
@@ -185,6 +185,7 @@ class CorefScorer(torch.nn.Module):
         return coref_scores, top_indices
 
 
+EPSILON = 1e-7
 # Note this function is kept here to keep a torch dep out of coref_util.
 def add_dummy(tensor: torch.Tensor, eps: bool = False):
     """Prepends zeros (or a very small value if eps is True)

--- a/spacy/ml/models/coref.py
+++ b/spacy/ml/models/coref.py
@@ -1,10 +1,9 @@
 from typing import List, Tuple
-import torch
 
 from thinc.api import Model, chain
 from thinc.api import PyTorchWrapper, ArgsKwargs
 from thinc.types import Floats2d, Ints2d, Ints1d
-from thinc.util import xp2torch, torch2xp
+from thinc.util import torch, xp2torch, torch2xp
 
 from ...tokens import Doc
 from ...util import registry

--- a/spacy/ml/models/coref_util.py
+++ b/spacy/ml/models/coref_util.py
@@ -8,8 +8,6 @@ MentionClusters = List[List[Tuple[int, int]]]
 
 DEFAULT_CLUSTER_PREFIX = "coref_clusters"
 
-EPSILON = 1e-7
-
 class GraphNode:
     def __init__(self, node_id: int):
         self.id = node_id

--- a/spacy/ml/models/coref_util.py
+++ b/spacy/ml/models/coref_util.py
@@ -2,7 +2,6 @@ from thinc.types import Ints2d
 from spacy.tokens import Doc
 from typing import List, Tuple, Callable, Any, Set, Dict
 from ...util import registry
-import torch
 
 # type alias to make writing this less tedious
 MentionClusters = List[List[Tuple[int, int]]]
@@ -24,20 +23,6 @@ class GraphNode:
     def __repr__(self) -> str:
         return str(self.id)
 
-
-def add_dummy(tensor: torch.Tensor, eps: bool = False):
-    """ Prepends zeros (or a very small value if eps is True)
-    to the first (not zeroth) dimension of tensor.
-    """
-    kwargs = dict(device=tensor.device, dtype=tensor.dtype)
-    shape: List[int] = list(tensor.shape)
-    shape[1] = 1
-    if not eps:
-        dummy = torch.zeros(shape, **kwargs)          # type: ignore
-    else:
-        dummy = torch.full(shape, EPSILON, **kwargs)  # type: ignore
-    output = torch.cat((dummy, tensor), dim=1)
-    return output
 
 def get_sentence_ids(doc):
     out = []

--- a/spacy/ml/models/span_predictor.py
+++ b/spacy/ml/models/span_predictor.py
@@ -1,10 +1,9 @@
 from typing import List, Tuple
-import torch
 
 from thinc.api import Model, chain, tuplify
 from thinc.api import PyTorchWrapper, ArgsKwargs
 from thinc.types import Floats2d, Ints1d
-from thinc.util import xp2torch, torch2xp
+from thinc.util import torch, xp2torch, torch2xp
 
 from ...tokens import Doc
 from ...util import registry


### PR DESCRIPTION
Torch is required for the coref/spanpred models but shouldn't be
required for spaCy in general.

The one tricky part of this is that one function in coref_util relied on
torch, but that file was imported in several places. Since the function
was only used in one place I moved it there.

<!--- Provide a general summary of your changes in the title. -->

Tests are not working because they're a bit out of sync with other re-organizations, but that is not specific to the changes in this PR.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

bug fix? for in-progress PR

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
