### PR TITLE
dont use get_array_module

### DIFF
--- a/spacy/pipeline/textcat.py
+++ b/spacy/pipeline/textcat.py
@@ -192,7 +192,7 @@ class TextCategorizer(TrainablePipe):
         if not any(len(doc) for doc in docs):
             # Handle cases where there are no tokens in any docs.
             tensors = [doc.tensor for doc in docs]
-            xp = get_array_module(tensors)
+            xp = self.model.ops.xp
             scores = xp.zeros((len(list(docs)), len(self.labels)))
             return scores
         scores = self.model.predict(docs)


### PR DESCRIPTION
Update for new `thinc` compatibility

## Description
The behavior of `get_array_module` is changing in `thinc` and it will `raise ValueError` when passing an argument that is neither a `numpy` object nor a `cupy` object.

### Types of change
Mini update

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
