### PR TITLE
Add "Aim-spaCy" to spaCy Universe

### DIFF
--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -16,8 +16,8 @@
             "image": "https://user-images.githubusercontent.com/13848158/136364717-0939222c-55b6-44f0-ad32-d9ab749546e4.png",
             "author": "AimStack",
             "author_links": {
-                "twitter": "https://twitter.com/aimstackio",
-                "github": "https://github.com/aimhubio",
+                "twitter": "aimstackio",
+                "github": "aimhubio",
                 "website": "https://aimstack.io"
             },
             "category": ["visualizers"],

--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -12,7 +12,7 @@
             ],
             "code_language": "python",
             "url": "https://aimstack.io/spacy",
-            "thumb": "https://user-images.githubusercontent.com/13848158/136364717-0939222c-55b6-44f0-ad32-d9ab749546e4.png",
+            "thumb": "https://user-images.githubusercontent.com/13848158/172912427-ee9327ea-3cd8-47fa-8427-6c0d36cd831f.png",
             "image": "https://user-images.githubusercontent.com/13848158/136364717-0939222c-55b6-44f0-ad32-d9ab749546e4.png",
             "author": "AimStack",
             "author_links": {

--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -1,6 +1,29 @@
 {
     "resources": [
         {
+            "id": "aim-spacy",
+            "title": "Aim-spaCy",
+            "slogan": "Aim-spaCy is an Aim-based spaCy experiment tracker.",
+            "description": "Aim-spaCy helps to easily collect, store and explore training logs for spaCy, including: hyper-parameters, metrics and displaCy visualizations",
+            "github": "aimhubio/aim-spacy",
+            "pip": "aim-spacy",
+            "code_example": [
+                "https://github.com/aimhubio/aim-spacy/tree/master/examples"
+            ],
+            "code_language": "python",
+            "url": "https://aimstack.io/spacy",
+            "thumb": "https://user-images.githubusercontent.com/13848158/136364717-0939222c-55b6-44f0-ad32-d9ab749546e4.png",
+            "image": "https://user-images.githubusercontent.com/13848158/136364717-0939222c-55b6-44f0-ad32-d9ab749546e4.png",
+            "author": "AimStack",
+            "author_links": {
+                "twitter": "https://twitter.com/aimstackio",
+                "github": "https://github.com/aimhubio",
+                "website": "https://aimstack.io"
+            },
+            "category": ["visualizers"],
+            "tags": ["experiment-tracking", "visualization"]
+        },
+        {
             "id": "spacy-report",
             "title": "spacy-report",
             "slogan": "Generates interactive reports for spaCy models.",


### PR DESCRIPTION
## Description
Added Aim-spaCy to spaCy Universe.

### Types of change
Edited the [universe.json](https://github.com/explosion/spaCy/blob/master/website/meta/universe.json) and added Aim-spaCy JSON object to the list of "resources".

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
