### PR TITLE
Fix lookup usage in French/Catalan (fix #11347)

### DIFF
--- a/spacy/lang/ca/lemmatizer.py
+++ b/spacy/lang/ca/lemmatizer.py
@@ -73,9 +73,9 @@ class CatalanLemmatizer(Lemmatizer):
         if not forms:
             forms.extend(oov_forms)
 
-        # use lookups, which fall back to the token itself
+        # use lookups, and fall back to the token itself
         if not forms:
-            forms.append(self.lookup_lemmatize(token)[0])
+            forms.append(lookup_table.get(token, [token])[0])
         forms = list(dict.fromkeys(forms))
         self.cache[cache_key] = forms
         return forms

--- a/spacy/lang/ca/lemmatizer.py
+++ b/spacy/lang/ca/lemmatizer.py
@@ -72,10 +72,10 @@ class CatalanLemmatizer(Lemmatizer):
                         oov_forms.append(form)
         if not forms:
             forms.extend(oov_forms)
-        if not forms and string in lookup_table.keys():
-            forms.append(self.lookup_lemmatize(token)[0])
+
+        # use lookups, which fall back to the token itself
         if not forms:
-            forms.append(string)
+            forms.append(self.lookup_lemmatize(token)[0])
         forms = list(dict.fromkeys(forms))
         self.cache[cache_key] = forms
         return forms

--- a/spacy/lang/ca/lemmatizer.py
+++ b/spacy/lang/ca/lemmatizer.py
@@ -75,7 +75,7 @@ class CatalanLemmatizer(Lemmatizer):
 
         # use lookups, and fall back to the token itself
         if not forms:
-            forms.append(lookup_table.get(token, [token])[0])
+            forms.append(lookup_table.get(string, [string])[0])
         forms = list(dict.fromkeys(forms))
         self.cache[cache_key] = forms
         return forms

--- a/spacy/lang/fr/lemmatizer.py
+++ b/spacy/lang/fr/lemmatizer.py
@@ -81,7 +81,7 @@ class FrenchLemmatizer(Lemmatizer):
 
         # use lookups, which fall back to the token itself
         if not forms:
-            forms.append(self.lookup_lemmatize(token)[0])
+            forms.append(lookup_table.get(token, [token])[0])
         forms = list(dict.fromkeys(forms))
         self.cache[cache_key] = forms
         return forms

--- a/spacy/lang/fr/lemmatizer.py
+++ b/spacy/lang/fr/lemmatizer.py
@@ -53,11 +53,16 @@ class FrenchLemmatizer(Lemmatizer):
         rules = rules_table.get(univ_pos, [])
         string = string.lower()
         forms = []
+        # first try lookup in table based on upos
         if string in index:
             forms.append(string)
             self.cache[cache_key] = forms
             return forms
+
+        # then add anything in the exceptions table
         forms.extend(exceptions.get(string, []))
+
+        # if nothing found yet, use the rules
         oov_forms = []
         if not forms:
             for old, new in rules:
@@ -69,12 +74,14 @@ class FrenchLemmatizer(Lemmatizer):
                         forms.append(form)
                     else:
                         oov_forms.append(form)
+
+        # if still nothing, add the oov forms from rules
         if not forms:
             forms.extend(oov_forms)
-        if not forms and string in lookup_table.keys():
-            forms.append(self.lookup_lemmatize(token)[0])
+
+        # use lookups, which fall back to the token itself
         if not forms:
-            forms.append(string)
+            forms.append(self.lookup_lemmatize(token)[0])
         forms = list(dict.fromkeys(forms))
         self.cache[cache_key] = forms
         return forms

--- a/spacy/lang/fr/lemmatizer.py
+++ b/spacy/lang/fr/lemmatizer.py
@@ -81,7 +81,7 @@ class FrenchLemmatizer(Lemmatizer):
 
         # use lookups, which fall back to the token itself
         if not forms:
-            forms.append(lookup_table.get(token, [token])[0])
+            forms.append(lookup_table.get(string, [string])[0])
         forms = list(dict.fromkeys(forms))
         self.cache[cache_key] = forms
         return forms


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Before using the lookups table in the French (and Catalan) lemmatizers, there's a check to see if the current term is in the table. But it's checking a string against hashes, so it's always false. Also the lookup table is designed so that you don't have to check if something is already present in advance.

The lookup lemmatizer always falls back to the input string, so I've also modified these lemmatizers to not have their own separate fallback. However I'm not sure if that's something we should rely on or an implementation detail. 

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
