### PR TITLE
prevent rewriting an already raw URL

### DIFF
--- a/spacy/cli/project/assets.py
+++ b/spacy/cli/project/assets.py
@@ -189,7 +189,11 @@ def convert_asset_url(url: str) -> str:
     RETURNS (str): The converted URL.
     """
     # If the asset URL is a regular GitHub URL it's likely a mistake
-    if re.match(r"(http(s?)):\/\/github.com", url) and "releases/download" not in url:
+    if (
+        re.match(r"(http(s?)):\/\/github.com", url)
+        and "releases/download" not in url
+        and "/raw/" not in url
+    ):
         converted = url.replace("github.com", "raw.githubusercontent.com")
         converted = re.sub(r"/(tree|blob)/", "/", converted)
         msg.warn(


### PR DESCRIPTION
## Description
On the `projects` CLI, when running `spacy project assets`, the helper function `convert_asset_url` attempts to catch regular github links that wouldn't download the actual file. However, a link can look like `https://github.com/user/project/raw/main/data` and this will download just fine. These cases shouldn't be rewritten because that will in fact result in a 404.

### Types of change
bug fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
