### PR TITLE
Require annotation decorator

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -952,6 +952,7 @@ class Errors(metaclass=ErrorsWithCodes):
              "sure it's overwritten on the subclass.")
     E1046 = ("{cls_name} is an abstract class and cannot be instantiated. If you are looking for spaCy's default "
              "knowledge base, use `InMemoryLookupKB`.")
+    E1047 = ("The function `{name}` requires annotations {annotations} to be set, but did not find {missing}.")
 
 
 # Deprecated model shortcuts, only used in errors and warnings

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -1738,7 +1738,7 @@ def all_equal(iterable):
 
 
 def require_annotation(
-    annotations: Sequence[Union[str, int]], *, require_complete: Sequence[bool] = None
+    annotations: Sequence[Union[str, int]], *, require_complete: Sequence[bool] = []
 ) -> Callable:
     """
     To be used as a decorator for functions whose first argument
@@ -1759,7 +1759,7 @@ def require_annotation(
         partial annotation is accepted.
     """
     # Check input.
-    if require_complete is None:
+    if not require_complete:
         require_complete = [False for _ in range(len(annotations))]
     else:
         if len(require_complete) != len(annotations):
@@ -1772,7 +1772,6 @@ def require_annotation(
 
     def require_annotation_decorator(func: Callable) -> Callable:
         def func_with_require(doclike, *args, **kwargs) -> Any:
-            require_complete: Sequence[bool]
             missing = []
             # Check for missing annotations
             for attr, complete in zip(annotations, require_complete):

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -1774,6 +1774,7 @@ def require_annotation(
 
     def require_annotation_decorator(func: Callable) -> Callable:
         def func_with_require(doclike, *args, **kwargs) -> Any:
+            require_complete: Sequence[bool]
             missing = []
             # Check for missing annotations
             for attr, complete in zip(annotations, require_complete):

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -1738,9 +1738,7 @@ def all_equal(iterable):
 
 
 def require_annotation(
-    annotations: Sequence[Union[str, int]],
-    *,
-    require_complete: Sequence[bool] = None
+    annotations: Sequence[Union[str, int]], *, require_complete: Sequence[bool] = None
 ) -> Callable:
     """
     To be used as a decorator for functions whose first argument
@@ -1788,7 +1786,9 @@ def require_annotation(
                         msg += " (complete)"
                 else:
                     msg = ""
-                    for i, (attr, complete) in enumerate(zip(annotations, require_complete)):
+                    for i, (attr, complete) in enumerate(
+                        zip(annotations, require_complete)
+                    ):
                         if i != 0:
                             msg += " "
                         msg += str(attr)
@@ -1803,5 +1803,7 @@ def require_annotation(
                 )
             else:
                 return func(doclike, *args, **kwargs)
+
         return func_with_require
+
     return require_annotation_decorator


### PR DESCRIPTION
Decorator to require annotations on a `Doc` or `Span` for a function.

## Description
The `syntax_iterators.py` for a couple of languages uses the `if not Doc.has_annotation("ATTR")` then `raise` a `ValueError` saying that we need this attribute for the function to work. Since the `noun_chunk` implementations in `syntax_iterators.py` forget to check `Doc.has_annotation("POS")` and only check for `"DEP"` they do not exit gracefully with an informative error message. To make it more ergonomic to describe annotation requirements of a function this PR introduces a `require_annotation` decorator that can be used like:

```python
@require_annotation(
    ["TAG", "DEP", "ENT_IOB"],
    require_complete=[True, True, False]
)
def do_stuff(doc: Union[Doc, Span]) -> Any:
       do something
```

In this example the `"TAG", "DEP", "ENT_IOB"` is expected by the function and its expected that all tokens are annotated with `"TAG"` and `"DEP"` information, but `"ENT_IOB"` can be partial. The hope is that this pattern makes it easy to get the requirements of a function correct right at definition.

### Types of change
Small improvement for error handling.

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
