### PR TITLE
Remove `simply`

### DIFF
--- a/website/docs/api/architectures.md
+++ b/website/docs/api/architectures.md
@@ -587,7 +587,7 @@ consists of either two or three subnetworks:
   run once for each batch.
 - **lower**: Construct a feature-specific vector for each `(token, feature)`
   pair. This is also run once for each batch. Constructing the state
-  representation is then simply a matter of summing the component features and
+  representation is then a matter of summing the component features and
   applying the non-linearity.
 - **upper** (optional): A feed-forward network that predicts scores from the
   state representation. If not present, the output from the lower model is used
@@ -628,7 +628,7 @@ same signature, but the `use_upper` argument was `True` by default.
 > ```
 
 Build a tagger model, using a provided token-to-vector component. The tagger
-model simply adds a linear layer with softmax activation to predict scores given
+model adds a linear layer with softmax activation to predict scores given
 the token vectors.
 
 | Name        | Description                                                                                |
@@ -920,5 +920,5 @@ A function that reads an existing `KnowledgeBase` from file.
 A function that takes as input a [`KnowledgeBase`](/api/kb) and a
 [`Span`](/api/span) object denoting a named entity, and returns a list of
 plausible [`Candidate`](/api/kb/#candidate) objects. The default
-`CandidateGenerator` simply uses the text of a mention to find its potential
+`CandidateGenerator` uses the text of a mention to find its potential
 aliases in the `KnowledgeBase`. Note that this function is case-dependent.


### PR DESCRIPTION
## Description
This just removes the word `simply` from the architecture docs. I was reading this page, and as a relative beginner, nothing about it was simple. There might be other ways to express some of these ideas, eg `only`, but I'm not actually sure what most of these sentences are saying :) 

### Types of change
Doc fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
