### PR TITLE
Add docs for biluo_to_iob and iob_to_biluo.

### DIFF
--- a/website/docs/api/top-level.md
+++ b/website/docs/api/top-level.md
@@ -1009,7 +1009,7 @@ This method was previously available as `spacy.gold.spans_from_biluo_tags`.
 Convert a sequence of [BILUO](/usage/linguistic-features#accessing-ner) tags to
 [IOB](/usage/linguistic-features#accessing-ner) tags. This is useful if you want
 use the [BILUO](/usage/linguistic-features#accessing-ner) tags with a model that
-only support [IOB](/usage/linguistic-features#accessing-ner) tags.
+only supports [IOB](/usage/linguistic-features#accessing-ner) tags.
 
 > #### Example
 >
@@ -1031,7 +1031,7 @@ only support [IOB](/usage/linguistic-features#accessing-ner) tags.
 Convert a sequence of [IOB](/usage/linguistic-features#accessing-ner) tags to
 [BILUO](/usage/linguistic-features#accessing-ner) tags. This is useful if you
 want use the [IOB](/usage/linguistic-features#accessing-ner) tags with a model
-that only support [BILUO](/usage/linguistic-features#accessing-ner) tags.
+that only supports [BILUO](/usage/linguistic-features#accessing-ner) tags.
 
 <Infobox title="Changed in v3.0" variant="warning" id="iob_to_biluo">
 

--- a/website/docs/api/top-level.md
+++ b/website/docs/api/top-level.md
@@ -1008,8 +1008,7 @@ This method was previously available as `spacy.gold.spans_from_biluo_tags`.
 
 Convert a sequence of [BILUO](/usage/linguistic-features#accessing-ner) tags to
 [IOB](/usage/linguistic-features#accessing-ner) tags. This is useful if you want
-use the [BILUO](/usage/linguistic-features#accessing-ner) tags with a model that
-only supports [IOB](/usage/linguistic-features#accessing-ner) tags.
+use the BILUO tags with a model that only supports IOB tags.
 
 > #### Example
 >
@@ -1030,8 +1029,7 @@ only supports [IOB](/usage/linguistic-features#accessing-ner) tags.
 
 Convert a sequence of [IOB](/usage/linguistic-features#accessing-ner) tags to
 [BILUO](/usage/linguistic-features#accessing-ner) tags. This is useful if you
-want use the [IOB](/usage/linguistic-features#accessing-ner) tags with a model
-that only supports [BILUO](/usage/linguistic-features#accessing-ner) tags.
+want use the IOB tags with a model that only supports BILUO tags.
 
 <Infobox title="Changed in v3.0" variant="warning" id="iob_to_biluo">
 

--- a/website/docs/api/top-level.md
+++ b/website/docs/api/top-level.md
@@ -1004,6 +1004,56 @@ This method was previously available as `spacy.gold.spans_from_biluo_tags`.
 | `tags`      | A sequence of [BILUO](/usage/linguistic-features#accessing-ner) tags with each tag describing one token. Each tag string will be of the form of either `""`, `"O"` or `"{action}-{label}"`, where action is one of `"B"`, `"I"`, `"L"`, `"U"`. ~~List[str]~~ |
 | **RETURNS** | A sequence of `Span` objects with added entity labels. ~~List[Span]~~                                                                                                                                                                                        |
 
+### training.biluo_to_iob {#biluo_to_iob tag="function"}
+
+Convert a sequence of [BILUO](/usage/linguistic-features#accessing-ner) tags to
+[IOB](/usage/linguistic-features#accessing-ner) tags. This is useful if you want
+use the [BILUO](/usage/linguistic-features#accessing-ner) tags with a model that
+only support [IOB](/usage/linguistic-features#accessing-ner) tags.
+
+> #### Example
+>
+> ```python
+> from spacy.training import biluo_to_iob
+>
+> tags = ["O", "O", "B-LOC", "I-LOC", "L-LOC", "O"]
+> iob_tags = biluo_to_iob(tags)
+> assert iob_tags == ["O", "O", "B-LOC", "I-LOC", "I-LOC", "O"]
+> ```
+
+| Name        | Description                                                                             |
+| ----------- | --------------------------------------------------------------------------------------- |
+| `tags`      | A sequence of [BILUO](/usage/linguistic-features#accessing-ner) tags. ~~Iterable[str]~~ |
+| **RETURNS** | A list of [IOB](/usage/linguistic-features#accessing-ner) tags. ~~List[str]~~           |
+
+### training.iob_to_biluo {#iob_to_biluo tag="function"}
+
+Convert a sequence of [IOB](/usage/linguistic-features#accessing-ner) tags to
+[BILUO](/usage/linguistic-features#accessing-ner) tags. This is useful if you
+want use the [IOB](/usage/linguistic-features#accessing-ner) tags with a model
+that only support [BILUO](/usage/linguistic-features#accessing-ner) tags.
+
+<Infobox title="Changed in v3.0" variant="warning" id="iob_to_biluo">
+
+This method was previously available as `spacy.gold.iob_to_biluo`.
+
+</Infobox>
+
+> #### Example
+>
+> ```python
+> from spacy.training import iob_to_biluo
+>
+> tags = ["O", "O", "B-LOC", "I-LOC", "O"]
+> biluo_tags = iob_to_biluo(tags)
+> assert biluo_tags == ["O", "O", "B-LOC", "L-LOC", "O"]
+> ```
+
+| Name        | Description                                                                           |
+| ----------- | ------------------------------------------------------------------------------------- |
+| `tags`      | A sequence of [IOB](/usage/linguistic-features#accessing-ner) tags. ~~Iterable[str]~~ |
+| **RETURNS** | A list of [BILUO](/usage/linguistic-features#accessing-ner) tags. ~~List[str]~~       |
+
 ## Utility functions {#util source="spacy/util.py"}
 
 spaCy comes with a small collection of utility functions located in


### PR DESCRIPTION
## Description
Add function document for `training.biluo_to_iob` and `training.iob_to_biluo`, solving #9671.

### Types of change
Docs.

## Checklist
- [ x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [ x] My changes don't require a change to the documentation, or if they do, I've added all required information.
