### PR TITLE
`Morphology`: Don't pickle `tags` member variable

### DIFF
--- a/spacy/morphology.pyx
+++ b/spacy/morphology.pyx
@@ -27,9 +27,7 @@ cdef class Morphology:
         self.strings = strings
 
     def __reduce__(self):
-        tags = set([self.get(self.strings[s]) for s in self.strings])
-        tags -= set([""])
-        return (unpickle_morphology, (self.strings, sorted(tags)), None, None)
+        return (unpickle_morphology, (self.strings,), None, None)
 
     cdef shared_ptr[MorphAnalysisC] _lookup_tag(self, hash_t tag_hash):
         match = self.tags.find(tag_hash)
@@ -244,8 +242,9 @@ cdef int get_n_by_field(attr_t* results, const shared_ptr[MorphAnalysisC] morph,
             n_results += 1
     return n_results
 
-def unpickle_morphology(strings, tags):
+def unpickle_morphology(strings):
     cdef Morphology morphology = Morphology(strings)
-    for tag in tags:
-        morphology.add(tag)
+    # Repopulate the tag map.
+    for string in strings:
+        morphology.add(string)
     return morphology


### PR DESCRIPTION
## Description
The information required to recreate the `tags` map is present in the string store, so it's not necessary to serialize it as well.

Originally identified in [this PR](https://github.com/explosion/spaCy/pull/11344#discussion_r968070230).

### Types of change
Improvement?

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
