### PR TITLE
displaCy: Fix horizontal spacing for multiple span labels

### DIFF
--- a/spacy/displacy/render.py
+++ b/spacy/displacy/render.py
@@ -64,8 +64,11 @@ class SpanRenderer:
         # Set up how the text and labels will be rendered
         self.direction = DEFAULT_DIR
         self.lang = DEFAULT_LANG
+        # These values are in px
         self.top_offset = options.get("top_offset", 40)
-        self.top_offset_step = options.get("top_offset_step", 17)
+        # This is how far under the top offset the span labels appear
+        self.span_label_offset = options.get("span_label_offset", 20)
+        self.offset_step = options.get("top_offset_step", 17)
 
         # Set up which templates will be used
         template = options.get("template")
@@ -161,8 +164,16 @@ class SpanRenderer:
             if entities:
                 slices = self._get_span_slices(token["entities"])
                 starts = self._get_span_starts(token["entities"])
+                total_height = (
+                    self.top_offset
+                    + self.span_label_offset
+                    + (self.offset_step * (len(entities) - 1))
+                )
                 markup += self.span_template.format(
-                    text=token["text"], span_slices=slices, span_starts=starts
+                    text=token["text"],
+                    span_slices=slices,
+                    span_starts=starts,
+                    total_height=total_height,
                 )
             else:
                 markup += escape_html(token["text"] + " ")
@@ -171,7 +182,7 @@ class SpanRenderer:
     def _get_span_slices(self, entities: List[Dict]) -> str:
         """Get the rendered markup of all Span slices"""
         span_slices = []
-        for entity, step in zip(entities, itertools.count(step=self.top_offset_step)):
+        for entity, step in zip(entities, itertools.count(step=self.offset_step)):
             color = self.colors.get(entity["label"].upper(), self.default_color)
             span_slice = self.span_slice_template.format(
                 bg=color, top_offset=self.top_offset + step
@@ -182,7 +193,7 @@ class SpanRenderer:
     def _get_span_starts(self, entities: List[Dict]) -> str:
         """Get the rendered markup of all Span start tokens"""
         span_starts = []
-        for entity, step in zip(entities, itertools.count(step=self.top_offset_step)):
+        for entity, step in zip(entities, itertools.count(step=self.offset_step)):
             color = self.colors.get(entity["label"].upper(), self.default_color)
             span_start = (
                 self.span_start_template.format(

--- a/spacy/displacy/templates.py
+++ b/spacy/displacy/templates.py
@@ -67,7 +67,7 @@ TPL_SPANS = """
 """
 
 TPL_SPAN = """
-<span style="font-weight: bold; display: inline-block; position: relative;">
+<span style="font-weight: bold; display: inline-block; position: relative; height: {total_height}px;">
     {text}
     {span_slices}
     {span_starts}


### PR DESCRIPTION
This PR updates displaCy's template and logic for calculating the vertical spacing between lines when there are multiple labels covering a single span.

**Before (w/ prodigy comparison):**
![image](https://user-images.githubusercontent.com/5107405/174691497-9d978229-923f-4d7e-878e-97bb390ef8a4.png)

**After: (Ignore specific span differences + lack of coloring)**
<img width="1168" alt="image" src="https://user-images.githubusercontent.com/5107405/174691534-11f1bfe7-1d69-48f3-b1cd-2a144c3ceb27.png">

### Types of change
bug fix / enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
