### PR TITLE
`Example.get_aligned_parse`: Handle unit and zero length vectors correctly

### DIFF
--- a/spacy/tests/training/test_training.py
+++ b/spacy/tests/training/test_training.py
@@ -689,17 +689,16 @@ def test_projectivize(en_tokenizer):
     assert proj_labels == deps
 
     # Test documents with no alignments
-    doc_a = Doc(doc.vocab).from_json(
-        json.loads(
-            '{"text": "Double-Jointed", "tokens": [{"id": 0, "start": 0, "end": 14, "head": 0, "dep": "ROOT"}]}'
-        )
+    doc_a = Doc(
+        doc.vocab, words=["Double-Jointed"], spaces=[False], deps=["ROOT"], heads=[0]
     )
-    doc_b = Doc(doc.vocab).from_json(
-        json.loads(
-            '{"text": "Double-Jointed", "tokens": [{"id": 0, "start": 0, "end": 6, "dep": "amod", "head": 2}, {"id": 1, "start": 6, "end": 7, "dep": "punct", "head": 2}, {"id": 2, "start": 7, "end": 14, "dep": "ROOT", "head": 2}]}'
-        )
+    doc_b = Doc(
+        doc.vocab,
+        words=["Double", "-", "Jointed"],
+        spaces=[True, True, True],
+        deps=["amod", "punct", "ROOT"],
+        heads=[2, 2, 2],
     )
-
     example = Example(doc_a, doc_b)
     proj_heads, proj_deps = example.get_aligned_parse(projectivize=True)
     assert proj_heads == [None]
@@ -930,7 +929,7 @@ def test_split_sents(merged_dict):
     assert token_annotation_2["SENT_START"] == [1, 0, 0, 0]
 
 
-def test_alignment():
+def test_alignment(en_tokenizer):
     other_tokens = ["i", "listened", "to", "obama", "'", "s", "podcasts", "."]
     spacy_tokens = ["i", "listened", "to", "obama", "'s", "podcasts", "."]
     align = Alignment.from_strings(other_tokens, spacy_tokens)

--- a/spacy/tests/training/test_training.py
+++ b/spacy/tests/training/test_training.py
@@ -929,7 +929,7 @@ def test_split_sents(merged_dict):
     assert token_annotation_2["SENT_START"] == [1, 0, 0, 0]
 
 
-def test_alignment(en_tokenizer):
+def test_alignment():
     other_tokens = ["i", "listened", "to", "obama", "'", "s", "podcasts", "."]
     spacy_tokens = ["i", "listened", "to", "obama", "'s", "podcasts", "."]
     align = Alignment.from_strings(other_tokens, spacy_tokens)

--- a/spacy/tests/training/test_training.py
+++ b/spacy/tests/training/test_training.py
@@ -1,5 +1,5 @@
 import random
-import json
+
 import numpy
 import pytest
 import srsly

--- a/spacy/tests/training/test_training.py
+++ b/spacy/tests/training/test_training.py
@@ -1,5 +1,5 @@
 import random
-
+import json
 import numpy
 import pytest
 import srsly
@@ -678,6 +678,32 @@ def test_projectivize(en_tokenizer):
     nonproj_heads, nonproj_labels = example.get_aligned_parse(projectivize=False)
     assert proj_heads == [3, 2, 3, 3, 3]
     assert nonproj_heads == [3, 2, 3, 3, 2]
+
+    # Test single token documents
+    doc = en_tokenizer("Conrail")
+    heads = [0]
+    deps = ["dep"]
+    example = Example.from_dict(doc, {"heads": heads, "deps": deps})
+    proj_heads, proj_labels = example.get_aligned_parse(projectivize=True)
+    assert proj_heads == heads
+    assert proj_labels == deps
+
+    # Test documents with no alignments
+    doc_a = Doc(doc.vocab).from_json(
+        json.loads(
+            '{"text": "Double-Jointed", "tokens": [{"id": 0, "start": 0, "end": 14, "head": 0, "dep": "ROOT"}]}'
+        )
+    )
+    doc_b = Doc(doc.vocab).from_json(
+        json.loads(
+            '{"text": "Double-Jointed", "tokens": [{"id": 0, "start": 0, "end": 6, "dep": "amod", "head": 2}, {"id": 1, "start": 6, "end": 7, "dep": "punct", "head": 2}, {"id": 2, "start": 7, "end": 14, "dep": "ROOT", "head": 2}]}'
+        )
+    )
+
+    example = Example(doc_a, doc_b)
+    proj_heads, proj_deps = example.get_aligned_parse(projectivize=True)
+    assert proj_heads == [None]
+    assert proj_deps == [None]
 
 
 def test_iob_to_biluo():

--- a/spacy/training/example.pyx
+++ b/spacy/training/example.pyx
@@ -249,9 +249,9 @@ cdef class Example:
         # Fetch all aligned gold token incides.
         if c2g_single_toks.shape == cand_to_gold.lengths.shape:
             # This the most likely case.
-            gold_i = cand_to_gold[:].squeeze()
+            gold_i = cand_to_gold[:]
         else:
-            gold_i = numpy.vectorize(lambda x: cand_to_gold[int(x)][0])(c2g_single_toks).squeeze()
+            gold_i = numpy.vectorize(lambda x: cand_to_gold[int(x)][0], otypes='i')(c2g_single_toks)
 
         # Fetch indices of all gold heads for the aligned gold tokens.
         heads = numpy.asarray(heads, dtype='i')
@@ -261,7 +261,7 @@ cdef class Example:
         # gold tokens (and are aligned to a single candidate token).
         g2c_len_heads = gold_to_cand.lengths[gold_head_i]
         g2c_len_heads = numpy.where(g2c_len_heads == 1)[0]
-        g2c_i = numpy.vectorize(lambda x: gold_to_cand[int(x)][0])(gold_head_i[g2c_len_heads]).squeeze()
+        g2c_i = numpy.vectorize(lambda x: gold_to_cand[int(x)][0], otypes='i')(gold_head_i[g2c_len_heads]).squeeze()
 
         # Update head/dep alignments with the above.
         aligned_heads = numpy.full((self.x.length), None)


### PR DESCRIPTION
## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
We were unnecessarily squeezing the gold token index vectors, causing unit-length vectors to yield a scalar and breaking indexing (the root cause seems to point to a reference sentence containing just one token). We additionally provide the output type to `np.vectorize` to correctly handle corner cases where no alignment can be made between the gold and candidate tokens.

These changes were sanity checked by locally training English and German parser models for multiple epochs.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Bugfix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
