### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/autoblack.yml
+++ b/.github/workflows/autoblack.yml
@@ -7,8 +7,14 @@ on:
   schedule:
     - cron: '0 8 * * 5'  # every Friday at 8am UTC
 
+permissions:
+  contents: read
+
 jobs:
   autoblack:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     if: github.repository_owner == 'explosion'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/explosionbot.yml
+++ b/.github/workflows/explosionbot.yml
@@ -6,6 +6,9 @@ on:
       - created
       - edited
 
+permissions:
+  contents: read
+
 jobs:
   explosion-bot:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
