### PR TITLE
NEL abstention threshold

### DIFF
--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -442,7 +442,7 @@ class EntityLinker(TrainablePipe):
                     if not candidates:
                         # no prediction possible for this entity - setting to NIL
                         final_kb_ids.append(self.NIL)
-                    elif len(candidates) == 1 and self.abstention_threshold is None:
+                    elif len(candidates) == 1 and self.abstention_threshold == 0:
                         # shortcut for efficiency reasons: take the 1 candidate
                         final_kb_ids.append(candidates[0].entity_)
                     else:
@@ -472,13 +472,13 @@ class EntityLinker(TrainablePipe):
                             if sims.shape != prior_probs.shape:
                                 raise ValueError(Errors.E161)
                             scores = prior_probs + sims - (prior_probs * sims)
-                        best_index = (
-                            xp.where(scores >= self.abstention_threshold)[0]
-                            .argmax()
-                            .item()
+                        scores = xp.where(scores >= self.abstention_threshold)[0]
+                        best_candidate_entity_ = (
+                            candidates[scores.argmax().item()].entity_
+                            if scores.size
+                            else EntityLinker.NIL
                         )
-                        best_candidate = candidates[best_index]
-                        final_kb_ids.append(best_candidate.entity_)
+                        final_kb_ids.append(best_candidate_entity_)
         if not (len(final_kb_ids) == entity_count):
             err = Errors.E147.format(
                 method="predict", msg="result variables not of equal length"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->
## Goals

Add a configurable confidence threshold for NEL predictions.

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Introduces the parameter `abstention_threshold` (defaults to 0) to `EntityLinker` and `EntityLinker_v1`. Predictions are discarded if their `score` doesn't meet the specified threshold. If no prediction does, `EntityLinker.NIL` / `EntityLinker_v1.NIL` is set.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
New feature.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
