### PR TITLE
Fix version in SpanRuler docs

### DIFF
--- a/website/docs/api/spanruler.md
+++ b/website/docs/api/spanruler.md
@@ -2,7 +2,7 @@
 title: SpanRuler
 tag: class
 source: spacy/pipeline/span_ruler.py
-new: 3.3
+new: 3.3.1
 teaser: 'Pipeline component for rule-based span and named entity recognition'
 api_string_name: span_ruler
 api_trainable: false

--- a/website/docs/usage/rule-based-matching.md
+++ b/website/docs/usage/rule-based-matching.md
@@ -1447,7 +1447,7 @@ with nlp.select_pipes(enable="tagger"):
     ruler.add_patterns(patterns)
 ```
 
-## Rule-based span matching {#spanruler new="3.3"}
+## Rule-based span matching {#spanruler new="3.3.1"}
 
 The [`SpanRuler`](/api/spanruler) is a generalized version of the entity ruler
 that lets you add spans to `doc.spans` or `doc.ents` based on pattern


### PR DESCRIPTION

## Description
Fix version in SpanRuler docs: the component is new since 3.3.1, not 3.3.0

### Types of change
docs fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
