### PR TITLE
Fix Dutch [E102] Can't merge non-disjoint spans that happens for nl_core_news_lg 

### DIFF
--- a/spacy/lang/nl/syntax_iterators.py
+++ b/spacy/lang/nl/syntax_iterators.py
@@ -45,9 +45,6 @@ def noun_chunks(doclike: Union[Doc, Span]) -> Iterator[Tuple[int, int, int]]:
         # For NOUNS
         # Pick children from syntactic parse (only those with certain dependencies)
         if word.pos == NOUN:
-            # Prevent nested chunks from being produced
-            if word.left_edge.i <= end_span:
-                continue
             # Some debugging. It happens that VERBS are POS-TAGGED as NOUNS
             # We check if the word has a "nsubj", if it's the case, we eliminate it
             nsubjs = filter(
@@ -68,6 +65,8 @@ def noun_chunks(doclike: Union[Doc, Span]) -> Iterator[Tuple[int, int, int]]:
         # PRONOUNS only if it is the subject of a verb
         elif word.pos == PRON:
             # Prevent nested chunks from being produced
+            if word.left_edge.i <= end_span:
+                continue
             if word.dep in pronoun_deps:
                 start_span = word.i
                 end_span = word.i + 1

--- a/spacy/lang/nl/syntax_iterators.py
+++ b/spacy/lang/nl/syntax_iterators.py
@@ -43,12 +43,11 @@ def noun_chunks(doclike: Union[Doc, Span]) -> Iterator[Tuple[int, int, int]]:
     # Only NOUNS and PRONOUNS matter
     for i, word in enumerate(filter(lambda x: x.pos in [PRON, NOUN], doclike)):
         # For NOUNS
-        # Prevent nested chunks from being produced
-        if word.left_edge.i <= start_span:
-            continue
-
         # Pick children from syntactic parse (only those with certain dependencies)
         if word.pos == NOUN:
+            # Prevent nested chunks from being produced
+            if word.left_edge.i <= start_span:
+                continue
             # Some debugging. It happens that VERBS are POS-TAGGED as NOUNS
             # We check if the word has a "nsubj", if it's the case, we eliminate it
             nsubjs = filter(

--- a/spacy/lang/nl/syntax_iterators.py
+++ b/spacy/lang/nl/syntax_iterators.py
@@ -68,8 +68,6 @@ def noun_chunks(doclike: Union[Doc, Span]) -> Iterator[Tuple[int, int, int]]:
         # PRONOUNS only if it is the subject of a verb
         elif word.pos == PRON:
             # Prevent nested chunks from being produced
-            if word.left_edge.i <= end_span:
-                continue
             if word.dep in pronoun_deps:
                 start_span = word.i
                 end_span = word.i + 1

--- a/spacy/lang/nl/syntax_iterators.py
+++ b/spacy/lang/nl/syntax_iterators.py
@@ -39,9 +39,14 @@ def noun_chunks(doclike: Union[Doc, Span]) -> Iterator[Tuple[int, int, int]]:
     # Label NP for the Span to identify it as Noun-Phrase
     span_label = doc.vocab.strings.add("NP")
 
+    start_span = -1
     # Only NOUNS and PRONOUNS matter
     for i, word in enumerate(filter(lambda x: x.pos in [PRON, NOUN], doclike)):
         # For NOUNS
+        # Prevent nested chunks from being produced
+        if word.left_edge.i <= start_span:
+            continue
+
         # Pick children from syntactic parse (only those with certain dependencies)
         if word.pos == NOUN:
             # Some debugging. It happens that VERBS are POS-TAGGED as NOUNS

--- a/spacy/lang/nl/syntax_iterators.py
+++ b/spacy/lang/nl/syntax_iterators.py
@@ -67,6 +67,9 @@ def noun_chunks(doclike: Union[Doc, Span]) -> Iterator[Tuple[int, int, int]]:
 
         # PRONOUNS only if it is the subject of a verb
         elif word.pos == PRON:
+            # Prevent nested chunks from being produced
+            if word.left_edge.i <= start_span:
+                continue
             if word.dep in pronoun_deps:
                 start_span = word.i
                 end_span = word.i + 1

--- a/spacy/lang/nl/syntax_iterators.py
+++ b/spacy/lang/nl/syntax_iterators.py
@@ -39,14 +39,14 @@ def noun_chunks(doclike: Union[Doc, Span]) -> Iterator[Tuple[int, int, int]]:
     # Label NP for the Span to identify it as Noun-Phrase
     span_label = doc.vocab.strings.add("NP")
 
-    start_span = -1
+    end_span = -1
     # Only NOUNS and PRONOUNS matter
     for i, word in enumerate(filter(lambda x: x.pos in [PRON, NOUN], doclike)):
         # For NOUNS
         # Pick children from syntactic parse (only those with certain dependencies)
         if word.pos == NOUN:
             # Prevent nested chunks from being produced
-            if word.left_edge.i <= start_span:
+            if word.left_edge.i <= end_span:
                 continue
             # Some debugging. It happens that VERBS are POS-TAGGED as NOUNS
             # We check if the word has a "nsubj", if it's the case, we eliminate it
@@ -68,7 +68,7 @@ def noun_chunks(doclike: Union[Doc, Span]) -> Iterator[Tuple[int, int, int]]:
         # PRONOUNS only if it is the subject of a verb
         elif word.pos == PRON:
             # Prevent nested chunks from being produced
-            if word.left_edge.i <= start_span:
+            if word.left_edge.i <= end_span:
                 continue
             if word.dep in pronoun_deps:
                 start_span = word.i

--- a/spacy/tests/lang/nl/test_noun_chunks.py
+++ b/spacy/tests/lang/nl/test_noun_chunks.py
@@ -1,5 +1,6 @@
-from spacy.tokens import Doc
 import pytest
+from spacy.tokens import Doc
+from spacy.util import filter_spans
 
 
 @pytest.fixture
@@ -207,3 +208,18 @@ def test_chunking(nl_sample, nl_reference_chunking):
     """
     chunks = [s.text.lower() for s in nl_sample.noun_chunks]
     assert chunks == nl_reference_chunking
+
+
+@pytest.mark.issue(10846)
+def test_no_overlapping_chunks(nl_vocab):
+    # fmt: off
+    doc = Doc(
+        nl_vocab,
+        words=["okt", "opvlamming", "panuveitiss", "Oculo", "sinistra", ">", "Oculo", "dextra", "en", "alghele", "malaise", "moe", ",", "tattoos", "opgezet", ".", "17-03-2020", "Ozurdex", "Oculo", "dextra", "et", "sinistra", ",", "opvlamming", "onder", "humir", "luchtweg", "ondanks", "wekelijks", "ada", "vele", "corpus", "vitreum", "(", "glasvocht", ")", "troebelingen", "beschreven"],
+        deps=["parataxis", "ROOT", "ROOT", "flat", "flat", "flat", "nsubj", "appos", "cc", "conj", "obj", "ROOT", "punct", "obj", "conj", "punct", "nummod", "ROOT", "nmod:poss", "appos", "flat", "flat", "punct", "appos", "case", "nmod", "ROOT", "case", "advmod", "nmod", "amod", "nsubj", "nmod", "punct", "nmod", "punct", "nsubj:pass", "ROOT"],
+        heads=[1, 1, 2, 2, 2, 2, 11, 6, 9, 7, 11, 11, 14, 14, 11, 11, 17, 17, 26, 18, 18, 18, 23, 18, 25, 23, 26, 32, 29, 32, 31, 29, 26, 34, 32, 34, 37, 37],
+        pos=["NOUN", "NOUN", "PROPN", "PROPN", "ADJ", "PUNCT", "PROPN", "NOUN", "CCONJ", "ADJ", "NOUN", "ADJ", "PUNCT", "ADJ", "VERB", "PUNCT", "NUM", "NOUN", "NOUN", "VERB", "PROPN", "PROPN", "PUNCT", "NOUN", "ADP", "PROPN", "NOUN", "ADP", "ADJ", "PROPN", "ADV", "NOUN", "NOUN", "PUNCT", "NOUN", "PUNCT", "NOUN", "VERB", ],
+    )
+    # fmt: on
+    chunks = list(doc.noun_chunks)
+    assert filter_spans(chunks) == chunks


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->
Fix Dutch [E102] Can't merge non-disjoint spans that happens for nl_core_news_lg
fix!: add if statement to check span

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
In file syntax_iterator for nl language during the noun chunking, add a test to make sure the position of the left_edge is less or equal to the span. 

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
It is a bug fix for the issue reported here #[10846](https://github.com/explosion/spaCy/issues/10846#issuecomment-1203160759)

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ ] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [X] My changes don't require a change to the documentation, or if they do, I've added all required information.
