### PR TITLE
Add option to disable pipes in EntityRuler

### DIFF
--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -87,6 +87,7 @@ class EntityRuler(Pipe):
         ent_id_sep: str = DEFAULT_ENT_ID_SEP,
         patterns: Optional[List[PatternType]] = None,
         scorer: Optional[Callable] = entity_ruler_score,
+        disable_pipes: Optional[List[str]] = [],
     ) -> None:
         """Initialize the entity ruler. If patterns are supplied here, they
         need to be a list of dictionaries with a `"label"` and `"pattern"`
@@ -128,6 +129,7 @@ class EntityRuler(Pipe):
         if patterns is not None:
             self.add_patterns(patterns)
         self.scorer = scorer
+        self.disable_pipes = disable_pipes
 
     def __len__(self) -> int:
         """The number of all patterns added to the entity ruler."""
@@ -294,7 +296,9 @@ class EntityRuler(Pipe):
             subsequent_pipes = [pipe for pipe in self.nlp.pipe_names[current_index:]]
         except ValueError:
             subsequent_pipes = []
-        with self.nlp.select_pipes(disable=subsequent_pipes):
+
+        disable = list(set(subsequent_pipes + self.disable_pipes))
+        with self.nlp.select_pipes(disable=disable):
             token_patterns = []
             phrase_pattern_labels = []
             phrase_pattern_texts = []

--- a/spacy/pipeline/entityruler.py
+++ b/spacy/pipeline/entityruler.py
@@ -27,6 +27,7 @@ PatternType = Dict[str, Union[str, List[Dict[str, Any]]]]
         "validate": False,
         "overwrite_ents": False,
         "ent_id_sep": DEFAULT_ENT_ID_SEP,
+        "disable_pipes": [],
         "scorer": {"@scorers": "spacy.entity_ruler_scorer.v1"},
     },
     default_score_weights={
@@ -43,6 +44,7 @@ def make_entity_ruler(
     validate: bool,
     overwrite_ents: bool,
     ent_id_sep: str,
+    disable_pipes: List[str],
     scorer: Optional[Callable],
 ):
     return EntityRuler(
@@ -52,6 +54,7 @@ def make_entity_ruler(
         validate=validate,
         overwrite_ents=overwrite_ents,
         ent_id_sep=ent_id_sep,
+        disable_pipes=disable_pipes,
         scorer=scorer,
     )
 
@@ -85,9 +88,9 @@ class EntityRuler(Pipe):
         validate: bool = False,
         overwrite_ents: bool = False,
         ent_id_sep: str = DEFAULT_ENT_ID_SEP,
+        disable_pipes: List[str] = [],
         patterns: Optional[List[PatternType]] = None,
         scorer: Optional[Callable] = entity_ruler_score,
-        disable_pipes: Optional[List[str]] = [],
     ) -> None:
         """Initialize the entity ruler. If patterns are supplied here, they
         need to be a list of dictionaries with a `"label"` and `"pattern"`
@@ -126,10 +129,10 @@ class EntityRuler(Pipe):
         )
         self.ent_id_sep = ent_id_sep
         self._ent_ids = defaultdict(tuple)  # type: ignore
+        self.disable_pipes = disable_pipes
         if patterns is not None:
             self.add_patterns(patterns)
         self.scorer = scorer
-        self.disable_pipes = disable_pipes
 
     def __len__(self) -> int:
         """The number of all patterns added to the entity ruler."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

The EntityRuler uses reference to the calling `Language` internally to generate docs for matching. Depending on how the pipeline is configured, this can call pipes that aren't needed, resulting in unused work. This PR adds a `disable_pipes` option to the EntityRuler that allows specifying pipes that should be disabled when creating Docs internally. 

There are other ways this could be done. For example, we could try automatic inference of which pipes are needed, since pipes specify the attributes they set. But I think this approach is better, since we would want a manual override for any inference in any case.

Another thing to note is that pipes after the EntityRuler are disabled by default. Maybe it's enough if we make that more prominent in the documentation?

Currently this is just at a proposal stage, and these things still need doing:

- [ ] same feature in span ruler
- [ ] doc updates

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
