### PR TITLE
more explicit Example constructor example

### DIFF
--- a/website/docs/api/example.md
+++ b/website/docs/api/example.md
@@ -23,11 +23,11 @@ both documents.
 > ```python
 > from spacy.tokens import Doc
 > from spacy.training import Example
->
-> words = ["hello", "world", "!"]
-> spaces = [True, False, False]
-> predicted = Doc(nlp.vocab, words=words, spaces=spaces)
-> reference = parse_gold_doc(my_data)
+> pred_words = ["Apply", "some", "sunscreen", "unless", "you", "can", "not"]
+> gold_words = ["Apply", "some", "sun", "screen", "unless", "you", "cannot"]
+> gold_tags = ["VERB", "DET", "NOUN", "NOUN", "SCONJ", "PRON", "VERB"]
+> predicted = Doc(nlp.vocab, words=pred_words)
+> reference = Doc(nlp.vocab, words=gold_words, tags=gold_tags)
 > example = Example(predicted, reference)
 > ```
 

--- a/website/docs/api/example.md
+++ b/website/docs/api/example.md
@@ -23,11 +23,13 @@ both documents.
 > ```python
 > from spacy.tokens import Doc
 > from spacy.training import Example
-> pred_words = ["Apply", "some", "sunscreen", "unless", "you", "can", "not"]
-> gold_words = ["Apply", "some", "sun", "screen", "unless", "you", "cannot"]
-> gold_tags = ["VERB", "DET", "NOUN", "NOUN", "SCONJ", "PRON", "VERB"]
-> predicted = Doc(nlp.vocab, words=pred_words)
-> reference = Doc(nlp.vocab, words=gold_words, tags=gold_tags)
+> pred_words = ["Apply", "some", "sunscreen"]
+> pred_spaces = [True, True, False]
+> gold_words = ["Apply", "some", "sun", "screen"]
+> gold_spaces = [True, True, False, False]
+> gold_tags = ["VERB", "DET", "NOUN", "NOUN"]
+> predicted = Doc(nlp.vocab, words=pred_words, spaces=pred_spaces)
+> reference = Doc(nlp.vocab, words=gold_words, spaces=gold_spaces, tags=gold_tags)
 > example = Example(predicted, reference)
 > ```
 


### PR DESCRIPTION

## Description
The API docs for `Example` refer to a dummy function `parse_gold_doc` that implies "parse whatever data to create your `Doc` object", but this seems to create some confusion among users. Instead, proposing to make this example code much more explicit by calling the `Doc` constructor for both `predicted` and `reference`.

### Types of change
doc fix

## Checklist
- [X] I confirm that I have the right to submit this contribution under the project's MIT license.
- [X] I ran the tests, and all new and existing tests passed.
- [X] My changes don't require a change to the documentation, or if they do, I've added all required information.
