### PR TITLE
Add Softmax scorer for spancat

### DIFF
--- a/spacy/ml/models/spancat.py
+++ b/spacy/ml/models/spancat.py
@@ -1,11 +1,13 @@
 from typing import List, Tuple, cast
-from thinc.api import Model, with_getitem, chain, list2ragged, Logistic
-from thinc.api import Maxout, Linear, concatenate, glorot_uniform_init
-from thinc.api import reduce_mean, reduce_max, reduce_first, reduce_last
-from thinc.types import Ragged, Floats2d
 
-from ...util import registry
+from thinc.api import Linear, Logistic, Maxout, Model, Softmax, chain
+from thinc.api import concatenate, glorot_uniform_init, list2ragged
+from thinc.api import reduce_first, reduce_last, reduce_max, reduce_mean
+from thinc.api import with_getitem
+from thinc.types import Floats2d, Ragged
+
 from ...tokens import Doc
+from ...util import registry
 from ..extract_spans import extract_spans
 
 

--- a/spacy/ml/models/spancat.py
+++ b/spacy/ml/models/spancat.py
@@ -24,7 +24,7 @@ def build_softmax(nO=None, nI=None) -> Model[Floats2d, Floats2d]:
     """An output layer for span classification. Uses a softmax layer for
     exclusive classes
     """
-    return chain(Softmax(nO=nO, nI=nI, init_W=glorot_uniform_init))
+    return Softmax(nO=nO, nI=nI, init_W=glorot_uniform_init)
 
 
 @registry.layers("spacy.mean_max_reducer.v1")

--- a/spacy/ml/models/spancat.py
+++ b/spacy/ml/models/spancat.py
@@ -19,6 +19,14 @@ def build_linear_logistic(nO=None, nI=None) -> Model[Floats2d, Floats2d]:
     return chain(Linear(nO=nO, nI=nI, init_W=glorot_uniform_init), Logistic())
 
 
+@registry.layers("spacy.Softmax.v1")
+def build_softmax(nO=None, nI=None) -> Model[Floats2d, Floats2d]:
+    """An output layer for span classification. Uses a softmax layer for
+    exclusive classes
+    """
+    return chain(Softmax(nO=nO, nI=nI, init_W=glorot_uniform_init))
+
+
 @registry.layers("spacy.mean_max_reducer.v1")
 def build_mean_max_reducer(hidden_size: int) -> Model[Ragged, Floats2d]:
     """Reduce sequences by concatenating their mean and max pooled vectors,


### PR DESCRIPTION
**WIP**: This PR adds a Softmax scorer for the spancat component that should be used in cases where classes are exclusive. 

## Description

Spancat currently has a `LinearLogistic` layer that creates multilabel annotations on text. However, this is not necessary when classes are exclusive or when spans are non-overlapping. Switching from a `LinearLogistic` to a `Softmax` layer is recommended. This issue came up when we're doing the spancat experiments. 

### Usage

In order for the user to switch to `spacy.Softmax.v1`, they have to update the config and specify the architecture in the `scorer`. 
**Alternative usage (not yet implemented)**: Add a parameter, `exclusive_classes:bool` (a la `textcat`), in the `SpanCategorizer` architecture to use Softmax automatically. 

### Types of change
New feature

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
