### PR TITLE
Remove unnecessary regex groups

### DIFF
--- a/spacy/lang/punctuation.py
+++ b/spacy/lang/punctuation.py
@@ -22,8 +22,8 @@ TOKENIZER_SUFFIXES = (
     + [
         r"(?<=[0-9])\+",
         r"(?<=°[FfCcKk])\.",
-        r"(?<=[0-9])(?:{c})".format(c=CURRENCY),
-        r"(?<=[0-9])(?:{u})".format(u=UNITS),
+        r"(?<=[0-9]){c}".format(c=CURRENCY),
+        r"(?<=[0-9]){u}".format(u=UNITS),
         r"(?<=[0-9{al}{e}{p}{q}])\.".format(
             al=ALPHA_LOWER, e=r"%²\-\+", q=CONCAT_QUOTES, p=PUNCT
         ),

--- a/spacy/lang/punctuation.py
+++ b/spacy/lang/punctuation.py
@@ -24,7 +24,7 @@ TOKENIZER_SUFFIXES = (
         r"(?<=°[FfCcKk])\.",
         r"(?<=[0-9])(?:{c})".format(c=CURRENCY),
         r"(?<=[0-9])(?:{u})".format(u=UNITS),
-        r"(?<=[0-9{al}{e}{p}(?:{q})])\.".format(
+        r"(?<=[0-9{al}{e}{p}{q}])\.".format(
             al=ALPHA_LOWER, e=r"%²\-\+", q=CONCAT_QUOTES, p=PUNCT
         ),
         r"(?<=[{au}][{au}])\.".format(au=ALPHA_UPPER),


### PR DESCRIPTION
## Description
While working on https://github.com/explosion/spaCy/pull/10837, I came across regex groups that do not appear to serve any purpose. I propose to remove them.

### Types of change
Code cleanup

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
