### PR TITLE
refactoring of pymorphy2 wrapper and handling of repeated normal forms with tests

### DIFF
--- a/spacy/lang/ru/lemmatizer.py
+++ b/spacy/lang/ru/lemmatizer.py
@@ -22,5 +22,5 @@ class RussianLemmatizer(PyMorhpy2Lemmatizer):
         scorer: Optional[Callable] = lemmatizer_score,
     ) -> None:
         super().__init__(
-            vocab, model, lang="ru", name=name, mode=mode, overwrite=overwrite, scorer=scorer,
+            vocab, model, "ru", name=name, mode=mode, overwrite=overwrite, scorer=scorer,
         )

--- a/spacy/lang/ru/lemmatizer.py
+++ b/spacy/lang/ru/lemmatizer.py
@@ -2,8 +2,7 @@ from typing import Optional, List, Dict, Tuple, Callable
 
 from thinc.api import Model
 
-from ...pipeline import Lemmatizer
-from ...pipeline.lemmatizer import lemmatizer_score
+from ...pipeline.lemmatizer import lemmatizer_score, PyMorhpy2Lemmatizer
 from ...symbols import POS
 from ...tokens import Token
 from ...vocab import Vocab
@@ -11,8 +10,7 @@ from ...vocab import Vocab
 
 PUNCT_RULES = {"«": '"', "»": '"'}
 
-
-class RussianLemmatizer(Lemmatizer):
+class RussianLemmatizer(PyMorhpy2Lemmatizer):
     def __init__(
         self,
         vocab: Vocab,
@@ -23,164 +21,6 @@ class RussianLemmatizer(Lemmatizer):
         overwrite: bool = False,
         scorer: Optional[Callable] = lemmatizer_score,
     ) -> None:
-        if mode == "pymorphy2":
-            try:
-                from pymorphy2 import MorphAnalyzer
-            except ImportError:
-                raise ImportError(
-                    "The Russian lemmatizer mode 'pymorphy2' requires the "
-                    "pymorphy2 library. Install it with: pip install pymorphy2"
-                ) from None
-            if getattr(self, "_morph", None) is None:
-                self._morph = MorphAnalyzer()
         super().__init__(
-            vocab, model, name, mode=mode, overwrite=overwrite, scorer=scorer
+            vocab, model, lang="ru", name=name, mode=mode, overwrite=overwrite, scorer=scorer,
         )
-
-    def pymorphy2_lemmatize(self, token: Token) -> List[str]:
-        string = token.text
-        univ_pos = token.pos_
-        morphology = token.morph.to_dict()
-        if univ_pos == "PUNCT":
-            return [PUNCT_RULES.get(string, string)]
-        if univ_pos not in ("ADJ", "DET", "NOUN", "NUM", "PRON", "PROPN", "VERB"):
-            # Skip unchangeable pos
-            return [string.lower()]
-        analyses = self._morph.parse(string)
-        filtered_analyses = []
-        for analysis in analyses:
-            if not analysis.is_known:
-                # Skip suggested parse variant for unknown word for pymorphy
-                continue
-            analysis_pos, _ = oc2ud(str(analysis.tag))
-            if analysis_pos == univ_pos or (
-                analysis_pos in ("NOUN", "PROPN") and univ_pos in ("NOUN", "PROPN")
-            ):
-                filtered_analyses.append(analysis)
-        if not len(filtered_analyses):
-            return [string.lower()]
-        if morphology is None or (len(morphology) == 1 and POS in morphology):
-            return list(
-                dict.fromkeys([analysis.normal_form for analysis in filtered_analyses])
-            )
-        if univ_pos in ("ADJ", "DET", "NOUN", "PROPN"):
-            features_to_compare = ["Case", "Number", "Gender"]
-        elif univ_pos == "NUM":
-            features_to_compare = ["Case", "Gender"]
-        elif univ_pos == "PRON":
-            features_to_compare = ["Case", "Number", "Gender", "Person"]
-        else:  # VERB
-            features_to_compare = [
-                "Aspect",
-                "Gender",
-                "Mood",
-                "Number",
-                "Tense",
-                "VerbForm",
-                "Voice",
-            ]
-        analyses, filtered_analyses = filtered_analyses, []
-        for analysis in analyses:
-            _, analysis_morph = oc2ud(str(analysis.tag))
-            for feature in features_to_compare:
-                if (
-                    feature in morphology
-                    and feature in analysis_morph
-                    and morphology[feature].lower() != analysis_morph[feature].lower()
-                ):
-                    break
-            else:
-                filtered_analyses.append(analysis)
-        if not len(filtered_analyses):
-            return [string.lower()]
-        return list(
-            dict.fromkeys([analysis.normal_form for analysis in filtered_analyses])
-        )
-
-    def pymorphy2_lookup_lemmatize(self, token: Token) -> List[str]:
-        string = token.text
-        analyses = self._morph.parse(string)
-        if len(analyses) == 1:
-            return [analyses[0].normal_form]
-        return [string]
-
-
-def oc2ud(oc_tag: str) -> Tuple[str, Dict[str, str]]:
-    gram_map = {
-        "_POS": {
-            "ADJF": "ADJ",
-            "ADJS": "ADJ",
-            "ADVB": "ADV",
-            "Apro": "DET",
-            "COMP": "ADJ",  # Can also be an ADV - unchangeable
-            "CONJ": "CCONJ",  # Can also be a SCONJ - both unchangeable ones
-            "GRND": "VERB",
-            "INFN": "VERB",
-            "INTJ": "INTJ",
-            "NOUN": "NOUN",
-            "NPRO": "PRON",
-            "NUMR": "NUM",
-            "NUMB": "NUM",
-            "PNCT": "PUNCT",
-            "PRCL": "PART",
-            "PREP": "ADP",
-            "PRTF": "VERB",
-            "PRTS": "VERB",
-            "VERB": "VERB",
-        },
-        "Animacy": {"anim": "Anim", "inan": "Inan"},
-        "Aspect": {"impf": "Imp", "perf": "Perf"},
-        "Case": {
-            "ablt": "Ins",
-            "accs": "Acc",
-            "datv": "Dat",
-            "gen1": "Gen",
-            "gen2": "Gen",
-            "gent": "Gen",
-            "loc2": "Loc",
-            "loct": "Loc",
-            "nomn": "Nom",
-            "voct": "Voc",
-        },
-        "Degree": {"COMP": "Cmp", "Supr": "Sup"},
-        "Gender": {"femn": "Fem", "masc": "Masc", "neut": "Neut"},
-        "Mood": {"impr": "Imp", "indc": "Ind"},
-        "Number": {"plur": "Plur", "sing": "Sing"},
-        "NumForm": {"NUMB": "Digit"},
-        "Person": {"1per": "1", "2per": "2", "3per": "3", "excl": "2", "incl": "1"},
-        "Tense": {"futr": "Fut", "past": "Past", "pres": "Pres"},
-        "Variant": {"ADJS": "Brev", "PRTS": "Brev"},
-        "VerbForm": {
-            "GRND": "Conv",
-            "INFN": "Inf",
-            "PRTF": "Part",
-            "PRTS": "Part",
-            "VERB": "Fin",
-        },
-        "Voice": {"actv": "Act", "pssv": "Pass"},
-        "Abbr": {"Abbr": "Yes"},
-    }
-    pos = "X"
-    morphology = dict()
-    unmatched = set()
-    grams = oc_tag.replace(" ", ",").split(",")
-    for gram in grams:
-        match = False
-        for categ, gmap in sorted(gram_map.items()):
-            if gram in gmap:
-                match = True
-                if categ == "_POS":
-                    pos = gmap[gram]
-                else:
-                    morphology[categ] = gmap[gram]
-        if not match:
-            unmatched.add(gram)
-    while len(unmatched) > 0:
-        gram = unmatched.pop()
-        if gram in ("Name", "Patr", "Surn", "Geox", "Orgn"):
-            pos = "PROPN"
-        elif gram == "Auxt":
-            pos = "AUX"
-        elif gram == "Pltm":
-            morphology["Number"] = "Ptan"
-    return pos, morphology

--- a/spacy/lang/uk/lemmatizer.py
+++ b/spacy/lang/uk/lemmatizer.py
@@ -18,5 +18,5 @@ class UkrainianLemmatizer(PyMorhpy2Lemmatizer):
         scorer: Optional[Callable] = lemmatizer_score,
     ) -> None:
         super().__init__(
-            vocab, model, lang="uk", name=name, mode=mode, overwrite=overwrite, scorer=scorer, 
+            vocab, model, "uk", name=name, mode=mode, overwrite=overwrite, scorer=scorer, 
         )

--- a/spacy/lang/uk/lemmatizer.py
+++ b/spacy/lang/uk/lemmatizer.py
@@ -2,12 +2,11 @@ from typing import Optional, Callable
 
 from thinc.api import Model
 
-from ..ru.lemmatizer import RussianLemmatizer
-from ...pipeline.lemmatizer import lemmatizer_score
+from ...pipeline.lemmatizer import lemmatizer_score, PyMorhpy2Lemmatizer
 from ...vocab import Vocab
 
 
-class UkrainianLemmatizer(RussianLemmatizer):
+class UkrainianLemmatizer(PyMorhpy2Lemmatizer):
     def __init__(
         self,
         vocab: Vocab,
@@ -18,17 +17,6 @@ class UkrainianLemmatizer(RussianLemmatizer):
         overwrite: bool = False,
         scorer: Optional[Callable] = lemmatizer_score,
     ) -> None:
-        if mode == "pymorphy2":
-            try:
-                from pymorphy2 import MorphAnalyzer
-            except ImportError:
-                raise ImportError(
-                    "The Ukrainian lemmatizer mode 'pymorphy2' requires the "
-                    "pymorphy2 library and dictionaries. Install them with: "
-                    "pip install pymorphy2 pymorphy2-dicts-uk"
-                ) from None
-            if getattr(self, "_morph", None) is None:
-                self._morph = MorphAnalyzer(lang="uk")
         super().__init__(
-            vocab, model, name, mode=mode, overwrite=overwrite, scorer=scorer
+            vocab, model, lang="uk", name=name, mode=mode, overwrite=overwrite, scorer=scorer, 
         )

--- a/spacy/pipeline/lemmatizer.py
+++ b/spacy/pipeline/lemmatizer.py
@@ -377,6 +377,7 @@ class PyMorhpy2Lemmatizer(Lemmatizer):
             return [PUNCT_RULES.get(string, string)]
         if univ_pos not in ("ADJ", "DET", "NOUN", "NUM", "PRON", "PROPN", "VERB"):
             # Skip unchangeable pos
+            return self.pymorphy2_lookup_lemmatize(token)
             return [string.lower()]
         analyses = self._morph.parse(string)
         filtered_analyses = []
@@ -432,8 +433,11 @@ class PyMorhpy2Lemmatizer(Lemmatizer):
     def pymorphy2_lookup_lemmatize(self, token: Token) -> List[str]:
         string = token.text
         analyses = self._morph.parse(string)
-        if len(analyses) == 1:
-            return [analyses[0].normal_form]
+        # often multiple forms would derive from the same normal form
+        # thus check _unique_ normal forms
+        normal_forms = set([an.normal_form for an in analyses])
+        if len(normal_forms) == 1:
+            return [next(iter(normal_forms))]
         return [string]
 
 

--- a/spacy/pipeline/lemmatizer.py
+++ b/spacy/pipeline/lemmatizer.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any, Callable, Iterable, Union, Tuple
+from typing import Optional, List, Dict, Any, Callable, Iterable, Union, Tuple, Literal
 from thinc.api import Model
 from pathlib import Path
 
@@ -14,6 +14,8 @@ from ..tokens import Doc, Token
 from ..vocab import Vocab
 from ..util import logger, SimpleFrozenList, registry
 from .. import util
+from ..symbols import POS
+
 
 
 @Language.factory(
@@ -334,3 +336,183 @@ class Lemmatizer(Pipe):
         util.from_bytes(bytes_data, deserialize, exclude)
         self._validate_tables()
         return self
+
+
+PUNCT_RULES = {"«": '"', "»": '"'}
+
+
+class PyMorhpy2Lemmatizer(Lemmatizer):
+    def __init__(
+        self,
+        vocab: Vocab,
+        model: Optional[Model],
+        lang: Literal["ru", "uk"],
+        name: str = "lemmatizer",
+        *,
+        mode: str = "pymorphy2",
+        overwrite: bool = False,
+        scorer: Optional[Callable] = lemmatizer_score,
+    ) -> None:
+        if mode not in {"pymorphy2", "pymorphy2_lookup"}:
+            raise ValueError(f"unknown mode for a pymorphy2 lemmatizer: {mode}")
+        try:
+            from pymorphy2 import MorphAnalyzer
+        except ImportError:
+            raise ImportError(
+                "The Russian lemmatizer mode 'pymorphy2' requires the "
+                "pymorphy2 library. Install it with: pip install pymorphy2"
+            ) from None
+        if getattr(self, "_morph", None) is None:
+            self._morph = MorphAnalyzer(lang=lang)
+
+        super().__init__(
+            vocab, model, name, mode=mode, overwrite=overwrite, scorer=scorer
+        )
+
+    def pymorphy2_lemmatize(self, token: Token) -> List[str]:
+        string = token.text
+        univ_pos = token.pos_
+        morphology = token.morph.to_dict()
+        if univ_pos == "PUNCT":
+            return [PUNCT_RULES.get(string, string)]
+        if univ_pos not in ("ADJ", "DET", "NOUN", "NUM", "PRON", "PROPN", "VERB"):
+            # Skip unchangeable pos
+            return [string.lower()]
+        analyses = self._morph.parse(string)
+        filtered_analyses = []
+        for analysis in analyses:
+            if not analysis.is_known:
+                # Skip suggested parse variant for unknown word for pymorphy
+                continue
+            analysis_pos, _ = oc2ud(str(analysis.tag))
+            if analysis_pos == univ_pos or (
+                analysis_pos in ("NOUN", "PROPN") and univ_pos in ("NOUN", "PROPN")
+            ):
+                filtered_analyses.append(analysis)
+        if not len(filtered_analyses):
+            return [string.lower()]
+        if morphology is None or (len(morphology) == 1 and POS in morphology):
+            return list(
+                dict.fromkeys([analysis.normal_form for analysis in filtered_analyses])
+            )
+        if univ_pos in ("ADJ", "DET", "NOUN", "PROPN"):
+            features_to_compare = ["Case", "Number", "Gender"]
+        elif univ_pos == "NUM":
+            features_to_compare = ["Case", "Gender"]
+        elif univ_pos == "PRON":
+            features_to_compare = ["Case", "Number", "Gender", "Person"]
+        else:  # VERB
+            features_to_compare = [
+                "Aspect",
+                "Gender",
+                "Mood",
+                "Number",
+                "Tense",
+                "VerbForm",
+                "Voice",
+            ]
+        analyses, filtered_analyses = filtered_analyses, []
+        for analysis in analyses:
+            _, analysis_morph = oc2ud(str(analysis.tag))
+            for feature in features_to_compare:
+                if (
+                    feature in morphology
+                    and feature in analysis_morph
+                    and morphology[feature].lower() != analysis_morph[feature].lower()
+                ):
+                    break
+            else:
+                filtered_analyses.append(analysis)
+        if not len(filtered_analyses):
+            return [string.lower()]
+        return list(
+            dict.fromkeys([analysis.normal_form for analysis in filtered_analyses])
+        )
+
+    def pymorphy2_lookup_lemmatize(self, token: Token) -> List[str]:
+        string = token.text
+        analyses = self._morph.parse(string)
+        if len(analyses) == 1:
+            return [analyses[0].normal_form]
+        return [string]
+
+
+def oc2ud(oc_tag: str) -> Tuple[str, Dict[str, str]]:
+    gram_map = {
+        "_POS": {
+            "ADJF": "ADJ",
+            "ADJS": "ADJ",
+            "ADVB": "ADV",
+            "Apro": "DET",
+            "COMP": "ADJ",  # Can also be an ADV - unchangeable
+            "CONJ": "CCONJ",  # Can also be a SCONJ - both unchangeable ones
+            "GRND": "VERB",
+            "INFN": "VERB",
+            "INTJ": "INTJ",
+            "NOUN": "NOUN",
+            "NPRO": "PRON",
+            "NUMR": "NUM",
+            "NUMB": "NUM",
+            "PNCT": "PUNCT",
+            "PRCL": "PART",
+            "PREP": "ADP",
+            "PRTF": "VERB",
+            "PRTS": "VERB",
+            "VERB": "VERB",
+        },
+        "Animacy": {"anim": "Anim", "inan": "Inan"},
+        "Aspect": {"impf": "Imp", "perf": "Perf"},
+        "Case": {
+            "ablt": "Ins",
+            "accs": "Acc",
+            "datv": "Dat",
+            "gen1": "Gen",
+            "gen2": "Gen",
+            "gent": "Gen",
+            "loc2": "Loc",
+            "loct": "Loc",
+            "nomn": "Nom",
+            "voct": "Voc",
+        },
+        "Degree": {"COMP": "Cmp", "Supr": "Sup"},
+        "Gender": {"femn": "Fem", "masc": "Masc", "neut": "Neut"},
+        "Mood": {"impr": "Imp", "indc": "Ind"},
+        "Number": {"plur": "Plur", "sing": "Sing"},
+        "NumForm": {"NUMB": "Digit"},
+        "Person": {"1per": "1", "2per": "2", "3per": "3", "excl": "2", "incl": "1"},
+        "Tense": {"futr": "Fut", "past": "Past", "pres": "Pres"},
+        "Variant": {"ADJS": "Brev", "PRTS": "Brev"},
+        "VerbForm": {
+            "GRND": "Conv",
+            "INFN": "Inf",
+            "PRTF": "Part",
+            "PRTS": "Part",
+            "VERB": "Fin",
+        },
+        "Voice": {"actv": "Act", "pssv": "Pass"},
+        "Abbr": {"Abbr": "Yes"},
+    }
+    pos = "X"
+    morphology = dict()
+    unmatched = set()
+    grams = oc_tag.replace(" ", ",").split(",")
+    for gram in grams:
+        match = False
+        for categ, gmap in sorted(gram_map.items()):
+            if gram in gmap:
+                match = True
+                if categ == "_POS":
+                    pos = gmap[gram]
+                else:
+                    morphology[categ] = gmap[gram]
+        if not match:
+            unmatched.add(gram)
+    while len(unmatched) > 0:
+        gram = unmatched.pop()
+        if gram in ("Name", "Patr", "Surn", "Geox", "Orgn"):
+            pos = "PROPN"
+        elif gram == "Auxt":
+            pos = "AUX"
+        elif gram == "Pltm":
+            morphology["Number"] = "Ptan"
+    return pos, morphology

--- a/spacy/pipeline/lemmatizer.py
+++ b/spacy/pipeline/lemmatizer.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any, Callable, Iterable, Union, Tuple, Literal
+from typing import Optional, List, Dict, Any, Callable, Iterable, Union, Tuple
 from thinc.api import Model
 from pathlib import Path
 
@@ -346,7 +346,7 @@ class PyMorhpy2Lemmatizer(Lemmatizer):
         self,
         vocab: Vocab,
         model: Optional[Model],
-        lang: Literal["ru", "uk"],
+        lang: str, 
         name: str = "lemmatizer",
         *,
         mode: str = "pymorphy2",

--- a/spacy/tests/pipeline/test_pymorphy2_lemmatizer.py
+++ b/spacy/tests/pipeline/test_pymorphy2_lemmatizer.py
@@ -1,0 +1,35 @@
+import pytest
+import pickle
+from spacy import util, registry
+from spacy.lang.uk import Ukrainian
+from spacy.lang.ru import Russian
+from spacy.lookups import Lookups
+
+from ..util import make_tempdir
+
+
+def test_lookup_lemmatizer_uk():
+    nlp = Ukrainian()
+    lemmatizer = nlp.add_pipe("lemmatizer", config={"mode": "pymorphy2_lookup"})
+    assert isinstance(lemmatizer.lookups, Lookups)
+    assert not lemmatizer.lookups.tables
+    assert lemmatizer.mode == "pymorphy2_lookup"
+    nlp.initialize()
+    assert nlp("якась")[0].lemma_ == "якийсь"
+    assert nlp("якийсь")[0].lemma_ == "якийсь"
+    assert nlp("зеленої")[0].lemma_ == 'зелений'
+    assert nlp("розповідають")[0].lemma_ == 'розповідати'
+    assert nlp("розповіси")[0].lemma_ == 'розповісти'
+    # assert nlp("телятові")[0].lemma_ == 'теля' # pymorph2 fails
+
+def test_lookup_lemmatizer_ru():
+    nlp = Russian()
+    lemmatizer = nlp.add_pipe("lemmatizer", config={"mode": "pymorphy2_lookup"})
+    assert isinstance(lemmatizer.lookups, Lookups)
+    assert not lemmatizer.lookups.tables
+    assert lemmatizer.mode == "pymorphy2_lookup"
+    nlp.initialize()
+    assert nlp("бременем")[0].lemma_ == 'бремя'
+    assert nlp("будешь")[0].lemma_ == "быть"
+    # assert nlp("какая-то")[0].lemma_ == "какой-то" # fails due to faulty word splitting
+    assert nlp("зелёной")[0].lemma_ == 'зелёный'


### PR DESCRIPTION
## Description
This addresses #11620 and #11626 by:
- refactoring pymorph2 wrapper out of Russian Lemmatizer into the common `spacy/pipeline/lemmatizer.py`. This ensures that initialization code is not replicated between Russian and Ukrainian (and any other languages pymorphy2 may support, like pre-revolution Russian spelling). 
- in the refactored modified `PyMorhpy2Lemmatizer(Lemmatizer)`, the allowed modes are `in {"pymorphy2", "pymorphy2_lookup"}` to address #11620 
- `pymorphy2_lookup` is modified to better handle unambiguous cases where a text form maps to the same normal form, e.g. `хорошим [(plural, dat), (sing, masc, instr), ...] --> хороший`, see #11626
- `pymorphy2` falls back to `pymorphy2_lookup` if POS of the token is empty, instead of returning the text form

### Types of change
bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation
