### PR TITLE
fix links in 3.4 release notes

### DIFF
--- a/website/docs/usage/v3-4.md
+++ b/website/docs/usage/v3-4.md
@@ -66,8 +66,8 @@ The English CNN pipelines have new word vectors:
 | Package                                         | Model Version |  TAG | Parser LAS | NER F |
 | ----------------------------------------------- | ------------- | ---: | ---------: | ----: |
 | [`en_core_web_md`](/models/en#en_core_web_md) | v3.3.0        | 97.3 |       90.1 |  84.6 |
-| [`en_core_web_md`](/models/en#en_core_web_lg) | v3.4.0        | 97.2 |       90.3 |  85.5 |
-| [`en_core_web_lg`](/models/en#en_core_web_md) | v3.3.0        | 97.4 |       90.1 |  85.3 |
+| [`en_core_web_md`](/models/en#en_core_web_md) | v3.4.0        | 97.2 |       90.3 |  85.5 |
+| [`en_core_web_lg`](/models/en#en_core_web_lg) | v3.3.0        | 97.4 |       90.1 |  85.3 |
 | [`en_core_web_lg`](/models/en#en_core_web_lg) | v3.4.0        | 97.3 |       90.2 |  85.6 |
 
 ## Notes about upgrading from v3.3 {#upgrading}


### PR DESCRIPTION
## Description
It looks like the md/lg links in the 3-4 readme got mixed up 

### Types of change
doc fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
