### PR TITLE
Support full prerelease versions in the compat table

### DIFF
--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -7,6 +7,7 @@ import typer
 from ._util import app, Arg, Opt, WHEEL_SUFFIX, SDIST_SUFFIX
 from .. import about
 from ..util import is_package, get_minor_version, run_command
+from ..util import is_prerelease_version
 from ..errors import OLD_MODEL_SHORTCUTS
 
 
@@ -74,7 +75,10 @@ def download(model: str, direct: bool = False, sdist: bool = False, *pip_args) -
 
 
 def get_compatibility() -> dict:
-    version = get_minor_version(about.__version__)
+    if is_prerelease_version(about.__version__):
+        version = about.__version__
+    else:
+        version = get_minor_version(about.__version__)
     r = requests.get(about.__compatibility__)
     if r.status_code != 200:
         msg.fail(

--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -76,7 +76,7 @@ def download(model: str, direct: bool = False, sdist: bool = False, *pip_args) -
 
 def get_compatibility() -> dict:
     if is_prerelease_version(about.__version__):
-        version = about.__version__
+        version: Optional[str] = about.__version__
     else:
         version = get_minor_version(about.__version__)
     r = requests.get(about.__compatibility__)

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -795,6 +795,15 @@ def get_model_lower_version(constraint: str) -> Optional[str]:
     return None
 
 
+def is_prerelease_version(version: str) -> str:
+    """Check whether a version is a prerelease version.
+
+    version (str): The version, e.g. "3.0.0.dev1".
+    RETURNS (bool): Whether the version is a prerelease version.
+    """
+    return Version(version).is_prerelease
+
+
 def get_base_version(version: str) -> str:
     """Generate the base version without any prerelease identifiers.
 

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -795,7 +795,7 @@ def get_model_lower_version(constraint: str) -> Optional[str]:
     return None
 
 
-def is_prerelease_version(version: str) -> str:
+def is_prerelease_version(version: str) -> bool:
     """Check whether a version is a prerelease version.
 
     version (str): The version, e.g. "3.0.0.dev1".


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Switching to minor version based compatibility in the compatibility table has simplified making patch releases and keeps the compatibility table smaller, however it's difficult to publish prerelease model versions for testing because there's no way to specify a prerelease version based on minor version compatibility, and as soon as there's a newer stable-looking minor version in the compatibility table, the website uses it by default for the model entries.

This isn't the only way to solve this problem, but it seemed like a relatively straightforward alternative for dev releases as in #10624, where the models could only be installed through external URLs rather than `spacy download` for v3.3.0.dev0.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

?

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
