### PR TITLE
Remove setup_requires from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,14 +31,6 @@ project_urls =
 zip_safe = false
 include_package_data = true
 python_requires = >=3.6
-setup_requires =
-    cython>=0.25,<3.0
-    numpy>=1.15.0
-    # We also need our Cython packages here to compile against
-    cymem>=2.0.2,<2.1.0
-    preshed>=3.0.2,<3.1.0
-    murmurhash>=0.28.0,<1.1.0
-    thinc>=8.1.0,<8.2.0
 install_requires =
     # Our libraries
     spacy-legacy>=3.0.9,<3.1.0

--- a/spacy/tests/package/test_requirements.py
+++ b/spacy/tests/package/test_requirements.py
@@ -4,8 +4,8 @@ from pathlib import Path
 
 def test_build_dependencies():
     # Check that library requirements are pinned exactly the same across different setup files.
-    # TODO: correct checks for numpy rather than ignoring
     libs_ignore_requirements = [
+        "cython",
         "pytest",
         "pytest-timeout",
         "mock",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Remove `setup_requires` from `setup.cfg`.

`setup_requires` worked in the original `setup.py`-only version but I have never found a version of `setuptools` where it was supported in `setup.cfg`. But since it was possible that there was some old version of `setuptools` that did indeed support this, I kept it around for v3. However I really do not think it is needed at this point, and this reduces the duplication of build requirements specifications. Now they should only go in `pyproject.toml` and `build-constraints.txt`. Install requirements remain in `install_requires` and `requirements.txt` as before.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Chore.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
