### PR TITLE
Fix some of the broken links on universe pages

### DIFF
--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -84,7 +84,7 @@
             "code_language": "python",
             "author": "Leap Beyond",
             "author_links": {
-                "github": "https://github.com/LeapBeyond",
+                "github": "LeapBeyond",
                 "website": "https://leapbeyond.ai"
             },
             "code_example": [
@@ -107,8 +107,8 @@
             "code_language": "python",
             "author": "Peter Baumgartner",
             "author_links": {
-                "twitter" : "https://twitter.com/pmbaumgartner",
-                "github": "https://github.com/pmbaumgartner",
+                "twitter" : "pmbaumgartner",
+                "github": "pmbaumgartner",
                 "website": "https://www.peterbaumgartner.com/"
             },
             "code_example": [
@@ -127,8 +127,8 @@
             "code_language": "python",
             "author": "Explosion",
             "author_links": {
-                "twitter" : "https://twitter.com/explosion_ai",
-                "github": "https://github.com/explosion",
+                "twitter" : "explosion_ai",
+                "github": "explosion",
                 "website": "https://explosion.ai/"
             },
             "code_example": [
@@ -600,8 +600,8 @@
             "code_language": "python",
             "author": "Keith Rozario",
             "author_links": {
-                "twitter" : "https://twitter.com/keithrozario",
-                "github": "https://github.com/keithrozario",
+                "twitter" : "keithrozario",
+                "github": "keithrozario",
                 "website": "https://www.keithrozario.com"
             },
             "code_example": [
@@ -2324,7 +2324,7 @@
             "author": "Daniel Whitenack & Chris Benson",
             "author_links": {
                 "website": "https://changelog.com/practicalai",
-                "twitter": "https://twitter.com/PracticalAIFM"
+                "twitter": "PracticalAIFM"
             },
             "category": ["podcasts"]
         },


### PR DESCRIPTION
Currently some of the "AUTHOR INFO" links (e.g. here[0]) are broken:

```
https://github.com/https://github.com/explosion
```

[0] https://spacy.io/universe/project/spacy-experimental


Also one remains broken with `https://szegedai.github.io/`.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
