### PR TITLE
fix: remove duplicate "New in v3.2" in sidebar

### DIFF
--- a/website/meta/sidebars.json
+++ b/website/meta/sidebars.json
@@ -12,7 +12,6 @@
                     { "text": "New in v3.0", "url": "/usage/v3" },
                     { "text": "New in v3.1", "url": "/usage/v3-1" },
                     { "text": "New in v3.2", "url": "/usage/v3-2" },
-                    { "text": "New in v3.2", "url": "/usage/v3-2" },
                     { "text": "New in v3.3", "url": "/usage/v3-3" },
                     { "text": "New in v3.4", "url": "/usage/v3-4" }
                 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

The spaCy website displays a duplicate "New in v3.2" link in the sidebar

### Types of change

Fix the docs.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
