### PR TITLE
Fix required maximum version of typing-extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ langcodes>=3.2.0,<4.0.0
 # Official Python utilities
 setuptools
 packaging>=20.0
-typing_extensions>=3.7.4.1,<5.0.0; python_version < "3.8"
+typing_extensions>=3.7.4.1,<4.5.0; python_version < "3.8"
 # Development dependencies
 pre-commit>=2.13.0
 cython>=0.25,<3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ langcodes>=3.2.0,<4.0.0
 # Official Python utilities
 setuptools
 packaging>=20.0
-typing_extensions>=3.7.4.1,<4.2.0; python_version < "3.8"
+typing_extensions>=3.7.4.1,<5.0.0; python_version < "3.8"
 # Development dependencies
 pre-commit>=2.13.0
 cython>=0.25,<3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ install_requires =
     # Official Python utilities
     setuptools
     packaging>=20.0
-    typing_extensions>=3.7.4,<5.0.0; python_version < "3.8"
+    typing_extensions>=3.7.4.1,<4.5.0; python_version < "3.8"
     langcodes>=3.2.0,<4.0.0
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ install_requires =
     # Official Python utilities
     setuptools
     packaging>=20.0
-    typing_extensions>=3.7.4,<4.2.0; python_version < "3.8"
+    typing_extensions>=3.7.4,<5.0.0; python_version < "3.8"
     langcodes>=3.2.0,<4.0.0
 
 [options.entry_points]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
This PR fixes the required maximum version of typing-extensions.

Currently it is bounded to <4.2.0: `typing_extensions>=3.7.4.1,<4.2.0; python_version < "3.8"`

This PR sets the upper bound to all compatible versions, until the next major release <5.0.0.

Required:
- [ ] https://github.com/explosion/confection/pull/20
- [ ] https://github.com/explosion/thinc/pull/833

See:
- https://github.com/explosion/spaCy/issues/12034

See issue in pydantic:
- https://github.com/pydantic/pydantic/issues/4885

See fixing PR in pydantic (`typing-extensions>=4.2.0`), which will be incompatible with your requirement `typing_extensions>=3.7.4,<4.2.0; python_version < "3.8"`:
- https://github.com/pydantic/pydantic/pull/4886

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ ] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
