### PR TITLE
update github actions to deal with deprecations

### DIFF
--- a/.github/workflows/autoblack.yml
+++ b/.github/workflows/autoblack.yml
@@ -12,10 +12,10 @@ jobs:
     if: github.repository_owner == 'explosion'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
             ref: ${{ github.head_ref }}
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
       - run: pip install black
       - name: Auto-format code if needed
         run: black spacy
@@ -23,10 +23,11 @@ jobs:
       # code and makes GitHub think the action failed
       - name: Check for modified files
         id: git-check
-        run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
+        run: echo modified=$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi) >> $GITHUB_OUTPUT
+
       - name: Create Pull Request
         if: steps.git-check.outputs.modified == 'true'
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
             title: Auto-format code with black
             labels: meta


### PR DESCRIPTION
Our autoblack github workflow uses a couple github actions that are currently deprecated:
![image](https://user-images.githubusercontent.com/397565/197779441-8f1c1a65-2c1c-4540-876a-2d072251b261.png)

We've still got some time before this starts actually breaking, but I'm getting started on this across our infra. The changing of the `@version` for 3 of the steps should be pretty straightforward. The changing the `set-output` is based on [this blog post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). 

There isn't a way AFAIK to locally test these workflow changes so we might just have to merge and iterate a bit. If it's inconvenient to do that right now, we have ~6 months before we have to do this, I just wanted to get a start on it so we don't have to rush or forget.