### PR TITLE
Fix types for Span.id and Span.id_

### DIFF
--- a/spacy/tokens/span.pyi
+++ b/spacy/tokens/span.pyi
@@ -117,15 +117,13 @@ class Span:
     end_char: int
     label: int
     kb_id: int
+    id: int
     ent_id: int
     ent_id_: str
-    @property
-    def id(self) -> int: ...
-    @property
-    def id_(self) -> str: ...
     @property
     def orth_(self) -> str: ...
     @property
     def lemma_(self) -> str: ...
     label_: str
     kb_id_: str
+    id_: str


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Make types for `Span.id` and `Span.id_` the same as for other properties in `Span` with getters and setters.

It seems like the property types are not interpreted as writable by pyright (see #11113). mypy doesn't seem to have an issue and I'm not sure what's intended/correct, but it seems sensible that they are all the same.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Types.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
