### PR TITLE
Fix menu order in linguistic-features.md

### DIFF
--- a/website/docs/usage/linguistic-features.md
+++ b/website/docs/usage/linguistic-features.md
@@ -11,8 +11,8 @@ menu:
   - ['Tokenization', 'tokenization']
   - ['Merging & Splitting', 'retokenization']
   - ['Sentence Segmentation', 'sbd']
-  - ['Vectors & Similarity', 'vectors-similarity']
   - ['Mappings & Exceptions', 'mappings-exceptions']
+  - ['Vectors & Similarity', 'vectors-similarity']
   - ['Language Data', 'language-data']
 ---
 


### PR DESCRIPTION
## Description
Swap 'Vectors & Similarity' and 'Mappings & Exceptions' in menu to match order in body. The original order leads to incorrect highlighting in the menu when scrolling.

### Types of change
Documentation

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
