### PR TITLE
Remove unnecessary regex group

### DIFF
--- a/spacy/lang/punctuation.py
+++ b/spacy/lang/punctuation.py
@@ -24,7 +24,7 @@ TOKENIZER_SUFFIXES = (
         r"(?<=°[FfCcKk])\.",
         r"(?<=[0-9])(?:{c})".format(c=CURRENCY),
         r"(?<=[0-9])(?:{u})".format(u=UNITS),
-        r"(?<=[0-9{al}{e}{p}(?:{q})])\.".format(
+        r"(?<=[0-9{al}{e}{p}{q}])\.".format(
             al=ALPHA_LOWER, e=r"%²\-\+", q=CONCAT_QUOTES, p=PUNCT
         ),
         r"(?<=[{au}][{au}])\.".format(au=ALPHA_UPPER),


### PR DESCRIPTION
## Description
In the course of working on https://github.com/explosion/spaCy/pull/10837, I came across this regex group that appears not to play any useful purpose, so propose to remove it.

### Types of change
Code cleanup

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
