### PR TITLE
Fix the interpolation in directory names when loading config files using cli.

### DIFF
--- a/spacy/cli/_util.py
+++ b/spacy/cli/_util.py
@@ -158,15 +158,15 @@ def load_project_config(
         sys.exit(1)
     validate_project_version(config)
     validate_project_commands(config)
+    if interpolate:
+        err = f"{PROJECT_FILE} validation error"
+        with show_validation_error(title=err, hint_fill=False):
+            config = substitute_project_variables(config, overrides)
     # Make sure directories defined in config exist
     for subdir in config.get("directories", []):
         dir_path = path / subdir
         if not dir_path.exists():
             dir_path.mkdir(parents=True)
-    if interpolate:
-        err = f"{PROJECT_FILE} validation error"
-        with show_validation_error(title=err, hint_fill=False):
-            config = substitute_project_variables(config, overrides)
     return config
 
 

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -123,6 +123,25 @@ def test_issue7055():
     assert "model" in filled_cfg["components"]["ner"]
 
 
+@pytest.mark.issue(11235)
+def test_issue11235():
+    """
+    Test that the cli handles interpolation in the directory names correctly when loading project config.
+    """
+    lang_var = "en"
+    variables = {"lang": lang_var}
+    commands = [{"name": "x", "script": ["hello ${vars.lang}"]}]
+    directories = ["cfg", "${vars.lang}_model"]
+    project = {"commands": commands, "vars": variables, "directories": directories}
+    with make_tempdir() as d:
+        srsly.write_yaml(d / "project.yml", project)
+        cfg = load_project_config(d)
+        # Check that the directories are interpolated and created correctly
+        assert os.path.exists(d / "cfg")
+        assert os.path.exists(d / f"{lang_var}_model")
+    assert cfg["commands"][0]["script"][0] == f"hello {lang_var}"
+    
+
 def test_cli_info():
     nlp = Dutch()
     nlp.add_pipe("textcat")


### PR DESCRIPTION
## Description
Solving #11235.
When loading config files, do the interpolation before checking the directories to handle variables in the directory names correctly. Related tests are added to test_cli.py.

Testing result:
- OS: `Windows 11`
- Python: `3.10`
- Result: 
```bash
$ py.test spacy
3298 passed, 1211 skipped, 32 xfailed, 1 xpassed in 354.31s (0:05:54)
```

### Types of change
Bugfix.

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
