### PR TITLE
the 'new' indicator wants a 'number'

### DIFF
--- a/website/docs/api/spanruler.md
+++ b/website/docs/api/spanruler.md
@@ -2,7 +2,7 @@
 title: SpanRuler
 tag: class
 source: spacy/pipeline/span_ruler.py
-new: 3.3.1
+new: 3.3
 teaser: 'Pipeline component for rule-based span and named entity recognition'
 api_string_name: span_ruler
 api_trainable: false


### PR DESCRIPTION

## Description
The `new` field is typed `number` and thus has gotten confused by our recent `spanruler` of `3.3.1`. Though slightly incorrect, proposal to put `3.3` here instead of `3.3.1` so we can keep treating these annotations as numbers.

### Types of change
website fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
- [ ] `cherry-pick` to `master` after merge
