### PR TITLE
vectors: remove use of float as row number

### DIFF
--- a/spacy/vectors.pyx
+++ b/spacy/vectors.pyx
@@ -339,7 +339,7 @@ cdef class Vectors:
             return self.key2row.get(key, -1)
         elif keys is not None:
             keys = [get_string_id(key) for key in keys]
-            rows = [self.key2row.get(key, -1.) for key in keys]
+            rows = [self.key2row.get(key, -1) for key in keys]
             return xp.asarray(rows, dtype="i")
         else:
             row2key = {row: key for key, row in self.key2row.items()}


### PR DESCRIPTION
## Description

The float -1 was returned rather than the integer -1 as the row for
unknown keys. This doesn't introduce a realy bug, since such floats
cast (without issues) to int in the conversion to NumPy arrays. Still,
it's nice to to do the correct thing :).

<!--- Provide a general summary of your changes in the title. -->

### Types of change

Bugfix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
