### PR TITLE
Disable mypy for Python 3.10 (v4)

### DIFF
--- a/.github/azure-steps.yml
+++ b/.github/azure-steps.yml
@@ -27,6 +27,7 @@ steps:
 
   - script: python -m mypy spacy
     displayName: 'Run mypy'
+    condition: ne(variables['python_version'], '3.10')
 
   - task: DeleteFiles@1
     inputs:


### PR DESCRIPTION

## Description
Until `mypy` 0.980 is released with [this fix](https://github.com/python/mypy/issues/13627), we're disabling the mypy tests on the CI for Python 3.10.

### Types of change
hot fix to CI infrastructure

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
