### PR TITLE
Fix speed problem with `top_k>1` on CPU in edit tree lemmatizer

### DIFF
--- a/spacy/pipeline/edit_tree_lemmatizer.py
+++ b/spacy/pipeline/edit_tree_lemmatizer.py
@@ -165,7 +165,7 @@ class EditTreeLemmatizer(TrainablePipe):
             doc_compat_guesses = []
             for i, token in enumerate(doc):
                 for _ in range(self.top_k):
-                    candidate = doc_scores[i].argmax()
+                    candidate = int(doc_scores[i].argmax())
                     candidate_tree_id = self.cfg["labels"][candidate]
                     if self.trees.apply(candidate_tree_id, token.text) is not None:
                         doc_compat_guesses.append(candidate_tree_id)

--- a/spacy/pipeline/edit_tree_lemmatizer.py
+++ b/spacy/pipeline/edit_tree_lemmatizer.py
@@ -193,7 +193,7 @@ class EditTreeLemmatizer(TrainablePipe):
 
     def _scores2guesses_top_k_greater_1(self, docs, scores):
         guesses = []
-        predictions_to_consider = min(self.top_k, len(self.labels))
+        top_k = min(self.top_k, len(self.labels))
         for doc, doc_scores in zip(docs, scores):
             doc_scores = self.numpy_ops.asarray(doc_scores)
             doc_compat_guesses = []

--- a/spacy/pipeline/edit_tree_lemmatizer.py
+++ b/spacy/pipeline/edit_tree_lemmatizer.py
@@ -198,7 +198,7 @@ class EditTreeLemmatizer(TrainablePipe):
             doc_scores = self.numpy_ops.asarray(doc_scores)
             doc_compat_guesses = []
             for i, token in enumerate(doc):
-                for _ in range(predictions_to_consider):
+                for _ in range(top_k):
                     candidate = int(doc_scores[i].argmax())
                     candidate_tree_id = self.cfg["labels"][candidate]
                     if self.trees.apply(candidate_tree_id, token.text) is not None:

--- a/spacy/pipeline/edit_tree_lemmatizer.py
+++ b/spacy/pipeline/edit_tree_lemmatizer.py
@@ -208,6 +208,7 @@ class EditTreeLemmatizer(TrainablePipe):
                 else:
                     doc_compat_guesses.append(-1)
             guesses.append(np.array(doc_compat_guesses))
+
         return guesses
 
     def _scores2guesses_top_k_guardrail(self, docs, scores):

--- a/spacy/pipeline/edit_tree_lemmatizer.py
+++ b/spacy/pipeline/edit_tree_lemmatizer.py
@@ -160,6 +160,8 @@ class EditTreeLemmatizer(TrainablePipe):
     def _scores2guesses(self, docs, scores):
         guesses = []
         for doc, doc_scores in zip(docs, scores):
+            if not isinstance(doc_scores, np.ndarray):
+                doc_scores = doc_scores.get()
             doc_compat_guesses = []
             for i, token in enumerate(doc):
                 for _ in range(self.top_k):

--- a/spacy/pipeline/edit_tree_lemmatizer.py
+++ b/spacy/pipeline/edit_tree_lemmatizer.py
@@ -160,8 +160,7 @@ class EditTreeLemmatizer(TrainablePipe):
     def _scores2guesses(self, docs, scores):
         guesses = []
         for doc, doc_scores in zip(docs, scores):
-            if not isinstance(doc_scores, np.ndarray):
-                doc_scores = doc_scores.get()
+            NumpyOps().asarray(doc_scores)
             doc_compat_guesses = []
             for i, token in enumerate(doc):
                 for _ in range(self.top_k):

--- a/spacy/tests/pipeline/test_edit_tree_lemmatizer.py
+++ b/spacy/tests/pipeline/test_edit_tree_lemmatizer.py
@@ -101,14 +101,15 @@ def test_initialize_from_labels():
     }
 
 
-def test_no_data():
+@pytest.mark.parametrize("top_k", (1, 5, 30))
+def test_no_data(top_k):
     # Test that the lemmatizer provides a nice error when there's no tagging data / labels
     TEXTCAT_DATA = [
         ("I'm so happy.", {"cats": {"POSITIVE": 1.0, "NEGATIVE": 0.0}}),
         ("I'm so angry", {"cats": {"POSITIVE": 0.0, "NEGATIVE": 1.0}}),
     ]
     nlp = English()
-    nlp.add_pipe("trainable_lemmatizer")
+    nlp.add_pipe("trainable_lemmatizer", config={"top_k": top_k})
     nlp.add_pipe("textcat")
 
     train_examples = []
@@ -119,10 +120,11 @@ def test_no_data():
         nlp.initialize(get_examples=lambda: train_examples)
 
 
-def test_incomplete_data():
+@pytest.mark.parametrize("top_k", (1, 5, 30))
+def test_incomplete_data(top_k):
     # Test that the lemmatizer works with incomplete information
     nlp = English()
-    lemmatizer = nlp.add_pipe("trainable_lemmatizer")
+    lemmatizer = nlp.add_pipe("trainable_lemmatizer", config={"top_k": top_k})
     lemmatizer.min_tree_freq = 1
     train_examples = []
     for t in PARTIAL_DATA:

--- a/spacy/tests/pipeline/test_edit_tree_lemmatizer.py
+++ b/spacy/tests/pipeline/test_edit_tree_lemmatizer.py
@@ -140,9 +140,10 @@ def test_incomplete_data():
     assert doc[2].lemma_ == "blue"
 
 
-def test_overfitting_IO():
+@pytest.mark.parametrize("top_k", (1, 5, 30))
+def test_overfitting_IO(top_k):
     nlp = English()
-    lemmatizer = nlp.add_pipe("trainable_lemmatizer")
+    lemmatizer = nlp.add_pipe("trainable_lemmatizer", config={"top_k": top_k})
     lemmatizer.min_tree_freq = 1
     train_examples = []
     for t in TRAIN_DATA:
@@ -175,7 +176,7 @@ def test_overfitting_IO():
     # Check model after a {to,from}_bytes roundtrip
     nlp_bytes = nlp.to_bytes()
     nlp3 = English()
-    nlp3.add_pipe("trainable_lemmatizer")
+    nlp3.add_pipe("trainable_lemmatizer", config={"top_k": top_k})
     nlp3.from_bytes(nlp_bytes)
     doc3 = nlp3(test_text)
     assert doc3[0].lemma_ == "she"


### PR DESCRIPTION
## Description

The edit-tree lemmatizer has a hyperparameter `top_k` that specifies the number of alternative predicted trees to consider for each token: if the first predicted tree is not applicable to the raw token text, the second predicted tree is considered and so on up to the value of `top_k`.

Although accuracies are normally higher if alternative predictions can be considered, the current standard published models all specify `top_k = 1`. This is because the pre-existing code is several times slower when executed on a CPU for any higher value of `top_k` owing to an expensive NumPy sort that is used to order the predictions for each token (the sort is avoided in the pre-existing code if `top_k == 1`).

This PR retains the existing approach if `top_k==1`, but introduces a procedural approach if `top_k>1`. The procedural approach avoids the NumPy sort and also has the important advantage that time is only spent processing alternative predictions if earlier predictions were not applicable. Because with a well-trained model the first predictions are typically applicable to most tokens, this largely removes the performance hit where `top_k > 1` and should allow us to choose values for standard models in the future based purely on accuracy requirements.

When using the edit-tree lemmatizer for its original intended purpose, it is unlikely that values of `top_k` above about 10 would ever be useful. However, it is conceivable that the code might be used for some other purpose where much higher values of `top_k` are required. For values of `top_k` above about 20, the pre-existing approach is more efficient than the new approach. To take the various scenarios into account, the new code checks the value of `top_k` and selects one of three strategies depending on whether it is `1`; `2<n<=20`; or `>20`. 

The following speed figures were measured training `pl_core_news_lg`. The relevant improvement is for `2<n<=20` and especially on CPU, although selecting the optimal strategy once for each batch of documents rather than testing to see whether `top_k` is greater than 1 or not each time an individual document is processed also has a small but consistent positive impact on speed for other scenarios:

| `top_k` | Speed CPU old | Speed CPU new | Speed GPU old | Speed GPU new |
| --------   | --------------------- | --------------------   | --------------------- | ---------------------- |
| 1 | 37040 | 37483 | 184859 | 192005 |
| 5 | **9585** | **36050** | 113997 | 123473 |
| 25 | 9271 | 9569 | 111335 | 112726 |

### Types of change
Speed enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
