### PR TITLE
change displacy default port to 5002

### DIFF
--- a/spacy/displacy/__init__.py
+++ b/spacy/displacy/__init__.py
@@ -80,7 +80,7 @@ def serve(
     minify: bool = False,
     options: Dict[str, Any] = {},
     manual: bool = False,
-    port: int = 5000,
+    port: int = 5002,
     host: str = "0.0.0.0",
 ) -> None:
     """Serve displaCy visualisation.

--- a/website/docs/api/top-level.md
+++ b/website/docs/api/top-level.md
@@ -245,7 +245,7 @@ browser. Will run a simple web server.
 | `minify`  | Minify HTML markup. Defaults to `False`. ~~bool~~                                                                                                                 |
 | `options` | [Visualizer-specific options](#displacy_options), e.g. colors. ~~Dict[str, Any]~~                                                                                 |
 | `manual`  | Don't parse `Doc` and instead expect a dict or list of dicts. [See here](/usage/visualizers#manual-usage) for formats and examples. Defaults to `False`. ~~bool~~ |
-| `port`    | Port to serve visualization. Defaults to `5000`. ~~int~~                                                                                                          |
+| `port`    | Port to serve visualization. Defaults to `5002`. ~~int~~                                                                                                          |
 | `host`    | Host to serve visualization. Defaults to `"0.0.0.0"`. ~~str~~                                                                                                     |
 
 ### displacy.render {#displacy.render tag="method" new="2"}


### PR DESCRIPTION
# Description
This changes the default port of displacy.serve from 5000 to 5002.

This is suggested because Apple now seems to occupy localhost:5000 for their AirPlay devices on macOs Monterey.
Related: https://stackoverflow.com/questions/70913242/access-to-localhost-was-denied-you-dont-have-authorisation-to-view-this-page-h 

Given that many users are likely to serve displacy to their localhost, it might be nice to change the default port to something like 5002. Otherwise, users on macOs Monterey will encounter a permission denied error (happened in my team).

## Types of change

Precaution to avoid bad user experience. Not essential.

## Checklist

- [x]  I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ]  I ran the tests, and all new and existing tests passed.
- [x]  My changes don't require a change to the documentation, or if they do, I've added all required information.


