### PR TITLE
account for NER labels with a hyphen in the name

### DIFF
--- a/spacy/cli/debug_data.py
+++ b/spacy/cli/debug_data.py
@@ -10,7 +10,7 @@ import math
 
 from ._util import app, Arg, Opt, show_validation_error, parse_config_overrides
 from ._util import import_code, debug_cli
-from ..training import Example
+from ..training import Example, strip_bilu_prefix
 from ..training.initialize import get_sourced_components
 from ..schemas import ConfigSchemaTraining
 from ..pipeline._parser_internals import nonproj
@@ -758,9 +758,9 @@ def _compile_gold(
                     # "Illegal" whitespace entity
                     data["ws_ents"] += 1
                 if label.startswith(("B-", "U-")):
-                    combined_label = label.split("-")[1]
+                    combined_label = strip_bilu_prefix(label)
                     data["ner"][combined_label] += 1
-                if sent_starts[i] == True and label.startswith(("I-", "L-")):
+                if sent_starts[i] and label.startswith(("I-", "L-")):
                     data["boundary_cross_ents"] += 1
                 elif label == "-":
                     data["ner"]["-"] += 1

--- a/spacy/cli/debug_data.py
+++ b/spacy/cli/debug_data.py
@@ -10,7 +10,7 @@ import math
 
 from ._util import app, Arg, Opt, show_validation_error, parse_config_overrides
 from ._util import import_code, debug_cli
-from ..training import Example, strip_bilu_prefix
+from ..training import Example, remove_bilu_prefix
 from ..training.initialize import get_sourced_components
 from ..schemas import ConfigSchemaTraining
 from ..pipeline._parser_internals import nonproj
@@ -758,7 +758,7 @@ def _compile_gold(
                     # "Illegal" whitespace entity
                     data["ws_ents"] += 1
                 if label.startswith(("B-", "U-")):
-                    combined_label = strip_bilu_prefix(label)
+                    combined_label = remove_bilu_prefix(label)
                     data["ner"][combined_label] += 1
                 if sent_starts[i] and label.startswith(("I-", "L-")):
                     data["boundary_cross_ents"] += 1
@@ -908,7 +908,7 @@ def _get_examples_without_label(
     for eg in data:
         if component == "ner":
             labels = [
-                label.split("-")[1]
+                remove_bilu_prefix(label)
                 for label in eg.get_aligned_ner()
                 if label not in ("O", "-", None)
             ]

--- a/spacy/pipeline/_parser_internals/arc_eager.pyx
+++ b/spacy/pipeline/_parser_internals/arc_eager.pyx
@@ -10,6 +10,7 @@ from ...strings cimport hash_string
 from ...structs cimport TokenC
 from ...tokens.doc cimport Doc, set_children_from_heads
 from ...tokens.token cimport MISSING_DEP
+from ...training import split_bilu_label
 from ...training.example cimport Example
 from .stateclass cimport StateClass
 from ._state cimport StateC, ArcC
@@ -687,7 +688,7 @@ cdef class ArcEager(TransitionSystem):
             return self.c[name_or_id]
         name = name_or_id
         if '-' in name:
-            move_str, label_str = name.split('-', 1)
+            move_str, label_str = split_bilu_label(name)
             label = self.strings[label_str]
         else:
             move_str = name

--- a/spacy/pipeline/_parser_internals/ner.pyx
+++ b/spacy/pipeline/_parser_internals/ner.pyx
@@ -13,6 +13,7 @@ from ...typedefs cimport weight_t, attr_t
 from ...lexeme cimport Lexeme
 from ...attrs cimport IS_SPACE
 from ...structs cimport TokenC, SpanC
+from ...training import split_bilu_label
 from ...training.example cimport Example
 from .stateclass cimport StateClass
 from ._state cimport StateC
@@ -182,7 +183,7 @@ cdef class BiluoPushDown(TransitionSystem):
         if name == '-' or name == '' or name is None:
             return Transition(clas=0, move=MISSING, label=0, score=0)
         elif '-' in name:
-            move_str, label_str = name.split('-', 1)
+            move_str, label_str = split_bilu_label(name)
             # Deprecated, hacky way to denote 'not this entity'
             if label_str.startswith('!'):
                 raise ValueError(Errors.E869.format(label=name))

--- a/spacy/pipeline/dep_parser.pyx
+++ b/spacy/pipeline/dep_parser.pyx
@@ -12,6 +12,7 @@ from ..language import Language
 from ._parser_internals import nonproj
 from ._parser_internals.nonproj import DELIMITER
 from ..scorer import Scorer
+from ..training import remove_bilu_prefix
 from ..util import registry
 
 
@@ -314,7 +315,7 @@ cdef class DependencyParser(Parser):
         # Get the labels from the model by looking at the available moves
         for move in self.move_names:
             if "-" in move:
-                label = move.split("-")[1]
+                label = remove_bilu_prefix(move)
                 if DELIMITER in label:
                     label = label.split(DELIMITER)[1]
                 labels.add(label)

--- a/spacy/pipeline/ner.pyx
+++ b/spacy/pipeline/ner.pyx
@@ -9,7 +9,7 @@ from ._parser_internals.ner cimport BiluoPushDown
 from ..language import Language
 from ..scorer import get_ner_prf, PRFScore
 from ..util import registry
-from ..training import strip_bilu_prefix
+from ..training import remove_bilu_prefix
 
 
 default_model_config = """
@@ -242,7 +242,7 @@ cdef class EntityRecognizer(Parser):
     def labels(self):
         # Get the labels from the model by looking at the available moves, e.g.
         # B-PERSON, I-PERSON, L-PERSON, U-PERSON
-        labels = set(strip_bilu_prefix(move) for move in self.move_names
+        labels = set(remove_bilu_prefix(move) for move in self.move_names
                      if move[0] in ("B", "I", "L", "U"))
         return tuple(sorted(labels))
 

--- a/spacy/pipeline/ner.pyx
+++ b/spacy/pipeline/ner.pyx
@@ -6,10 +6,10 @@ from thinc.api import Model, Config
 from ._parser_internals.transition_system import TransitionSystem
 from .transition_parser cimport Parser
 from ._parser_internals.ner cimport BiluoPushDown
-
 from ..language import Language
 from ..scorer import get_ner_prf, PRFScore
 from ..util import registry
+from ..training import strip_bilu_prefix
 
 
 default_model_config = """
@@ -242,7 +242,7 @@ cdef class EntityRecognizer(Parser):
     def labels(self):
         # Get the labels from the model by looking at the available moves, e.g.
         # B-PERSON, I-PERSON, L-PERSON, U-PERSON
-        labels = set(move.split("-")[1] for move in self.move_names
+        labels = set(strip_bilu_prefix(move) for move in self.move_names
                      if move[0] in ("B", "I", "L", "U"))
         return tuple(sorted(labels))
 

--- a/spacy/tests/parser/test_ner.py
+++ b/spacy/tests/parser/test_ner.py
@@ -108,8 +108,11 @@ def test_issue2385():
     tags2 = ("I-ORG", "I-ORG", "B-ORG")
     assert iob_to_biluo(tags2) == ["B-ORG", "L-ORG", "U-ORG"]
     # maintain support for iob2 format
-    tags3 = ("B-PERSON", "I-PERSON", "B-PERSON")
-    assert iob_to_biluo(tags3) == ["B-PERSON", "L-PERSON", "U-PERSON"]
+    tags3 = ("B-PERSON-1", "I-PERSON-1", "B-PERSON-1")
+    assert iob_to_biluo(tags3) == ["B-PERSON-1", "L-PERSON-1", "U-PERSON-1"]
+    # ensure it works with hyphens in the name
+    tags4 = ("B-MULTI-PERSON", "I-MULTI-PERSON", "B-MULTI-PERSON")
+    assert iob_to_biluo(tags4) == ["B-MULTI-PERSON", "L-MULTI-PERSON", "U-MULTI-PERSON"]
 
 
 @pytest.mark.issue(2800)
@@ -152,6 +155,19 @@ def test_issue3209():
     model.attrs["resize_output"](model, ner.moves.n_moves)
     nlp2.from_bytes(nlp.to_bytes())
     assert ner2.move_names == move_names
+
+
+def test_labels_from_BILUO():
+    """Test that labels are inferred incorrectly when there's a - in label.
+    """
+    nlp = English()
+    ner = nlp.add_pipe("ner")
+    ner.add_label("LARGE-ANIMAL")
+    nlp.initialize()
+    move_names = ["O", "B-LARGE-ANIMAL", "I-LARGE-ANIMAL", "L-LARGE-ANIMAL", "U-LARGE-ANIMAL"]
+    labels = {"LARGE-ANIMAL"}
+    assert ner.move_names == move_names
+    assert set(ner.labels) == labels
 
 
 @pytest.mark.issue(4267)

--- a/spacy/tests/parser/test_ner.py
+++ b/spacy/tests/parser/test_ner.py
@@ -158,7 +158,7 @@ def test_issue3209():
 
 
 def test_labels_from_BILUO():
-    """Test that labels are inferred incorrectly when there's a - in label.
+    """Test that labels are inferred correctly when there's a - in label.
     """
     nlp = English()
     ner = nlp.add_pipe("ner")

--- a/spacy/tests/parser/test_ner.py
+++ b/spacy/tests/parser/test_ner.py
@@ -108,8 +108,8 @@ def test_issue2385():
     tags2 = ("I-ORG", "I-ORG", "B-ORG")
     assert iob_to_biluo(tags2) == ["B-ORG", "L-ORG", "U-ORG"]
     # maintain support for iob2 format
-    tags3 = ("B-PERSON-1", "I-PERSON-1", "B-PERSON-1")
-    assert iob_to_biluo(tags3) == ["B-PERSON-1", "L-PERSON-1", "U-PERSON-1"]
+    tags3 = ("B-PERSON", "I-PERSON", "B-PERSON")
+    assert iob_to_biluo(tags3) == ["B-PERSON", "L-PERSON", "U-PERSON"]
     # ensure it works with hyphens in the name
     tags4 = ("B-MULTI-PERSON", "I-MULTI-PERSON", "B-MULTI-PERSON")
     assert iob_to_biluo(tags4) == ["B-MULTI-PERSON", "L-MULTI-PERSON", "U-MULTI-PERSON"]

--- a/spacy/tests/parser/test_ner.py
+++ b/spacy/tests/parser/test_ner.py
@@ -10,7 +10,7 @@ from spacy.lang.it import Italian
 from spacy.language import Language
 from spacy.lookups import Lookups
 from spacy.pipeline._parser_internals.ner import BiluoPushDown
-from spacy.training import Example, iob_to_biluo
+from spacy.training import Example, iob_to_biluo, split_bilu_label
 from spacy.tokens import Doc, Span
 from spacy.vocab import Vocab
 import logging
@@ -314,7 +314,7 @@ def test_oracle_moves_missing_B(en_vocab):
         elif tag == "O":
             moves.add_action(move_types.index("O"), "")
         else:
-            action, label = tag.split("-", 1)
+            action, label = split_bilu_label(tag)
             moves.add_action(move_types.index("B"), label)
             moves.add_action(move_types.index("I"), label)
             moves.add_action(move_types.index("L"), label)
@@ -340,7 +340,7 @@ def test_oracle_moves_whitespace(en_vocab):
         elif tag == "O":
             moves.add_action(move_types.index("O"), "")
         else:
-            action, label = tag.split("-", 1)
+            action, label = split_bilu_label(tag)
             moves.add_action(move_types.index(action), label)
     moves.get_oracle_sequence(example)
 

--- a/spacy/tests/parser/test_ner.py
+++ b/spacy/tests/parser/test_ner.py
@@ -314,7 +314,7 @@ def test_oracle_moves_missing_B(en_vocab):
         elif tag == "O":
             moves.add_action(move_types.index("O"), "")
         else:
-            action, label = tag.split("-")
+            action, label = tag.split("-", 1)
             moves.add_action(move_types.index("B"), label)
             moves.add_action(move_types.index("I"), label)
             moves.add_action(move_types.index("L"), label)
@@ -340,7 +340,7 @@ def test_oracle_moves_whitespace(en_vocab):
         elif tag == "O":
             moves.add_action(move_types.index("O"), "")
         else:
-            action, label = tag.split("-")
+            action, label = tag.split("-", 1)
             moves.add_action(move_types.index(action), label)
     moves.get_oracle_sequence(example)
 

--- a/spacy/tests/util.py
+++ b/spacy/tests/util.py
@@ -5,6 +5,7 @@ import srsly
 from spacy.tokens import Doc
 from spacy.vocab import Vocab
 from spacy.util import make_tempdir  # noqa: F401
+from spacy.training import split_bilu_label
 from thinc.api import get_current_ops
 
 
@@ -40,7 +41,7 @@ def apply_transition_sequence(parser, doc, sequence):
     desired state."""
     for action_name in sequence:
         if "-" in action_name:
-            move, label = action_name.split("-", 1)
+            move, label = split_bilu_label(action_name)
             parser.add_label(label)
     with parser.step_through(doc) as stepwise:
         for transition in sequence:

--- a/spacy/tests/util.py
+++ b/spacy/tests/util.py
@@ -40,7 +40,7 @@ def apply_transition_sequence(parser, doc, sequence):
     desired state."""
     for action_name in sequence:
         if "-" in action_name:
-            move, label = action_name.split("-")
+            move, label = action_name.split("-", 1)
             parser.add_label(label)
     with parser.step_through(doc) as stepwise:
         for transition in sequence:

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -38,6 +38,7 @@ from .underscore import Underscore, get_ext_args
 from ._retokenize import Retokenizer
 from ._serialize import ALL_ATTRS as DOCBIN_ALL_ATTRS
 from ..util import get_words_and_spaces
+from ..training import split_bilu_label
 
 DEF PADDING = 5
 
@@ -330,7 +331,7 @@ cdef class Doc:
                 else:
                     if len(ent) < 3 or ent[1] != "-":
                         raise ValueError(Errors.E177.format(tag=ent))
-                    ent_iob, ent_type = ent.split("-", 1)
+                    ent_iob, ent_type = split_bilu_label(ent)
                     if ent_iob not in iob_strings:
                         raise ValueError(Errors.E177.format(tag=ent))
                     ent_iob = iob_strings.index(ent_iob)

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -38,7 +38,6 @@ from .underscore import Underscore, get_ext_args
 from ._retokenize import Retokenizer
 from ._serialize import ALL_ATTRS as DOCBIN_ALL_ATTRS
 from ..util import get_words_and_spaces
-from ..training import split_bilu_label
 
 DEF PADDING = 5
 
@@ -331,7 +330,7 @@ cdef class Doc:
                 else:
                     if len(ent) < 3 or ent[1] != "-":
                         raise ValueError(Errors.E177.format(tag=ent))
-                    ent_iob, ent_type = split_bilu_label(ent)
+                    ent_iob, ent_type = ent.split("-", 1)
                     if ent_iob not in iob_strings:
                         raise ValueError(Errors.E177.format(tag=ent))
                     ent_iob = iob_strings.index(ent_iob)

--- a/spacy/training/__init__.py
+++ b/spacy/training/__init__.py
@@ -2,9 +2,10 @@ from .corpus import Corpus, JsonlCorpus  # noqa: F401
 from .example import Example, validate_examples, validate_get_examples  # noqa: F401
 from .alignment import Alignment  # noqa: F401
 from .augment import dont_augment, orth_variants_augmenter  # noqa: F401
-from .iob_utils import iob_to_biluo, biluo_to_iob, remove_bilu_prefix  # noqa: F401
+from .iob_utils import iob_to_biluo, biluo_to_iob  # noqa: F401
 from .iob_utils import offsets_to_biluo_tags, biluo_tags_to_offsets  # noqa: F401
 from .iob_utils import biluo_tags_to_spans, tags_to_entities  # noqa: F401
+from .iob_utils import split_bilu_label, remove_bilu_prefix  # noqa: F401
 from .gold_io import docs_to_json, read_json_file  # noqa: F401
 from .batchers import minibatch_by_padded_size, minibatch_by_words  # noqa: F401
 from .loggers import console_logger  # noqa: F401

--- a/spacy/training/__init__.py
+++ b/spacy/training/__init__.py
@@ -2,7 +2,7 @@ from .corpus import Corpus, JsonlCorpus  # noqa: F401
 from .example import Example, validate_examples, validate_get_examples  # noqa: F401
 from .alignment import Alignment  # noqa: F401
 from .augment import dont_augment, orth_variants_augmenter  # noqa: F401
-from .iob_utils import iob_to_biluo, biluo_to_iob  # noqa: F401
+from .iob_utils import iob_to_biluo, biluo_to_iob, strip_bilu_prefix  # noqa: F401
 from .iob_utils import offsets_to_biluo_tags, biluo_tags_to_offsets  # noqa: F401
 from .iob_utils import biluo_tags_to_spans, tags_to_entities  # noqa: F401
 from .gold_io import docs_to_json, read_json_file  # noqa: F401

--- a/spacy/training/__init__.py
+++ b/spacy/training/__init__.py
@@ -2,7 +2,7 @@ from .corpus import Corpus, JsonlCorpus  # noqa: F401
 from .example import Example, validate_examples, validate_get_examples  # noqa: F401
 from .alignment import Alignment  # noqa: F401
 from .augment import dont_augment, orth_variants_augmenter  # noqa: F401
-from .iob_utils import iob_to_biluo, biluo_to_iob, strip_bilu_prefix  # noqa: F401
+from .iob_utils import iob_to_biluo, biluo_to_iob, remove_bilu_prefix  # noqa: F401
 from .iob_utils import offsets_to_biluo_tags, biluo_tags_to_offsets  # noqa: F401
 from .iob_utils import biluo_tags_to_spans, tags_to_entities  # noqa: F401
 from .gold_io import docs_to_json, read_json_file  # noqa: F401

--- a/spacy/training/augment.py
+++ b/spacy/training/augment.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, StrictStr
 
 from ..util import registry
 from .example import Example
+from ..training import split_bilu_label
 
 if TYPE_CHECKING:
     from ..language import Language  # noqa: F401
@@ -278,10 +279,8 @@ def make_whitespace_variant(
             ent_prev = doc_dict["entities"][position - 1]
             ent_next = doc_dict["entities"][position]
             if "-" in ent_prev and "-" in ent_next:
-                ent_iob_prev = ent_prev.split("-")[0]
-                ent_type_prev = ent_prev.split("-", 1)[1]
-                ent_iob_next = ent_next.split("-")[0]
-                ent_type_next = ent_next.split("-", 1)[1]
+                ent_iob_prev, ent_type_prev = split_bilu_label(ent_prev)
+                ent_iob_next, ent_type_next = split_bilu_label(ent_next)
                 if (
                     ent_iob_prev in ("B", "I")
                     and ent_iob_next in ("I", "L")

--- a/spacy/training/augment.py
+++ b/spacy/training/augment.py
@@ -3,11 +3,10 @@ from typing import Optional
 import random
 import itertools
 from functools import partial
-from pydantic import BaseModel, StrictStr
 
 from ..util import registry
 from .example import Example
-from ..training import split_bilu_label
+from .iob_utils import split_bilu_label
 
 if TYPE_CHECKING:
     from ..language import Language  # noqa: F401

--- a/spacy/training/example.pyx
+++ b/spacy/training/example.pyx
@@ -9,7 +9,7 @@ from ..tokens.span import Span
 from ..attrs import IDS
 from .alignment import Alignment
 from .iob_utils import biluo_to_iob, offsets_to_biluo_tags, doc_to_biluo_tags
-from .iob_utils import biluo_tags_to_spans
+from .iob_utils import biluo_tags_to_spans, remove_bilu_prefix
 from ..errors import Errors, Warnings
 from ..pipeline._parser_internals import nonproj
 from ..tokens.token cimport MISSING_DEP
@@ -519,7 +519,7 @@ def _parse_ner_tags(biluo_or_offsets, vocab, words, spaces):
         else:
             ent_iobs.append(iob_tag.split("-")[0])
             if iob_tag.startswith("I") or iob_tag.startswith("B"):
-                ent_types.append(iob_tag.split("-", 1)[1])
+                ent_types.append(remove_bilu_prefix(iob_tag))
             else:
                 ent_types.append("")
     return ent_iobs, ent_types

--- a/spacy/training/iob_utils.py
+++ b/spacy/training/iob_utils.py
@@ -218,8 +218,8 @@ def tags_to_entities(tags: Iterable[str]) -> List[Tuple[str, int, int]]:
     return entities
 
 
-def strip_bilu_prefix(label: str) -> str:
-    return "-".join(label.split("-")[1:])
+def remove_bilu_prefix(label: str) -> str:
+    return label.split("-", 1)[1]
 
 
 # Fallbacks to make backwards-compat easier

--- a/spacy/training/iob_utils.py
+++ b/spacy/training/iob_utils.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Tuple, Iterable, Union, Iterator
+from typing import List, Dict, Tuple, Iterable, Union, Iterator, cast
 import warnings
 
 from ..errors import Errors, Warnings
@@ -216,6 +216,10 @@ def tags_to_entities(tags: Iterable[str]) -> List[Tuple[str, int, int]]:
         else:
             raise ValueError(Errors.E068.format(tag=tag))
     return entities
+
+
+def split_bilu_label(label: str) -> Tuple[str, str]:
+    return cast(Tuple[str, str], label.split("-", 1))
 
 
 def remove_bilu_prefix(label: str) -> str:

--- a/spacy/training/iob_utils.py
+++ b/spacy/training/iob_utils.py
@@ -218,6 +218,10 @@ def tags_to_entities(tags: Iterable[str]) -> List[Tuple[str, int, int]]:
     return entities
 
 
+def strip_bilu_prefix(label: str):
+    return "-".join(label.split("-")[1:])
+
+
 # Fallbacks to make backwards-compat easier
 offsets_from_biluo_tags = biluo_tags_to_offsets
 spans_from_biluo_tags = biluo_tags_to_spans

--- a/spacy/training/iob_utils.py
+++ b/spacy/training/iob_utils.py
@@ -218,7 +218,7 @@ def tags_to_entities(tags: Iterable[str]) -> List[Tuple[str, int, int]]:
     return entities
 
 
-def strip_bilu_prefix(label: str):
+def strip_bilu_prefix(label: str) -> str:
     return "-".join(label.split("-")[1:])
 
 


### PR DESCRIPTION
## Description
This came up when running `spacy debug data` on data from [AnEM](https://raw.githubusercontent.com/juand-r/entity-recognition-datasets/master/data/AnEM/CONLL-format/data/AnEM.train), which contains an entity label `"Multi-tissue_structure"`. The `ner` pipe would parse this as `"Multi"` and the `debug data` command would do the same internally, because both were using
```
label.split("-")[1]
```
instead of
```
label.split("-", 1)[1]
```
when stripping of the BILU prefix (e.g. `"B-"`)

### Types of change
bug fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
