### PR TITLE
update lock-threads to v4

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -15,11 +15,11 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v3
+      - uses: dessant/lock-threads@v4
         with:
           process-only: 'issues'
           issue-inactive-days: '30'
-          issue-comment: > 
-            This thread has been automatically locked since there 
-            has not been any recent activity after it was closed. 
+          issue-comment: >
+            This thread has been automatically locked since there
+            has not been any recent activity after it was closed.
             Please open a new issue for related bugs.


### PR DESCRIPTION
The `lock-threads` action has been updated upstream to fix the node deprecation warnings, so now we can bump it here. 
