### PR TITLE
Better handling of unexpected types in `SetPredicate`

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -212,6 +212,8 @@ class Warnings(metaclass=ErrorsWithCodes):
     W121 = ("Attempting to trace non-existent method '{method}' in pipe '{pipe}'")
     W122 = ("Couldn't trace method '{method}' in pipe '{pipe}'. This can happen if the pipe class "
             "is a Cython extension type.")
+    W123 = ("Attempting to apply matcher set predicate '{predicate}' "
+            "to attribute of unexpected type '{attr_type}'.")
 
 
 class Errors(metaclass=ErrorsWithCodes):

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -212,8 +212,6 @@ class Warnings(metaclass=ErrorsWithCodes):
     W121 = ("Attempting to trace non-existent method '{method}' in pipe '{pipe}'")
     W122 = ("Couldn't trace method '{method}' in pipe '{pipe}'. This can happen if the pipe class "
             "is a Cython extension type.")
-    W123 = ("Attempting to apply matcher set predicate '{predicate}' "
-            "to attribute of unexpected type '{attr_type}'.")
 
 
 class Errors(metaclass=ErrorsWithCodes):

--- a/spacy/matcher/matcher.pyx
+++ b/spacy/matcher/matcher.pyx
@@ -885,10 +885,10 @@ class _SetPredicate:
                     value = set((get_string_id(v) for v in MorphAnalysis.from_id(self.vocab, value)))
                 else:
                     unexpected_value_type = True
-            elif isinstance(value, Iterable):
-                value = set(get_string_id(v) for v in value)
             elif isinstance(value, (str, int)):
                 value = set((get_string_id(value),))
+            elif isinstance(value, Iterable) and all(isinstance(v, (str, int)) for v in value):
+                value = set(get_string_id(v) for v in value)
             else:
                 unexpected_value_type = True
 

--- a/spacy/matcher/matcher.pyx
+++ b/spacy/matcher/matcher.pyx
@@ -879,11 +879,8 @@ class _SetPredicate:
         elif self.predicate in ("IS_SUBSET", "IS_SUPERSET", "INTERSECTS"):
             # ensure that all values are enclosed in a set
             if self.attr == MORPH:
-                if isinstance(value, int):
-                    # break up MORPH into individual Feat=Val values
-                    value = set((get_string_id(v) for v in MorphAnalysis.from_id(self.vocab, value)))
-                else:
-                    return False
+                # break up MORPH into individual Feat=Val values
+                value = set(get_string_id(v) for v in MorphAnalysis.from_id(self.vocab, value))
             elif isinstance(value, (str, int)):
                 value = set((get_string_id(value),))
             elif isinstance(value, Iterable) and all(isinstance(v, (str, int)) for v in value):

--- a/spacy/matcher/matcher.pyx
+++ b/spacy/matcher/matcher.pyx
@@ -871,12 +871,11 @@ class _SetPredicate:
         else:
             value = get_token_attr_for_matcher(token.c, self.attr)
 
-        unexpected_value_type = False
         if self.predicate in ("IN", "NOT_IN"):
             if isinstance(value, (str, int)):
                 value = get_string_id(value)
             else:
-                unexpected_value_type = True
+                return False
         elif self.predicate in ("IS_SUBSET", "IS_SUPERSET", "INTERSECTS"):
             # ensure that all values are enclosed in a set
             if self.attr == MORPH:
@@ -884,17 +883,15 @@ class _SetPredicate:
                     # break up MORPH into individual Feat=Val values
                     value = set((get_string_id(v) for v in MorphAnalysis.from_id(self.vocab, value)))
                 else:
-                    unexpected_value_type = True
+                    return False
             elif isinstance(value, (str, int)):
                 value = set((get_string_id(value),))
             elif isinstance(value, Iterable) and all(isinstance(v, (str, int)) for v in value):
                 value = set(get_string_id(v) for v in value)
             else:
-                unexpected_value_type = True
+                return False
 
-        if unexpected_value_type:
-            return False
-        elif self.predicate == "IN":
+        if self.predicate == "IN":
             return value in self.value
         elif self.predicate == "NOT_IN":
             return value not in self.value

--- a/spacy/matcher/matcher.pyx
+++ b/spacy/matcher/matcher.pyx
@@ -893,7 +893,6 @@ class _SetPredicate:
                 unexpected_value_type = True
 
         if unexpected_value_type:
-            warnings.warn(Warnings.W123.format(predicate=self.predicate, attr_type=type(value)))
             return False
         elif self.predicate == "IN":
             return value in self.value

--- a/spacy/matcher/matcher.pyx
+++ b/spacy/matcher/matcher.pyx
@@ -893,7 +893,8 @@ class _SetPredicate:
                 unexpected_value_type = True
 
         if unexpected_value_type:
-            return self._emit_value_type_warning(value)
+            warnings.warn(Warnings.W123.format(predicate=self.predicate, attr_type=type(value)))
+            return False
         elif self.predicate == "IN":
             return value in self.value
         elif self.predicate == "NOT_IN":
@@ -904,10 +905,6 @@ class _SetPredicate:
             return value >= self.value
         elif self.predicate == "INTERSECTS":
             return bool(value & self.value)
-
-    def _emit_value_type_warning(self, value):
-        warnings.warn(Warnings.W123.format(predicate=self.predicate, attr_type=type(value)))
-        return False
 
     def __repr__(self):
         return repr(("SetPredicate", self.i, self.attr, self.value, self.predicate))

--- a/spacy/matcher/matcher.pyx
+++ b/spacy/matcher/matcher.pyx
@@ -871,12 +871,12 @@ class _SetPredicate:
         else:
             value = get_token_attr_for_matcher(token.c, self.attr)
 
-        value_type_mismatch = False
+        unexpected_value_type = False
         if self.predicate in ("IN", "NOT_IN"):
             if isinstance(value, (str, int)):
                 value = get_string_id(value)
             else:
-                value_type_mismatch = True
+                unexpected_value_type = True
         elif self.predicate in ("IS_SUBSET", "IS_SUPERSET", "INTERSECTS"):
             # ensure that all values are enclosed in a set
             if self.attr == MORPH:
@@ -884,15 +884,15 @@ class _SetPredicate:
                     # break up MORPH into individual Feat=Val values
                     value = set((get_string_id(v) for v in MorphAnalysis.from_id(self.vocab, value)))
                 else:
-                    value_type_mismatch = True
+                    unexpected_value_type = True
             elif isinstance(value, Iterable):
                 value = set(get_string_id(v) for v in value)
             elif isinstance(value, (str, int)):
                 value = set((get_string_id(value),))
             else:
-                value_type_mismatch = True
+                unexpected_value_type = True
 
-        if value_type_mismatch:
+        if unexpected_value_type:
             return self._emit_value_type_warning(value)
         elif self.predicate == "IN":
             return value in self.value

--- a/spacy/tests/matcher/test_matcher_api.py
+++ b/spacy/tests/matcher/test_matcher_api.py
@@ -492,10 +492,10 @@ def test_matcher_extension_in_set_predicate(en_vocab):
     pattern = [{"_": {"ext": {"IN": ["A", "C"]}}}]
     matcher.add("M", [pattern])
     doc = Doc(en_vocab, words=["a", "b", "c"])
-    doc[0]._.ext = ["A", "B"]
 
     # The IN predicate expects an exact match between the
-    # extension value and one of the patterns.
+    # extension value and one of the pattern's.
+    doc[0]._.ext = ["A", "B"]
     assert len(matcher(doc)) == 0
 
     doc[0]._.ext = ["A"]

--- a/spacy/tests/matcher/test_matcher_api.py
+++ b/spacy/tests/matcher/test_matcher_api.py
@@ -368,7 +368,7 @@ def test_matcher_intersect_value_operator(en_vocab):
     doc[0]._.ext = ["A", "B"]
     assert len(matcher(doc)) == 1
 
-    # INTERSECTS returns False if the value isn't a str or int
+    # INTERSECTS matches nothing for iterables that aren't all str or int
     matcher = Matcher(en_vocab)
     pattern = [{"_": {"ext": {"INTERSECTS": ["Abx", "C"]}}}]
     matcher.add("M", [pattern])
@@ -495,7 +495,7 @@ def test_matcher_extension_in_set_predicate(en_vocab):
     doc[0]._.ext = ["A", "B"]
 
     # The IN predicate expects an exact match between the
-    # extension value and one of the pattern's.
+    # extension value and one of the patterns.
     assert len(matcher(doc)) == 0
 
     doc[0]._.ext = ["A"]

--- a/spacy/tests/matcher/test_matcher_api.py
+++ b/spacy/tests/matcher/test_matcher_api.py
@@ -476,7 +476,6 @@ def test_matcher_extension_set_membership(en_vocab):
     assert len(matches) == 0
 
 
-@pytest.mark.xfail(reason="IN predicate must handle sequence values in extensions")
 def test_matcher_extension_in_set_predicate(en_vocab):
     matcher = Matcher(en_vocab)
     Token.set_extension("ext", default=[])
@@ -484,7 +483,10 @@ def test_matcher_extension_in_set_predicate(en_vocab):
     matcher.add("M", [pattern])
     doc = Doc(en_vocab, words=["a", "b", "c"])
     doc[0]._.ext = ["A", "B"]
-    assert len(matcher(doc)) == 1
+
+    # The IN predicate expects an exact match between the
+    # extension value and one of the pattern's.
+    assert len(matcher(doc)) == 0
 
 
 def test_matcher_basic_check(en_vocab):

--- a/spacy/tests/matcher/test_matcher_api.py
+++ b/spacy/tests/matcher/test_matcher_api.py
@@ -370,11 +370,13 @@ def test_matcher_intersect_value_operator(en_vocab):
 
     # INTERSECTS returns False if the value isn't a str or int
     matcher = Matcher(en_vocab)
-    pattern = [{"_": {"ext": {"INTERSECTS": ["A", "C"]}}}]
+    pattern = [{"_": {"ext": {"INTERSECTS": ["Abx", "C"]}}}]
     matcher.add("M", [pattern])
     doc = Doc(en_vocab, words=["a", "b", "c"])
-    doc[0]._.ext = [["A"], "B"]
+    doc[0]._.ext = [["Abx"], "B"]
     assert len(matcher(doc)) == 0
+    doc[0]._.ext = ["Abx", "B"]
+    assert len(matcher(doc)) == 1
 
     # INTERSECTS with an empty pattern list matches nothing
     matcher = Matcher(en_vocab)

--- a/spacy/tests/matcher/test_matcher_api.py
+++ b/spacy/tests/matcher/test_matcher_api.py
@@ -494,7 +494,7 @@ def test_matcher_extension_in_set_predicate(en_vocab):
     doc = Doc(en_vocab, words=["a", "b", "c"])
 
     # The IN predicate expects an exact match between the
-    # extension value and one of the pattern's.
+    # extension value and one of the pattern's values.
     doc[0]._.ext = ["A", "B"]
     assert len(matcher(doc)) == 0
 

--- a/spacy/tests/matcher/test_matcher_api.py
+++ b/spacy/tests/matcher/test_matcher_api.py
@@ -368,6 +368,14 @@ def test_matcher_intersect_value_operator(en_vocab):
     doc[0]._.ext = ["A", "B"]
     assert len(matcher(doc)) == 1
 
+    # INTERSECTS returns False if the value isn't a str or int
+    matcher = Matcher(en_vocab)
+    pattern = [{"_": {"ext": {"INTERSECTS": ["A", "C"]}}}]
+    matcher.add("M", [pattern])
+    doc = Doc(en_vocab, words=["a", "b", "c"])
+    doc[0]._.ext = [["A"], "B"]
+    assert len(matcher(doc)) == 0
+
     # INTERSECTS with an empty pattern list matches nothing
     matcher = Matcher(en_vocab)
     pattern = [{"_": {"ext": {"INTERSECTS": []}}}]
@@ -487,6 +495,12 @@ def test_matcher_extension_in_set_predicate(en_vocab):
     # The IN predicate expects an exact match between the
     # extension value and one of the pattern's.
     assert len(matcher(doc)) == 0
+
+    doc[0]._.ext = ["A"]
+    assert len(matcher(doc)) == 0
+
+    doc[0]._.ext = "A"
+    assert len(matcher(doc)) == 1
 
 
 def test_matcher_basic_check(en_vocab):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
The `IN` and `NOT_IN` set predicates in `Matcher` would raise an unhandled exception when matching against attribute values that are non-hashable (like `list`s). This is now resolved by performing some defensive type checking of the attribute values prior to calling the Python `in` operator.

Going forward, if _any_ set predicate encounters a value of an unexpected type, it will fail early, i.e., return `False`, instead of crashing.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Bug fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
