### PR TITLE
Add a way to get the URL to download a pipeline to the CLI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,5 @@ mypy>=0.910,<0.970; platform_machine!='aarch64'
 types-dataclasses>=0.1.3; python_version < "3.7"
 types-mock>=0.1.1
 types-requests
+types-setuptools>=57.0.0
 black>=22.0,<23.0

--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -79,9 +79,12 @@ def download(
 
 
 def get_model_filename(model_name: str, version: str, sdist: bool = False) -> str:
-    dl_tpl = "{m}-{v}/{m}-{v}{s}#egg={m}=={v}"
+    dl_tpl = "{m}-{v}/{m}-{v}{s}"
+    egg_tpl = "#egg={m}=={v}"
     suffix = SDIST_SUFFIX if sdist else WHEEL_SUFFIX
     filename = dl_tpl.format(m=model_name, v=version, s=suffix)
+    if sdist:
+        filename += egg_tpl.format(m=model_name, v=version)
     return filename
 
 

--- a/spacy/cli/info.py
+++ b/spacy/cli/info.py
@@ -46,6 +46,8 @@ def info(
         if model is not None:
             title = f"Download info for pipeline '{model}'"
             data = info_model_url(model)
+            print(data["download_url"])
+            return data
         else:
             msg.fail("--url option requires a pipeline name", exits=1)
     elif model:

--- a/spacy/cli/info.py
+++ b/spacy/cli/info.py
@@ -17,7 +17,7 @@ def info_cli(
     markdown: bool = Opt(False, "--markdown", "-md", help="Generate Markdown for GitHub issues"),
     silent: bool = Opt(False, "--silent", "-s", "-S", help="Don't print anything (just return)"),
     exclude: str = Opt("labels", "--exclude", "-e", help="Comma-separated keys to exclude from the print-out"),
-    url: bool = Opt(False, "--url", "-u", help="Print the URL to download the pipeline from"),
+    url: bool = Opt(False, "--url", "-u", help="Print the URL to download the most recent version of the pipeline"),
     requirements: bool = Opt(False, "--requirements", "-r", help="Print requirements info for a pipeline"),
     # fmt: on
 ):

--- a/spacy/cli/info.py
+++ b/spacy/cli/info.py
@@ -19,13 +19,16 @@ def info_cli(
     markdown: bool = Opt(False, "--markdown", "-md", help="Generate Markdown for GitHub issues"),
     silent: bool = Opt(False, "--silent", "-s", "-S", help="Don't print anything (just return)"),
     exclude: str = Opt("labels", "--exclude", "-e", help="Comma-separated keys to exclude from the print-out"),
-    url: bool = Opt(False, "--url", "-u", help="Print the URL to download the most recent version of the pipeline"),
+    url: bool = Opt(False, "--url", "-u", help="Print the URL to download the most recent compatible version of the pipeline"),
     # fmt: on
 ):
     """
     Print info about spaCy installation. If a pipeline is specified as an argument,
     print its meta information. Flag --markdown prints details in Markdown for easy
-    copy-pasting to GitHub issues. Flag --url prints the download URL of the pipeline.
+    copy-pasting to GitHub issues.
+
+    Flag --url prints only the download URL of the most recent comptaible
+    version of the pipeline.
 
     DOCS: https://spacy.io/api/cli#info
     """

--- a/spacy/cli/info.py
+++ b/spacy/cli/info.py
@@ -142,7 +142,7 @@ def info_model_url(model: str) -> Dict[str, Any]:
     return {"download_url": download_url, "release_url": release_url}
 
 
-def info_model_requirements(model: str) -> Dict[str, Any]:
+def info_model_requirements(model: str, preformat=True) -> Dict[str, Any]:
     """Return formatted requirements statements for the pipeline."""
     url_info = info_model_url(model)
 
@@ -152,39 +152,39 @@ def info_model_requirements(model: str) -> Dict[str, Any]:
     # TODO pick one approach or the other. This is more like other commands and
     # cleaner but the output is hard to read.
 
-    setup_cfg = f"""install_requires =
-        {model} @ {url}"""
+    if  preformat:
 
-    poetry = f'{model} = {{ url = "{url}" }}'
+        # This seems prefereable
+        requirements = {"requirements": f"""
 
-    requirements = {
-        "Release info page": release_url,
-        "setup.cfg": setup_cfg,
-        "poetry": poetry,
-    }
+        Release info page:
 
-    # This seems prefereable
-    requirements = f"""
+        {release_url}
 
-    Release info page:
+        setup.cfg:
 
-    {release_url}
+        install_requires =
+            {model} @ {url}
 
-    setup.cfg:
+        poetry:
 
-    install_requires =
-        {model} @ {url}
+        {model} = {{ url = "{url}" }}
+        """
+        }
 
-    poetry:
+    else:
+        setup_cfg = f"""install_requires =
+            {model} @ {url}"""
 
-    {model} = {{ url = "{url}" }}
-    """
+        poetry = f'{model} = {{ url = "{url}" }}'
 
-    # Using an empty key prints an indented block, preserving formatting.
-    return {"": requirements}
+        requirements = {
+            "Release info page": release_url,
+            "setup.cfg": setup_cfg,
+            "poetry": poetry,
+        }
 
-    # use following line if using the dict
-    # return requirements
+    return requirements
 
 
 def get_markdown(

--- a/spacy/cli/info.py
+++ b/spacy/cli/info.py
@@ -43,10 +43,11 @@ def info(
     if not exclude:
         exclude = []
     if url:
-        if not model:
+        if model is not None:
+            title = f"Download info for pipeline '{model}'"
+            data = info_model_url(model)
+        else:
             msg.fail("--url option requires a pipeline name", exits=1)
-        title = f"Download info for pipeline '{model}'"
-        data = info_model_url(model)
     elif model:
         title = f"Info about pipeline '{model}'"
         data = info_model(model, silent=silent)

--- a/spacy/cli/info.py
+++ b/spacy/cli/info.py
@@ -17,7 +17,7 @@ def info_cli(
     markdown: bool = Opt(False, "--markdown", "-md", help="Generate Markdown for GitHub issues"),
     silent: bool = Opt(False, "--silent", "-s", "-S", help="Don't print anything (just return)"),
     exclude: str = Opt("labels", "--exclude", "-e", help="Comma-separated keys to exclude from the print-out"),
-    url: bool = Opt(False, "--url", "-u", help="Print the pipeline download URL"),
+    url: bool = Opt(False, "--url", "-u", help="Print the URL to download the pipeline from"),
     # fmt: on
 ):
     """

--- a/spacy/cli/info.py
+++ b/spacy/cli/info.py
@@ -27,7 +27,7 @@ def info_cli(
     print its meta information. Flag --markdown prints details in Markdown for easy
     copy-pasting to GitHub issues.
 
-    Flag --url prints only the download URL of the most recent comptaible
+    Flag --url prints only the download URL of the most recent compatible
     version of the pipeline.
 
     DOCS: https://spacy.io/api/cli#info

--- a/spacy/tests/package/test_requirements.py
+++ b/spacy/tests/package/test_requirements.py
@@ -17,6 +17,7 @@ def test_build_dependencies():
         "types-dataclasses",
         "types-mock",
         "types-requests",
+        "types-setuptools",
     ]
     # ignore language-specific packages that shouldn't be installed by all
     libs_ignore_setup = [

--- a/website/docs/api/cli.md
+++ b/website/docs/api/cli.md
@@ -83,7 +83,7 @@ $ python -m spacy info [model] [--markdown] [--silent] [--exclude]
 | `--markdown`, `-md`                              | Print information as Markdown. ~~bool (flag)~~                                                               |
 | `--silent`, `-s` <Tag variant="new">2.0.12</Tag> | Don't print anything, just return the values. ~~bool (flag)~~                                                |
 | `--exclude`, `-e`                                | Comma-separated keys to exclude from the print-out. Defaults to `"labels"`. ~~Optional[str]~~                |
-| `--url`, `-u` <Tag variant="new">3.5.0</Tag>     | Print the URL to download the most recent version of the pipeline. Requires a pipeline name. ~~bool (flag)~~ |
+| `--url`, `-u` <Tag variant="new">3.5.0</Tag>     | Print the URL to download the most recent compatible version of the pipeline. Requires a pipeline name. ~~bool (flag)~~ |
 | `--help`, `-h`                                   | Show help message and available arguments. ~~bool (flag)~~                                                   |
 | **PRINTS**                                       | Information about your spaCy installation.                                                                   |
 

--- a/website/docs/api/cli.md
+++ b/website/docs/api/cli.md
@@ -77,15 +77,15 @@ $ python -m spacy info [--markdown] [--silent] [--exclude]
 $ python -m spacy info [model] [--markdown] [--silent] [--exclude]
 ```
 
-| Name                                             | Description                                                                                                  |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| `model`                                          | A trained pipeline, i.e. package name or path (optional). ~~Optional[str] \(option)~~                        |
-| `--markdown`, `-md`                              | Print information as Markdown. ~~bool (flag)~~                                                               |
-| `--silent`, `-s` <Tag variant="new">2.0.12</Tag> | Don't print anything, just return the values. ~~bool (flag)~~                                                |
-| `--exclude`, `-e`                                | Comma-separated keys to exclude from the print-out. Defaults to `"labels"`. ~~Optional[str]~~                |
+| Name                                             | Description                                                                                                             |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `model`                                          | A trained pipeline, i.e. package name or path (optional). ~~Optional[str] \(option)~~                                   |
+| `--markdown`, `-md`                              | Print information as Markdown. ~~bool (flag)~~                                                                          |
+| `--silent`, `-s` <Tag variant="new">2.0.12</Tag> | Don't print anything, just return the values. ~~bool (flag)~~                                                           |
+| `--exclude`, `-e`                                | Comma-separated keys to exclude from the print-out. Defaults to `"labels"`. ~~Optional[str]~~                           |
 | `--url`, `-u` <Tag variant="new">3.5.0</Tag>     | Print the URL to download the most recent compatible version of the pipeline. Requires a pipeline name. ~~bool (flag)~~ |
-| `--help`, `-h`                                   | Show help message and available arguments. ~~bool (flag)~~                                                   |
-| **PRINTS**                                       | Information about your spaCy installation.                                                                   |
+| `--help`, `-h`                                   | Show help message and available arguments. ~~bool (flag)~~                                                              |
+| **PRINTS**                                       | Information about your spaCy installation.                                                                              |
 
 ## validate {#validate new="2" tag="command"}
 

--- a/website/docs/api/cli.md
+++ b/website/docs/api/cli.md
@@ -77,14 +77,15 @@ $ python -m spacy info [--markdown] [--silent] [--exclude]
 $ python -m spacy info [model] [--markdown] [--silent] [--exclude]
 ```
 
-| Name                                             | Description                                                                                   |
-| ------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| `model`                                          | A trained pipeline, i.e. package name or path (optional). ~~Optional[str] \(option)~~         |
-| `--markdown`, `-md`                              | Print information as Markdown. ~~bool (flag)~~                                                |
-| `--silent`, `-s` <Tag variant="new">2.0.12</Tag> | Don't print anything, just return the values. ~~bool (flag)~~                                 |
-| `--exclude`, `-e`                                | Comma-separated keys to exclude from the print-out. Defaults to `"labels"`. ~~Optional[str]~~ |
-| `--help`, `-h`                                   | Show help message and available arguments. ~~bool (flag)~~                                    |
-| **PRINTS**                                       | Information about your spaCy installation.                                                    |
+| Name                                             | Description                                                                                                  |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `model`                                          | A trained pipeline, i.e. package name or path (optional). ~~Optional[str] \(option)~~                        |
+| `--markdown`, `-md`                              | Print information as Markdown. ~~bool (flag)~~                                                               |
+| `--silent`, `-s` <Tag variant="new">2.0.12</Tag> | Don't print anything, just return the values. ~~bool (flag)~~                                                |
+| `--exclude`, `-e`                                | Comma-separated keys to exclude from the print-out. Defaults to `"labels"`. ~~Optional[str]~~                |
+| `--url`, `-u` <Tag variant="new">3.5.0</Tag>     | Print the URL to download the most recent version of the pipeline. Requires a pipeline name. ~~bool (flag)~~ |
+| `--help`, `-h`                                   | Show help message and available arguments. ~~bool (flag)~~                                                   |
+| **PRINTS**                                       | Information about your spaCy installation.                                                                   |
 
 ## validate {#validate new="2" tag="command"}
 

--- a/website/docs/usage/models.md
+++ b/website/docs/usage/models.md
@@ -531,20 +531,15 @@ should be specifying them directly.
 Because pipeline packages are valid Python packages, you can add them to your
 application's `requirements.txt`. If you're running your own internal PyPi
 installation, you can upload the pipeline packages there. pip's
-[requirements file format](https://pip.pypa.io/en/latest/reference/pip_install/#requirements-file-format)
+[requirements file format](https://pip.pypa.io/en/latest/reference/requirements-file-format/)
 supports both package names to download via a PyPi server, as well as
 [direct URLs](#pipeline-urls).
 
 ```text
 ### requirements.txt
 spacy>=3.0.0,<4.0.0
-https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz#egg=en_core_web_sm
+en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.4.0/en_core_web_sm-3.4.0-py3-none-any.whl
 ```
-
-Specifying `#egg=` with the package name tells pip which package to expect from
-the download URL. This way, the package won't be re-downloaded and overwritten
-if it's already installed - just like when you're downloading a package from
-PyPi.
 
 All pipeline packages are versioned and specify their spaCy dependency. This
 ensures cross-compatibility and lets you specify exact version requirements for

--- a/website/docs/usage/models.md
+++ b/website/docs/usage/models.md
@@ -365,14 +365,29 @@ pipeline package can be found.
 To download a trained pipeline directly using
 [pip](https://pypi.python.org/pypi/pip), point `pip install` to the URL or local
 path of the wheel file or archive. Installing the wheel is usually more
-efficient. To find the direct link to a package, head over to the
-[releases](https://github.com/explosion/spacy-models/releases), right click on
-the archive link and copy it to your clipboard.
+efficient.
+
+> #### How to Find Download URLs {#download-urls}
+>
+> Pretrained pipeline distributions are hosted on
+> [Github Releases](https://github.com/explosion/spacy-models/releases), and you
+> can find download links there, as well as on the model page. You can also get download URLs directly
+> from the command line by using `spacy info` with the `--url` flag, which may be useful for automation.
+>
+> ```bash
+> spacy info en_core_web_sm --url
+> ```
+>
+> This command will print the download URL for the latest version of a pipeline
+> compatible with the version of spaCy you're using. Note that in order to look up the compatability information an Internet connection is required.
 
 ```bash
 # With external URL
 $ pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0-py3-none-any.whl
 $ pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz
+
+# Using spacy info to get the external URL
+$ pip install $(spacy info en_core_web_sm --url)
 
 # With local file
 $ pip install /Users/you/en_core_web_sm-3.0.0-py3-none-any.whl
@@ -515,8 +530,8 @@ Because pipeline packages are valid Python packages, you can add them to your
 application's `requirements.txt`. If you're running your own internal PyPi
 installation, you can upload the pipeline packages there. pip's
 [requirements file format](https://pip.pypa.io/en/latest/reference/pip_install/#requirements-file-format)
-supports both package names to download via a PyPi server, as well as direct
-URLs.
+supports both package names to download via a PyPi server, as well as [direct
+URLs](#download-urls).
 
 ```text
 ### requirements.txt

--- a/website/docs/usage/models.md
+++ b/website/docs/usage/models.md
@@ -367,18 +367,18 @@ To download a trained pipeline directly using
 path of the wheel file or archive. Installing the wheel is usually more
 efficient.
 
-> #### How to Find Download URLs {#download-urls}
+> #### Pipeline Package URLs {#pipeline-urls}
 >
 > Pretrained pipeline distributions are hosted on
 > [Github Releases](https://github.com/explosion/spacy-models/releases), and you
-> can find download links there, as well as on the model page. You can also get download URLs directly
+> can find download links there, as well as on the model page. You can also get URLs directly
 > from the command line by using `spacy info` with the `--url` flag, which may be useful for automation.
 >
 > ```bash
 > spacy info en_core_web_sm --url
 > ```
 >
-> This command will print the download URL for the latest version of a pipeline
+> This command will print the URL for the latest version of a pipeline
 > compatible with the version of spaCy you're using. Note that in order to look up the compatability information an Internet connection is required.
 
 ```bash

--- a/website/docs/usage/models.md
+++ b/website/docs/usage/models.md
@@ -371,15 +371,17 @@ efficient.
 >
 > Pretrained pipeline distributions are hosted on
 > [Github Releases](https://github.com/explosion/spacy-models/releases), and you
-> can find download links there, as well as on the model page. You can also get URLs directly
-> from the command line by using `spacy info` with the `--url` flag, which may be useful for automation.
+> can find download links there, as well as on the model page. You can also get
+> URLs directly from the command line by using `spacy info` with the `--url`
+> flag, which may be useful for automation.
 >
 > ```bash
 > spacy info en_core_web_sm --url
 > ```
 >
 > This command will print the URL for the latest version of a pipeline
-> compatible with the version of spaCy you're using. Note that in order to look up the compatability information an Internet connection is required.
+> compatible with the version of spaCy you're using. Note that in order to look
+> up the compatibility information an internet connection is required.
 
 ```bash
 # With external URL
@@ -530,8 +532,8 @@ Because pipeline packages are valid Python packages, you can add them to your
 application's `requirements.txt`. If you're running your own internal PyPi
 installation, you can upload the pipeline packages there. pip's
 [requirements file format](https://pip.pypa.io/en/latest/reference/pip_install/#requirements-file-format)
-supports both package names to download via a PyPi server, as well as [direct
-URLs](#download-urls).
+supports both package names to download via a PyPi server, as well as
+[direct URLs](#pipeline-urls).
 
 ```text
 ### requirements.txt

--- a/website/src/templates/models.js
+++ b/website/src/templates/models.js
@@ -76,6 +76,7 @@ const MODEL_META = {
     benchmark_ner: 'NER accuracy',
     benchmark_speed: 'Speed',
     compat: 'Latest compatible package version for your spaCy installation',
+    download_url: 'Download URL for the pipeline',
 }
 
 const LABEL_SCHEME_META = {
@@ -134,6 +135,13 @@ function formatAccuracy(data, lang) {
         .filter(item => item)
 }
 
+function formatDownloadUrl(lang, name, version) {
+  const fullName = `${lang}_${name}-${version}`
+  const filename = `${fullName}-py3-none-any.whl`
+  const url = `https://github.com/explosion/spacy-models/releases/download/${fullName}/${filename}`
+  return <Link to={url} hideIcon>{filename}</Link>
+}
+
 function formatModelMeta(data) {
     return {
         fullName: `${data.lang}_${data.name}-${data.version}`,
@@ -150,6 +158,7 @@ function formatModelMeta(data) {
         labels: isEmptyObj(data.labels) ? null : data.labels,
         vectors: formatVectors(data.vectors),
         accuracy: formatAccuracy(data.performance, data.lang),
+        download_url: formatDownloadUrl(data.lang, data.name, data.version),
     }
 }
 
@@ -240,6 +249,7 @@ const Model = ({
         { label: 'Components', content: components, help: MODEL_META.components },
         { label: 'Pipeline', content: pipeline, help: MODEL_META.pipeline },
         { label: 'Vectors', content: meta.vectors, help: MODEL_META.vecs },
+        { label: 'Download URL', content: meta.download_url, help: MODEL_META.download_url },
         { label: 'Sources', content: sources, help: MODEL_META.sources },
         { label: 'Author', content: author },
         { label: 'License', content: license },

--- a/website/src/templates/models.js
+++ b/website/src/templates/models.js
@@ -249,7 +249,7 @@ const Model = ({
         { label: 'Components', content: components, help: MODEL_META.components },
         { label: 'Pipeline', content: pipeline, help: MODEL_META.pipeline },
         { label: 'Vectors', content: meta.vectors, help: MODEL_META.vecs },
-        { label: 'Download URL', content: meta.download_url, help: MODEL_META.download_url },
+        { label: 'Package URL', content: meta.download_url, help: MODEL_META.download_url },
         { label: 'Sources', content: sources, help: MODEL_META.sources },
         { label: 'Author', content: author },
         { label: 'License', content: license },

--- a/website/src/templates/models.js
+++ b/website/src/templates/models.js
@@ -76,7 +76,7 @@ const MODEL_META = {
     benchmark_ner: 'NER accuracy',
     benchmark_speed: 'Speed',
     compat: 'Latest compatible package version for your spaCy installation',
-    download_url: 'Download URL for the pipeline',
+    download_link: 'Download link for the pipeline',
 }
 
 const LABEL_SCHEME_META = {
@@ -135,7 +135,7 @@ function formatAccuracy(data, lang) {
         .filter(item => item)
 }
 
-function formatDownloadUrl(lang, name, version) {
+function formatDownloadLink(lang, name, version) {
   const fullName = `${lang}_${name}-${version}`
   const filename = `${fullName}-py3-none-any.whl`
   const url = `https://github.com/explosion/spacy-models/releases/download/${fullName}/${filename}`
@@ -158,7 +158,7 @@ function formatModelMeta(data) {
         labels: isEmptyObj(data.labels) ? null : data.labels,
         vectors: formatVectors(data.vectors),
         accuracy: formatAccuracy(data.performance, data.lang),
-        download_url: formatDownloadUrl(data.lang, data.name, data.version),
+        download_link: formatDownloadLink(data.lang, data.name, data.version),
     }
 }
 
@@ -249,7 +249,7 @@ const Model = ({
         { label: 'Components', content: components, help: MODEL_META.components },
         { label: 'Pipeline', content: pipeline, help: MODEL_META.pipeline },
         { label: 'Vectors', content: meta.vectors, help: MODEL_META.vecs },
-        { label: 'Package URL', content: meta.download_url, help: MODEL_META.download_url },
+        { label: 'Download Link', content: meta.download_link, help: MODEL_META.download_link },
         { label: 'Sources', content: sources, help: MODEL_META.sources },
         { label: 'Author', content: author },
         { label: 'License', content: license },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

This adds a `--url` flag to the `spacy info [model]` command that prints the URL of the most recent compatible version of the named pipeline. This URL is printed without any formatting for use in scripts, like:

```
url=$(spacy info en_core_web_sm --url)
wget "$url"
```

Because this requires a compatibility check, it requires an Internet connection.

This also adds the download URL for installed packages to the output of `spacy info [model]` if available. The information is typically available for pipelines installed with pip, and is accessed through `pkg_resources`. This does not require an Internet connection.

-----
Original description: 

This is a simple implementation of a `--dry-run` flag for `spacy download` that makes it print the URL of the package to be installed without downloading anything. 

I don't have strong opinions about the way this is done, but there are some questions:

- would it be better to print just the URL?
- should there be a method to get the URL for outside use?
- should we be concerned about the flags overlapping with pip (they don't currently)?

I'm not sure how universal this is, but I used `-n` for the short flag, which I understand to come from `noop`. 

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

minor enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
