### PR TITLE
Use `pull_request_target` event for spaCy universe GA trigger

### DIFF
--- a/.github/workflows/spacy_universe_alert.yml
+++ b/.github/workflows/spacy_universe_alert.yml
@@ -1,7 +1,7 @@
 name: spaCy universe project alert
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - "website/meta/universe.json"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Since we use forking model instead of branching model, when outside collaborator creates pull request with `universe.json` file change, `pull_request` event gets triggered by Github Action (GA) but **`spacy_universe_alert.yml` workflow** fails as `SLACK_BOT_TOKEN` wont be shared with forked public repository. Thankfully there is a way to overcome this unable to access `SLACK_BOT_TOKEN` issue, we can use `pull_request_target` event which can access `SLACK_BOT_TOKEN` and send the notification to our #alerts-universe properly :)

Resources:
1. https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
2. [Github blog: improvements-for-public-repository-forks](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks)

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ ] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
