### PR TITLE
Matchers documentation update (error in example)

### DIFF
--- a/website/docs/api/matcher.md
+++ b/website/docs/api/matcher.md
@@ -199,7 +199,7 @@ will be overwritten.
 >    [{"LOWER": "hello"}, {"LOWER": "world"}],
 >    [{"ORTH": "Google"}, {"ORTH": "Maps"}]
 > ]
-> matcher.add("TEST_PATTERNS", patterns)
+> matcher.add("TEST_PATTERNS", patterns, on_match=on_match)
 > doc = nlp("HELLO WORLD on Google Maps.")
 > matches = matcher(doc)
 > ```


### PR DESCRIPTION
## Description
Simple update of documentation (example for Matchers) to reflect the code.  Function `on_match` in the example was not called, therefore the sample was not doing anything. This PR fixes it (added necessary code in the example).

```python
def on_match(matcher, doc, id, matches): # ⚠️ NOTE: this function is unused in the current example
    print('Matched!', matches)

matcher = Matcher(nlp.vocab)
patterns = [
   [{"LOWER": "hello"}, {"LOWER": "world"}],
   [{"ORTH": "Google"}, {"ORTH": "Maps"}]
]
matcher.add("TEST_PATTERNS", patterns) #  ⚠️ NOTE: on_match argument is not passed! (fixed in the PR)
doc = nlp("HELLO WORLD on Google Maps.")
matches = matcher(doc)
```

### Types of change
Documentation update.

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
