### PR TITLE
disable failing test because Stanford servers are down

### DIFF
--- a/spacy/tests/training/test_readers.py
+++ b/spacy/tests/training/test_readers.py
@@ -60,11 +60,12 @@ def test_readers():
     assert isinstance(extra_corpus, Callable)
 
 
+# TODO: enable IMDB test once Stanford servers are back up and running
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "reader,additional_config",
     [
-        ("ml_datasets.imdb_sentiment.v1", {"train_limit": 10, "dev_limit": 10}),
+        #        ("ml_datasets.imdb_sentiment.v1", {"train_limit": 10, "dev_limit": 10}),
         ("ml_datasets.dbpedia.v1", {"train_limit": 10, "dev_limit": 10}),
         ("ml_datasets.cmu_movies.v1", {"limit": 10, "freq_cutoff": 200, "split": 0.8}),
     ],


### PR DESCRIPTION

## Description
Our slow test suite has been failing for two days because the Stanford URL for IMDB can not be reached. This is likely connected to a current [power outage](https://emergency.stanford.edu/) at Stanford’s campus.

### Types of change
temporarily disable failing test

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
