### PR TITLE
Reduce frequency with which on_match callbacks are called

### DIFF
--- a/spacy/matcher/matcher.pyx
+++ b/spacy/matcher/matcher.pyx
@@ -318,10 +318,10 @@ cdef class Matcher:
         for (key, *_) in final_matches:
             key_matches[key].append((key,*_))
 
-        for key, matches in key_matches.items():
+        for i, (key, matches) in enumerate(key_matches.items()):
             on_match = self._callbacks.get(key, None)
             if on_match is not None:
-                    on_match(self, doc, key, matches)
+                    on_match(self, doc, i, matches)
         return final_results
 
     def _normalize_key(self, key):

--- a/spacy/matcher/matcher.pyx
+++ b/spacy/matcher/matcher.pyx
@@ -1,4 +1,5 @@
 # cython: infer_types=True, profile=True
+from collections import defaultdict
 from typing import List, Iterable
 
 from libcpp.vector cimport vector
@@ -313,10 +314,14 @@ cdef class Matcher:
         else:
             final_results = final_matches
         # perform the callbacks on the filtered set of results
-        for i, (key, *_) in enumerate(final_matches):
+        key_matches = defaultdict(list)
+        for (key, *_) in final_matches:
+            key_matches[key].append((key,*_))
+
+        for key, matches in key_matches.items():
             on_match = self._callbacks.get(key, None)
             if on_match is not None:
-                on_match(self, doc, i, final_matches)
+                    on_match(self, doc, key, matches)
         return final_results
 
     def _normalize_key(self, key):

--- a/spacy/tests/matcher/test_matcher_api.py
+++ b/spacy/tests/matcher/test_matcher_api.py
@@ -84,7 +84,7 @@ def test_matcher_add_new_api(en_vocab):
     on_match = Mock()
     matcher.add("NEW_API_CALLBACK", patterns, on_match=on_match)
     assert len(matcher(doc)) == 2
-    assert on_match.call_count == 2
+    assert on_match.call_count == 1
 
 
 def test_matcher_no_match(matcher):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
Current matcher implementation makes all callbacks run on all matches. Desired behaviour is each callback(on_match) should be passed patterns linked with that callback only. 
### Changes I made:
1. Group patterns based on matcher and pass all matched patterns to corresponding callback function.
2. Update test case as one matcher should have one call in which it handle all matched patterns.

### Test script used:
```
import spacy
from spacy.matcher import Matcher
from spacy.tokens import Doc
nlp = spacy.load("en_core_web_sm")
Doc.set_extension("suggestions", default=[], force=True)

def on_match_adv(matcher, doc, id, matches):
    print(f"inside on_match_adv")
    print(f"matches: #expected=2, #got={len(matches)}")
    print(f"matches: {[doc[start:end] for _, start, end in matches]}")
    for _, start, end in matches:
        matched_span = doc[start:end]
        startIndex, endIndex = matched_span.start_char, matched_span.end_char
        coveredText = matched_span.text
        errorText = f"adverb-replacement"
        comment = f"Replace '{coveredText}' with '{errorText}'."
        suggestion = {"startIndex": startIndex, "endIndex": endIndex,
                      "coveredText": coveredText, "errorText": errorText,
                      "comment": comment}
        doc._.suggestions.append(suggestion)


def on_match_pron(matcher, doc, id, matches):
    print(f"inside on_match_pron")
    print(f"matches: #expected=1, #got={len(matches)}")
    print(f"matches: {[doc[start:end] for _, start, end in matches]}")
    for _, start, end in matches:
        matched_span = doc[start:end]
        startIndex, endIndex = matched_span.start_char, matched_span.end_char
        coveredText = matched_span[0].text
        errorText = f"pron-replacement"
        suggestion = {"startIndex": startIndex, "endIndex": endIndex,
                      "coveredText": coveredText, "errorText": errorText}
        doc._.suggestions.append(suggestion)


if __name__ == '__main__':
    sentence = "This is just just an example sentence."
    matcher = Matcher(nlp.vocab)
    # handle adverbs
    matcher.add("v1",[[{'POS': 'ADV'}]], on_match=on_match_adv)
    # handle pronouns
    matcher.add("v2", [[{'POS': 'PRON'}]], on_match=on_match_pron)
    doc = nlp(sentence)
    matches = matcher(doc)
    try:
        assert len(doc._.suggestions) == 3
    except Exception as err:
        print(doc._.suggestions)
    print(f"#suggestions expected: 3, got:{len(doc._.suggestions)}")

    # current behaviour:
    #1. calls `on_match_adv` twice once for each adverb occurence, on_match_pron once for single occurence of pronoun
    #2. act on all matched_patterns(3) in each callback
    #3.  final outcome: 9 suggestions (3*3 )
    
    # desired_outcome:
    # 1. should call `on_match_adv` once and handle both adverb occurences in that call
    # 2. should call `on_match_pron` once and handle all pron occurences in that call
    # 3. final outcome: 3 suggestions 2 for adverbs, 1 for pron (1 callback * 2 patterns+ 1 callback *1 matched pattern)

```

### Types of change
It is a bug fix.

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
