### PR TITLE
Add warning to install widget for M1 GPUs

### DIFF
--- a/website/src/styles/quickstart.module.sass
+++ b/website/src/styles/quickstart.module.sass
@@ -149,6 +149,9 @@
     & > span
         display: block
 
+    a
+        text-decoration: underline
+
 .small
     font-size: var(--font-size-code)
     line-height: 1.65

--- a/website/src/widgets/quickstart-install.js
+++ b/website/src/widgets/quickstart-install.js
@@ -201,7 +201,13 @@ const QuickstartInstall = ({ id, title }) => {
                             {nightly ? ' --pre' : ''}
                         </QS>
                         <QS package="conda">conda install -c conda-forge spacy</QS>
-                        <QS package="conda" hardware="gpu">
+                        <QS package="conda" hardware="gpu" os="windows">
+                            conda install -c conda-forge cupy
+                        </QS>
+                        <QS package="conda" hardware="gpu" os="linux">
+                            conda install -c conda-forge cupy
+                        </QS>
+                        <QS package="conda" hardware="gpu" os="mac" platform="x86">
                             conda install -c conda-forge cupy
                         </QS>
                         <QS package="conda" config="train">

--- a/website/src/widgets/quickstart-install.js
+++ b/website/src/widgets/quickstart-install.js
@@ -159,6 +159,9 @@ const QuickstartInstall = ({ id, title }) => {
                         setters={setters}
                         showDropdown={showDropdown}
                     >
+                        <QS os="mac" hardware="gpu" platform="arm">
+                            # Note M1 GPUs support is experimental, see <a href="https://github.com/explosion/spaCy/discussions/11436">#11436</a>
+                        </QS>
                         <QS package="pip" config="venv">
                             python -m venv .env
                         </QS>

--- a/website/src/widgets/quickstart-install.js
+++ b/website/src/widgets/quickstart-install.js
@@ -160,7 +160,7 @@ const QuickstartInstall = ({ id, title }) => {
                         showDropdown={showDropdown}
                     >
                         <QS os="mac" hardware="gpu" platform="arm">
-                            # Note M1 GPUs support is experimental, see <a href="https://github.com/explosion/spaCy/discussions/11436">#11436</a>
+                            # Note M1 GPUs support is experimental, see <a href="https://github.com/explosion/thinc/issues/792">this issue</a>
                         </QS>
                         <QS package="pip" config="venv">
                             python -m venv .env

--- a/website/src/widgets/quickstart-install.js
+++ b/website/src/widgets/quickstart-install.js
@@ -160,7 +160,7 @@ const QuickstartInstall = ({ id, title }) => {
                         showDropdown={showDropdown}
                     >
                         <QS os="mac" hardware="gpu" platform="arm">
-                            # Note M1 GPUs support is experimental, see <a href="https://github.com/explosion/thinc/issues/792">this issue</a>
+                            # Note M1 GPU support is experimental, see <a href="https://github.com/explosion/thinc/issues/792">this issue</a>
                         </QS>
                         <QS package="pip" config="venv">
                             python -m venv .env

--- a/website/src/widgets/quickstart-install.js
+++ b/website/src/widgets/quickstart-install.js
@@ -160,7 +160,7 @@ const QuickstartInstall = ({ id, title }) => {
                         showDropdown={showDropdown}
                     >
                         <QS os="mac" hardware="gpu" platform="arm">
-                            # Note M1 GPU support is experimental, see <a href="https://github.com/explosion/thinc/issues/792">this issue</a>
+                            # Note M1 GPU support is experimental, see <a href="https://github.com/explosion/thinc/issues/792">Thinc issue #792</a>
                         </QS>
                         <QS package="pip" config="venv">
                             python -m venv .env


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Currently support for M1 GPUs is experimental and limited, but the install widget allows you to select the M1/GPU combination as though everything will work. This adds a warning about the experimental status and links to the FAQ on the subject. This should prevent issues like #11641.

The way this displays is not ideal - for example, there's a link but it's not obvious because it's not underlined or anything. I will see if there's a way to modify the CSS to make it clearer, but any suggestions on other places to display this would also be welcome.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
