### PR TITLE
Add example sentence for Chinese on website.

### DIFF
--- a/website/meta/languages.json
+++ b/website/meta/languages.json
@@ -562,6 +562,7 @@
                     "url": "https://github.com/explosion/spacy-pkuseg"
                 }
             ],
+            "example": "这是一个用于示例的句子。",
             "has_examples": true
         }
     ],


### PR DESCRIPTION
# Description
Added example sentence for Chinese in website/meta/languages.json so that it can be displayed instead of "No text available yet" when the "Show text example" option is checked.

# Types of change
Docs

# Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ]  I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.