### PR TITLE
adding spans to doc_annotation in Example.to_dict

### DIFF
--- a/spacy/tests/training/test_new_example.py
+++ b/spacy/tests/training/test_new_example.py
@@ -455,8 +455,8 @@ def test_issue11260(annots):
 
     output_dict = example.to_dict()
     assert "spans" in output_dict["doc_annotation"]
-    assert output_dict["doc_annotation"]["spans"]["cities"] == [(7, 15, "LOC")]
-    assert output_dict["doc_annotation"]["spans"]["people"] == [(0, 1, "PERSON")]
+    assert output_dict["doc_annotation"]["spans"]["cities"] == [(7, 15, "LOC", "")]
+    assert output_dict["doc_annotation"]["spans"]["people"] == [(0, 1, "PERSON", "")]
 
     output_example = Example.from_dict(predicted, output_dict)
 

--- a/spacy/tests/training/test_new_example.py
+++ b/spacy/tests/training/test_new_example.py
@@ -431,3 +431,34 @@ def test_Example_aligned_whitespace(en_vocab):
 
     example = Example(predicted, reference)
     assert example.get_aligned("TAG", as_string=True) == tags
+
+
+@pytest.mark.parametrize(
+    "annots",
+    [
+        {
+            "words": ["I", "like", "New", "York", "."],
+            "spans": {
+                "cities": [(7, 15, "LOC")],
+                "people": [(0, 1, "PERSON")],
+            },
+        }
+    ],
+)
+
+@pytest.mark.issue("11260")
+def test_issue11260(annots):
+    vocab = Vocab()
+    predicted = Doc(vocab, words=annots["words"])
+    example = Example.from_dict(predicted, annots)
+    assert len(list(example.reference.spans["cities"])) == 1
+    assert len(list(example.reference.spans["people"])) == 1
+
+    output_dict = example.to_dict()
+    assert "spans" in output_dict["doc_annotation"]
+    assert len(output_dict["doc_annotation"]["spans"]["cities"]) == 1
+    assert len(output_dict["doc_annotation"]["spans"]["people"]) == 1
+    assert output_dict["doc_annotation"]["spans"]["people"][0].text == "I"
+    assert output_dict["doc_annotation"]["spans"]["cities"][0].text == "New York"
+
+

--- a/spacy/tests/training/test_new_example.py
+++ b/spacy/tests/training/test_new_example.py
@@ -433,43 +433,39 @@ def test_Example_aligned_whitespace(en_vocab):
     assert example.get_aligned("TAG", as_string=True) == tags
 
 
-@pytest.mark.parametrize(
-    "annots",
-    [
-        {
-            "words": ["I", "like", "New", "York", "."],
-            "spans": {
-                "cities": [(7, 15, "LOC")],
-                "people": [(0, 1, "PERSON")],
-            },
-        }
-    ],
-)
 @pytest.mark.issue("11260")
-def test_issue11260(annots):
+def test_issue11260():
+    annots = {
+        "words": ["I", "like", "New", "York", "."],
+        "spans": {
+            "cities": [(7, 15, "LOC", "")],
+            "people": [(0, 1, "PERSON", "")],
+        },
+    }
     vocab = Vocab()
     predicted = Doc(vocab, words=annots["words"])
     example = Example.from_dict(predicted, annots)
-    assert len(list(example.reference.spans["cities"])) == 1
-    assert len(list(example.reference.spans["people"])) == 1
+    assert len(example.reference.spans["cities"]) == 1
+    assert len(example.reference.spans["people"]) == 1
 
     output_dict = example.to_dict()
     assert "spans" in output_dict["doc_annotation"]
-    assert output_dict["doc_annotation"]["spans"]["cities"] == [(7, 15, "LOC", "")]
-    assert output_dict["doc_annotation"]["spans"]["people"] == [(0, 1, "PERSON", "")]
+    assert output_dict["doc_annotation"]["spans"]["cities"] == annots["spans"]["cities"]
+    assert output_dict["doc_annotation"]["spans"]["people"] == annots["spans"]["people"]
 
     output_example = Example.from_dict(predicted, output_dict)
 
-    assert len(list(output_example.reference.spans["cities"])) == len(
-        list(example.reference.spans["cities"])
+    assert len(output_example.reference.spans["cities"]) == len(
+        example.reference.spans["cities"]
     )
-    assert len(list(output_example.reference.spans["people"])) == len(
-        list(example.reference.spans["people"])
+    assert len(output_example.reference.spans["people"]) == len(
+        example.reference.spans["people"]
     )
     for span in example.reference.spans["cities"]:
         assert span.label_ == "LOC"
         assert span.text == "New York"
+        assert span.start_char == 7
     for span in example.reference.spans["people"]:
         assert span.label_ == "PERSON"
         assert span.text == "I"
-        assert span.start == 0
+        assert span.start_char == 0

--- a/spacy/tests/training/test_new_example.py
+++ b/spacy/tests/training/test_new_example.py
@@ -445,7 +445,6 @@ def test_Example_aligned_whitespace(en_vocab):
         }
     ],
 )
-
 @pytest.mark.issue("11260")
 def test_issue11260(annots):
     vocab = Vocab()
@@ -456,9 +455,21 @@ def test_issue11260(annots):
 
     output_dict = example.to_dict()
     assert "spans" in output_dict["doc_annotation"]
-    assert len(output_dict["doc_annotation"]["spans"]["cities"]) == 1
-    assert len(output_dict["doc_annotation"]["spans"]["people"]) == 1
-    assert output_dict["doc_annotation"]["spans"]["people"][0].text == "I"
-    assert output_dict["doc_annotation"]["spans"]["cities"][0].text == "New York"
+    assert output_dict["doc_annotation"]["spans"]["cities"] == [(7, 15, "LOC")]
+    assert output_dict["doc_annotation"]["spans"]["people"] == [(0, 1, "PERSON")]
 
+    output_example = Example.from_dict(predicted, output_dict)
 
+    assert len(list(output_example.reference.spans["cities"])) == len(
+        list(example.reference.spans["cities"])
+    )
+    assert len(list(output_example.reference.spans["people"])) == len(
+        list(example.reference.spans["people"])
+    )
+    for span in example.reference.spans["cities"]:
+        assert span.label_ == "LOC"
+        assert span.text == "New York"
+    for span in example.reference.spans["people"]:
+        assert span.label_ == "PERSON"
+        assert span.text == "I"
+        assert span.start == 0

--- a/spacy/training/example.pyx
+++ b/spacy/training/example.pyx
@@ -361,7 +361,7 @@ cdef class Example:
             "doc_annotation": {
                 "cats": dict(self.reference.cats),
                 "entities": doc_to_biluo_tags(self.reference),
-                "spans": dict(self.reference.spans),
+                "spans": self._spans_to_dict(),
                 "links": self._links_to_dict()
             },
             "token_annotation": {
@@ -376,6 +376,18 @@ cdef class Example:
                 "SENT_START": [int(bool(t.is_sent_start)) for t in self.reference]
             }
         }
+
+    def _spans_to_dict(self):
+        span_dict = {}
+        for key in self.reference.spans:
+            span_tuples = []
+            for span in self.reference.spans[key]: 
+                span_tuple = (span.start_char, span.end_char, span.label, span.kb_id)
+                span_tuples.append(span_tuple)
+            span_dict[key] = span_tuples
+
+        return span_dict
+
 
     def _links_to_dict(self):
         links = {}

--- a/spacy/training/example.pyx
+++ b/spacy/training/example.pyx
@@ -361,6 +361,7 @@ cdef class Example:
             "doc_annotation": {
                 "cats": dict(self.reference.cats),
                 "entities": doc_to_biluo_tags(self.reference),
+                "spans": dict(self.reference.spans),
                 "links": self._links_to_dict()
             },
             "token_annotation": {

--- a/spacy/training/example.pyx
+++ b/spacy/training/example.pyx
@@ -382,7 +382,7 @@ cdef class Example:
         for key in self.reference.spans:
             span_tuples = []
             for span in self.reference.spans[key]: 
-                span_tuple = (span.start_char, span.end_char, span.label, span.kb_id)
+                span_tuple = (span.start_char, span.end_char, span.label_, span.kb_id_)
                 span_tuples.append(span_tuple)
             span_dict[key] = span_tuples
 

--- a/website/docs/api/data-formats.md
+++ b/website/docs/api/data-formats.md
@@ -395,12 +395,13 @@ file to keep track of your settings and hyperparameters and your own
 >    "pos": List[str],
 >    "morphs": List[str],
 >    "sent_starts": List[Optional[bool]],
->    "deps": List[string],
+>    "deps": List[str],
 >    "heads": List[int],
 >    "entities": List[str],
 >    "entities": List[(int, int, str)],
 >    "cats": Dict[str, float],
 >    "links": Dict[(int, int), dict],
+>    "spans": Dict[str, List[Tuple]],
 > }
 > ```
 
@@ -417,9 +418,10 @@ file to keep track of your settings and hyperparameters and your own
 | `deps`        | List of string values indicating the [dependency relation](/usage/linguistic-features#dependency-parse) of a token to its head. ~~List[str]~~                                                                                  |
 | `heads`       | List of integer values indicating the dependency head of each token, referring to the absolute index of each token in the text. ~~List[int]~~                                                                                  |
 | `entities`    | **Option 1:** List of [BILUO tags](/usage/linguistic-features#accessing-ner) per token of the format `"{action}-{label}"`, or `None` for unannotated tokens. ~~List[str]~~                                                     |
-| `entities`    | **Option 2:** List of `"(start, end, label)"` tuples defining all entities in the text. ~~List[Tuple[int, int, str]]~~                                                                                                         |
+| `entities`    | **Option 2:** List of `(start_char, end_char, label)` tuples defining all entities in the text. ~~List[Tuple[int, int, str]]~~                                                                                                 |
 | `cats`        | Dictionary of `label`/`value` pairs indicating how relevant a certain [text category](/api/textcategorizer) is for the text. ~~Dict[str, float]~~                                                                              |
 | `links`       | Dictionary of `offset`/`dict` pairs defining [named entity links](/usage/linguistic-features#entity-linking). The character offsets are linked to a dictionary of relevant knowledge base IDs. ~~Dict[Tuple[int, int], Dict]~~ |
+| `spans`       | Dictionary of `spans_key`/`List[Tuple]` pairs defining the spans for each spans key as `(start_char, end_char, label, kb_id)` tuples. ~~Dict[str, List[Tuple[int, int, str, str]]~~                                            |
 
 <Infobox title="Notes and caveats">
 


### PR DESCRIPTION
Added spans to doc_annotation in the Example.to_dict method.

## Description
I've added a test for the issue in test_new_example.py. I'm not sure, if it's the right place and if it should be tested differently.

### Types of change
Fix to #11260 

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
