### PR TITLE
precompute_hiddens/Parser: do not look up CPU ops (3.4)

### DIFF
--- a/spacy/ml/parser_model.pyx
+++ b/spacy/ml/parser_model.pyx
@@ -441,7 +441,7 @@ cdef class precompute_hiddens:
 
         cdef CBlas cblas
         if isinstance(self.ops, CupyOps):
-            cblas = get_ops("cpu").cblas()
+            cblas = NUMPY_OPS.cblas()
         else:
             cblas = self.ops.cblas()
 

--- a/spacy/pipeline/transition_parser.pyx
+++ b/spacy/pipeline/transition_parser.pyx
@@ -9,7 +9,7 @@ from libc.stdlib cimport calloc, free
 import random
 
 import srsly
-from thinc.api import get_ops, set_dropout_rate, CupyOps
+from thinc.api import get_ops, set_dropout_rate, CupyOps, NumpyOps
 from thinc.extra.search cimport Beam
 import numpy.random
 import numpy
@@ -28,6 +28,9 @@ from ._parser_internals import _beam_utils
 from ..training import validate_examples, validate_get_examples
 from ..errors import Errors, Warnings
 from .. import util
+
+
+_NUMPY_OPS = NumpyOps()
 
 
 cdef class Parser(TrainablePipe):
@@ -262,7 +265,7 @@ cdef class Parser(TrainablePipe):
         ops = self.model.ops
         cdef CBlas cblas
         if isinstance(ops, CupyOps):
-            cblas = get_ops("cpu").cblas()
+            cblas = _NUMPY_OPS.cblas()
         else:
             cblas = ops.cblas()
         self._ensure_labels_are_added(docs)

--- a/spacy/pipeline/transition_parser.pyx
+++ b/spacy/pipeline/transition_parser.pyx
@@ -30,7 +30,7 @@ from ..errors import Errors, Warnings
 from .. import util
 
 
-_NUMPY_OPS = NumpyOps()
+NUMPY_OPS = NumpyOps()
 
 
 cdef class Parser(TrainablePipe):
@@ -265,7 +265,7 @@ cdef class Parser(TrainablePipe):
         ops = self.model.ops
         cdef CBlas cblas
         if isinstance(ops, CupyOps):
-            cblas = _NUMPY_OPS.cblas()
+            cblas = NUMPY_OPS.cblas()
         else:
             cblas = ops.cblas()
         self._ensure_labels_are_added(docs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

`get_ops("cpu")` is quite expensive. To avoid this, we want to cache the result as in #11068. However, for 3.x we do not want to change the ABI. So we avoid the expensive lookup by using NumpyOps. This should have a minimal impact, since `get_ops("cpu")` was only used when the model ops were `CupyOps`. If the ops are `AppleOps`, we are still passing through the correct BLAS implementation.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Performance fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
