### PR TITLE
Fix span typings

### DIFF
--- a/spacy/tokens/span.pyi
+++ b/spacy/tokens/span.pyi
@@ -119,6 +119,8 @@ class Span:
     kb_id: int
     ent_id: int
     ent_id_: str
+    id: int
+    id_: str
     @property
     def orth_(self) -> str: ...
     @property

--- a/spacy/tokens/span.pyi
+++ b/spacy/tokens/span.pyi
@@ -119,8 +119,10 @@ class Span:
     kb_id: int
     ent_id: int
     ent_id_: str
-    id: int
-    id_: str
+    @property
+    def id(self) -> int: ...
+    @property
+    def id_(self) -> str: ...
     @property
     def orth_(self) -> str: ...
     @property


### PR DESCRIPTION
## Description

`Span` is missing `id` and `id_` attributes in the typing file, i.e. `span.pyi`. But it is [available properties](https://github.com/explosion/spaCy/blob/master/spacy/tokens/span.pyx#L784)

Fixes #11118


### Types of change
Bug fix on typings

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
