### PR TITLE
Fix `test_{prefer,require}_gpu`

### DIFF
--- a/spacy/tests/test_misc.py
+++ b/spacy/tests/test_misc.py
@@ -11,6 +11,7 @@ from spacy.util import dot_to_object, SimpleFrozenList, import_file
 from spacy.util import to_ternary_int
 from thinc.api import Config, Optimizer, ConfigValidationError
 from thinc.api import set_current_ops
+from thinc.compat import has_cupy_gpu, has_torch_mps_gpu
 from spacy.training.batchers import minibatch_by_words
 from spacy.lang.en import English
 from spacy.lang.nl import Dutch
@@ -18,7 +19,7 @@ from spacy.language import DEFAULT_CONFIG_PATH
 from spacy.schemas import ConfigSchemaTraining, TokenPattern, TokenPatternSchema
 from pydantic import ValidationError
 
-from thinc.api import get_current_ops, NumpyOps, CupyOps
+from thinc.api import get_current_ops, NumpyOps, CupyOps, MPSOps
 
 from .util import get_random_doc, make_tempdir
 
@@ -111,26 +112,25 @@ def test_PrecomputableAffine(nO=4, nI=5, nF=3, nP=2):
 
 def test_prefer_gpu():
     current_ops = get_current_ops()
-    try:
-        import cupy  # noqa: F401
-
-        prefer_gpu()
+    if has_cupy_gpu:
+        assert prefer_gpu()
         assert isinstance(get_current_ops(), CupyOps)
-    except ImportError:
+    elif has_torch_mps_gpu:
+        assert prefer_gpu()
+        assert isinstance(get_current_ops(), MPSOps)
+    else:
         assert not prefer_gpu()
     set_current_ops(current_ops)
 
 
 def test_require_gpu():
     current_ops = get_current_ops()
-    try:
-        import cupy  # noqa: F401
-
+    if has_cupy_gpu:
         require_gpu()
         assert isinstance(get_current_ops(), CupyOps)
-    except ImportError:
-        with pytest.raises(ValueError):
-            require_gpu()
+    elif has_torch_mps_gpu:
+        require_gpu()
+        assert isinstance(get_current_ops(), MPSOps)
     set_current_ops(current_ops)
 
 

--- a/spacy/tests/test_misc.py
+++ b/spacy/tests/test_misc.py
@@ -10,7 +10,7 @@ from spacy.ml._precomputable_affine import _backprop_precomputable_affine_paddin
 from spacy.util import dot_to_object, SimpleFrozenList, import_file
 from spacy.util import to_ternary_int
 from thinc.api import Config, Optimizer, ConfigValidationError
-from thinc.api import set_current_ops
+from thinc.api import get_current_ops, set_current_ops, NumpyOps, CupyOps, MPSOps
 from thinc.compat import has_cupy_gpu, has_torch_mps_gpu
 from spacy.training.batchers import minibatch_by_words
 from spacy.lang.en import English
@@ -19,7 +19,6 @@ from spacy.language import DEFAULT_CONFIG_PATH
 from spacy.schemas import ConfigSchemaTraining, TokenPattern, TokenPatternSchema
 from pydantic import ValidationError
 
-from thinc.api import get_current_ops, NumpyOps, CupyOps, MPSOps
 
 from .util import get_random_doc, make_tempdir
 


### PR DESCRIPTION
## Description

These tests assumed that GPUs are only supported with CuPy, but since Thinc 8.1 we also support Metal Performance Shaders.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bug fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
