### PR TITLE
Reimplement parser rehearsal function

### DIFF
--- a/spacy/pipeline/_parser_internals/batch.pyx
+++ b/spacy/pipeline/_parser_internals/batch.pyx
@@ -32,6 +32,9 @@ class GreedyBatch(Batch):
     def advance(self, scores):
         self._next_states = self._moves.transition_states(self._next_states, scores)
 
+    def advance_with_actions(self, actions):
+        self._next_states = self._moves.apply_transitions(self._next_states, actions)
+
     def get_states(self):
         return self._states
 

--- a/spacy/pipeline/_parser_internals/transition_system.pxd
+++ b/spacy/pipeline/_parser_internals/transition_system.pxd
@@ -54,5 +54,9 @@ cdef class TransitionSystem:
     cdef int set_costs(self, int* is_valid, weight_t* costs,
                        const StateC* state, gold) except -1
 
+
+cdef void c_apply_actions(TransitionSystem moves, StateC** states, const int* actions,
+    int batch_size) nogil
+
 cdef void c_transition_batch(TransitionSystem moves, StateC** states, const float* scores,
         int nr_class, int batch_size) nogil

--- a/spacy/pipeline/transition_parser.pyx
+++ b/spacy/pipeline/transition_parser.pyx
@@ -1,5 +1,6 @@
 # cython: infer_types=True, cdivision=True, boundscheck=False, binding=True
 from __future__ import print_function
+from typing import List
 from cymem.cymem cimport Pool
 cimport numpy as np
 from itertools import islice
@@ -12,11 +13,12 @@ import contextlib
 import srsly
 from thinc.api import set_dropout_rate, CupyOps, get_array_module
 from thinc.extra.search cimport Beam
+from thinc.types import Ints1d
 import numpy.random
 import numpy
 import warnings
 
-from ._parser_internals.stateclass cimport StateClass
+from ._parser_internals.stateclass cimport StateC, StateClass
 from ..tokens.doc cimport Doc
 from .trainable_pipe import TrainablePipe
 from ._parser_internals cimport _beam_utils
@@ -359,7 +361,42 @@ class Parser(TrainablePipe):
 
     def rehearse(self, examples, sgd=None, losses=None, **cfg):
         """Perform a "rehearsal" update, to prevent catastrophic forgetting."""
-        raise NotImplementedError
+        if losses is None:
+            losses = {}
+        for multitask in self._multitasks:
+            if hasattr(multitask, 'rehearse'):
+                multitask.rehearse(examples, losses=losses, sgd=sgd)
+        if self._rehearsal_model is None:
+            return None
+        losses.setdefault(self.name, 0.)
+        validate_examples(examples, "Parser.rehearse")
+        docs = [eg.predicted for eg in examples]
+        # This is pretty dirty, but the NER can resize itself in init_batch,
+        # if labels are missing. We therefore have to check whether we need to
+        # expand our model output.
+        self._resize()
+        # Prepare the stepwise model, and get the callback for finishing the batch
+        set_dropout_rate(self._rehearsal_model, 0.0)
+        set_dropout_rate(self.model, 0.0)
+        (student_states, student_scores), backprop_scores = self.model.begin_update((docs, self.moves))
+        actions = states2actions(student_states)
+        _, teacher_scores = self._rehearsal_model.predict((docs, self.moves, actions))
+
+        teacher_scores = self.model.ops.xp.vstack(teacher_scores)
+        student_scores = self.model.ops.xp.vstack(student_scores)
+        assert teacher_scores.shape == student_scores.shape
+
+        d_scores = (student_scores - teacher_scores) / teacher_scores.shape[0]
+        # If all weights for an output are 0 in the original model, don't
+        # supervise that output. This allows us to add classes.
+        loss = (d_scores**2).sum() / d_scores.size
+        backprop_scores((student_states, d_scores))
+
+        if sgd is not None:
+            self.finish_update(sgd)
+        losses[self.name] += loss
+
+        return losses
 
     def update_beam(self, examples, *, beam_width,
             drop=0., sgd=None, losses=None, beam_density=0.0):
@@ -474,3 +511,26 @@ def _change_attrs(model, **kwargs):
             model.attrs.pop(key)
         else:
             model.attrs[key] = value
+
+
+def states2actions(states: List[StateClass]) -> List[Ints1d]:
+    cdef int step
+    cdef StateClass state
+    cdef StateC* c_state
+    actions = []
+    while True:
+        step = len(actions)
+
+        step_actions = []
+        for state in states:
+            c_state = state.c
+            if step < c_state.history.size():
+                step_actions.append(c_state.history[step])
+
+        # We are done if we have exhausted all histories.
+        if len(step_actions) == 0:
+            break
+
+        actions.append(numpy.array(step_actions, dtype="i"))
+
+    return actions

--- a/spacy/tests/serialize/test_serialize_config.py
+++ b/spacy/tests/serialize/test_serialize_config.py
@@ -264,9 +264,11 @@ def test_serialize_custom_nlp():
         model = nlp2.get_pipe("parser").model
         assert model.get_ref("tok2vec") is not None
         assert model.has_param("lower_W")
-        assert model.has_param("upper_W")
         assert model.has_param("lower_b")
-        assert model.has_param("upper_b")
+        upper = model.get_ref("upper")
+        assert upper is not None
+        assert upper.has_param("W")
+        assert upper.has_param("b")
 
 
 @pytest.mark.parametrize("parser_config_string", [parser_config_string_upper])
@@ -284,9 +286,11 @@ def test_serialize_parser(parser_config_string):
         model = nlp2.get_pipe("parser").model
         assert model.get_ref("tok2vec") is not None
         assert model.has_param("lower_W")
-        assert model.has_param("upper_W")
         assert model.has_param("lower_b")
-        assert model.has_param("upper_b")
+        upper = model.get_ref("upper")
+        assert upper is not None
+        assert upper.has_param("b")
+        assert upper.has_param("W")
 
 
 def test_config_nlp_roundtrip():

--- a/spacy/tests/training/test_rehearse.py
+++ b/spacy/tests/training/test_rehearse.py
@@ -203,8 +203,7 @@ def _optimize(nlp, component: str, data: List, rehearse: bool):
     return nlp
 
 
-# Fixme: reenable ner and parser when rehearsal is implemented.
-@pytest.mark.parametrize("component", ["tagger", "textcat_multilabel"])
+@pytest.mark.parametrize("component", ["ner", "tagger", "parser", "textcat_multilabel"])
 def test_rehearse(component):
     nlp = spacy.blank("en")
     nlp.add_pipe(component)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Before the parser refactor, rehearsal was driven by a loop in the `rehearse` method itself. For each parsing step, the loops would:

1. Get the predictions of the teacher.
2. Get the predictions and backprop function of the student.
3. Compute the loss and backprop into the student.
4. Move the teacher and student forward with the predictions of
   the student.

In the refactored parser, we cannot perform search stepwise rehearsal anymore, since the model now predicts all parsing steps at once. Therefore, rehearsal is performed in the following steps:

1. Get the predictions of all parsing steps from the student, along with its backprop function.
2. Get the predictions from the teacher, but use the predictions of the student to advance the parser while doing so.
3. Compute the loss and backprop into the student.

To support the second step a new method, `advance_with_actions` is added to `GreedyBatch`, which performs the provided parsing steps.

---

Another thing to be aware of while reviewing this PR is that an issue surfaced while reinstating the rehearsal test is that the Thinc optimizers do not support resizing of existing parameters. The solution that we came up after some discussion is that we should work around this by wrapping the weights/biases of the upper layer of the parser model in `Linear` (like the old parser). When the upper layer is resized, we copy over the existing parameters into a new `Linear` instance. This does not trigger an error in Optimizer, because it sees the resized layer as a new set of parameters.


### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Refactor

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
