### PR TITLE
add NER counts to debug data

### DIFF
--- a/spacy/cli/debug_data.py
+++ b/spacy/cli/debug_data.py
@@ -361,7 +361,7 @@ def debug_data(
             if label != "-"
         ]
         labels_with_counts = _format_labels(labels_with_counts, counts=True)
-        msg.text(f"Labels in train data: {_format_labels(labels)}", show=verbose)
+        msg.text(f"Labels in train data: {labels_with_counts}", show=verbose)
         missing_labels = model_labels - labels
         if missing_labels:
             msg.warn(


### PR DESCRIPTION
## Description
`labels_with_counts` wasn't being printed for the NER, not even when `verbose`. I think this was probably just a typo/oversight: the variable was constructed but never actually used. We do print the counts for other components including the tagger, parser and recently spancat. 

### Types of change
small fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
