### PR TITLE
fix processing of "auto" in convert

### DIFF
--- a/spacy/cli/_util.py
+++ b/spacy/cli/_util.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
 SDIST_SUFFIX = ".tar.gz"
 WHEEL_SUFFIX = "-py3-none-any.whl"
 
+AUTO = "auto"
+
 PROJECT_FILE = "project.yml"
 PROJECT_LOCK = "project.lock"
 COMMAND = "python -m spacy"
@@ -596,6 +598,8 @@ def walk_directory(path: Path, suffix: Optional[str] = None) -> List[Path]:
             continue
         elif path.is_dir():
             paths.extend(path.iterdir())
+        elif suffix == AUTO:
+            locs.append(path)
         elif suffix is not None and not path.parts[-1].endswith(suffix):
             continue
         else:

--- a/spacy/cli/_util.py
+++ b/spacy/cli/_util.py
@@ -29,8 +29,6 @@ if TYPE_CHECKING:
 SDIST_SUFFIX = ".tar.gz"
 WHEEL_SUFFIX = "-py3-none-any.whl"
 
-AUTO = "auto"
-
 PROJECT_FILE = "project.yml"
 PROJECT_LOCK = "project.lock"
 COMMAND = "python -m spacy"
@@ -585,6 +583,10 @@ def setup_gpu(use_gpu: int, silent=None) -> None:
 
 
 def walk_directory(path: Path, suffix: Optional[str] = None) -> List[Path]:
+    """Given a directory and a suffix, recursively find all files matching the suffix.
+    Directories or files with names beginning with a . are ignored, but hidden flags on
+    filesystems are not checked.
+    When provided with a suffix `None`, all files are returned without filtering."""
     if not path.is_dir():
         return [path]
     paths = [path]
@@ -598,8 +600,6 @@ def walk_directory(path: Path, suffix: Optional[str] = None) -> List[Path]:
             continue
         elif path.is_dir():
             paths.extend(path.iterdir())
-        elif suffix == AUTO:
-            locs.append(path)
         elif suffix is not None and not path.parts[-1].endswith(suffix):
             continue
         else:

--- a/spacy/cli/_util.py
+++ b/spacy/cli/_util.py
@@ -586,7 +586,7 @@ def walk_directory(path: Path, suffix: Optional[str] = None) -> List[Path]:
     """Given a directory and a suffix, recursively find all files matching the suffix.
     Directories or files with names beginning with a . are ignored, but hidden flags on
     filesystems are not checked.
-    When provided with a suffix `None`, all files are returned without filtering."""
+    When provided with a suffix `None`, there is no suffix-based filtering."""
     if not path.is_dir():
         return [path]
     paths = [path]

--- a/spacy/cli/convert.py
+++ b/spacy/cli/convert.py
@@ -68,15 +68,11 @@ def convert_cli(
 
     DOCS: https://spacy.io/api/cli#convert
     """
-    print("CONVERT")
     input_path = Path(input_path)
     output_dir: Union[str, Path] = "-" if output_dir == Path("-") else output_dir
     silent = output_dir == "-"
     msg = Printer(no_print=silent)
-    print("BEFORE", converter)
     converter = _get_converter(msg, converter, input_path)
-    print("AFTER", converter)
-    print("VERIFYING")
     verify_cli_args(msg, input_path, output_dir, file_type.value, converter, ner_map)
     convert(
         input_path,

--- a/spacy/cli/convert.py
+++ b/spacy/cli/convert.py
@@ -247,5 +247,4 @@ def _get_converter(msg, converter, input_path: Path):
                 "Conversion may not succeed. "
                 "See https://spacy.io/api/cli#convert"
             )
-    print("got convertor", converter)
     return converter

--- a/spacy/cli/convert.py
+++ b/spacy/cli/convert.py
@@ -7,7 +7,7 @@ import re
 import sys
 import itertools
 
-from ._util import app, Arg, Opt, walk_directory
+from ._util import app, Arg, Opt, walk_directory, AUTO
 from ..training import docs_to_json
 from ..tokens import Doc, DocBin
 from ..training.converters import iob_to_docs, conll_ner_to_docs, json_to_docs
@@ -49,7 +49,7 @@ def convert_cli(
     model: Optional[str] = Opt(None, "--model", "--base", "-b", help="Trained spaCy pipeline for sentence segmentation to use as base (for --seg-sents)"),
     morphology: bool = Opt(False, "--morphology", "-m", help="Enable appending morphology to tags"),
     merge_subtokens: bool = Opt(False, "--merge-subtokens", "-T", help="Merge CoNLL-U subtokens"),
-    converter: str = Opt("auto", "--converter", "-c", help=f"Converter: {tuple(CONVERTERS.keys())}"),
+    converter: str = Opt(AUTO, "--converter", "-c", help=f"Converter: {tuple(CONVERTERS.keys())}"),
     ner_map: Optional[Path] = Opt(None, "--ner-map", "-nm", help="NER tag mapping (as JSON-encoded dict of entity types)", exists=True),
     lang: Optional[str] = Opt(None, "--lang", "-l", help="Language (if tokenizer required)"),
     concatenate: bool = Opt(None, "--concatenate", "-C", help="Concatenate output to a single file"),
@@ -100,7 +100,7 @@ def convert(
     model: Optional[str] = None,
     morphology: bool = False,
     merge_subtokens: bool = False,
-    converter: str = "auto",
+    converter: str = AUTO,
     ner_map: Optional[Path] = None,
     lang: Optional[str] = None,
     concatenate: bool = False,
@@ -213,17 +213,17 @@ def verify_cli_args(
         if len(input_locs) == 0:
             msg.fail("No input files in directory", input_path, exits=1)
         file_types = list(set([loc.suffix[1:] for loc in input_locs]))
-        if converter == "auto" and len(file_types) >= 2:
+        if converter == AUTO and len(file_types) >= 2:
             file_types_str = ",".join(file_types)
             msg.fail("All input files must be same type", file_types_str, exits=1)
-    if converter != "auto" and converter not in CONVERTERS:
+    if converter != AUTO and converter not in CONVERTERS:
         msg.fail(f"Can't find converter for {converter}", exits=1)
 
 
 def _get_converter(msg, converter, input_path: Path):
     if input_path.is_dir():
         input_path = walk_directory(input_path, converter)[0]
-    if converter == "auto":
+    if converter == AUTO:
         converter = input_path.suffix[1:]
     if converter == "ner" or converter == "iob":
         with input_path.open(encoding="utf8") as file_:

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -1204,6 +1204,7 @@ def test_walk_directory():
             Path(d / f).touch()
 
         assert (len(walk_directory(d))) == 7
+        assert (len(walk_directory(d, suffix=None))) == 7
         assert (len(walk_directory(d, suffix="json"))) == 1
         assert (len(walk_directory(d, suffix="iob"))) == 2
         assert (len(walk_directory(d, suffix="conll"))) == 3

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -20,7 +20,7 @@ from spacy.cli._util import is_subpath_of, load_project_config, walk_directory
 from spacy.cli._util import parse_config_overrides, string_to_list
 from spacy.cli._util import substitute_project_variables
 from spacy.cli._util import validate_project_commands
-from spacy.cli._util import upload_file, download_file, AUTO
+from spacy.cli._util import upload_file, download_file
 from spacy.cli.debug_data import _compile_gold, _get_labels_from_model
 from spacy.cli.debug_data import _get_labels_from_spancat
 from spacy.cli.debug_data import _get_distribution, _get_kl_divergence
@@ -1209,4 +1209,3 @@ def test_walk_directory():
         assert (len(walk_directory(d, suffix="iob"))) == 2
         assert (len(walk_directory(d, suffix="conll"))) == 3
         assert (len(walk_directory(d, suffix="pdf"))) == 0
-        assert (len(walk_directory(d, suffix=AUTO))) == 7

--- a/spacy/tests/test_cli_app.py
+++ b/spacy/tests/test_cli_app.py
@@ -1,0 +1,33 @@
+import os
+from pathlib import Path
+from typer.testing import CliRunner
+
+from spacy.cli._util import app
+from .util import make_tempdir
+
+
+def test_convert_auto():
+    with make_tempdir() as d_in, make_tempdir() as d_out:
+        for f in ["data1.iob", "data2.iob", "data3.iob"]:
+            Path(d_in / f).touch()
+
+        # ensure that "automatic" suffix detection works
+        result = CliRunner().invoke(app, ["convert", str(d_in), str(d_out)])
+        assert "Generated output file" in result.stdout
+        out_files = os.listdir(d_out)
+        assert len(out_files) == 3
+        assert "data1.spacy" in out_files
+        assert "data2.spacy" in out_files
+        assert "data3.spacy" in out_files
+
+
+def test_convert_auto_conflict():
+    with make_tempdir() as d_in, make_tempdir() as d_out:
+        for f in ["data1.iob", "data2.iob", "data3.json"]:
+            Path(d_in / f).touch()
+
+        # ensure that "automatic" suffix detection warns when there are different file types
+        result = CliRunner().invoke(app, ["convert", str(d_in), str(d_out)])
+        assert "All input files must be same type" in result.stdout
+        out_files = os.listdir(d_out)
+        assert len(out_files) == 0


### PR DESCRIPTION
## Description
The refactoring of `walk_directory` in https://github.com/explosion/spaCy/pull/11376 changed the behaviour of matching on a suffix that is not "iob", "jsonl" or "conll", returning zero hits instead of all files. However, `convert` relies on getting all files when using the option "auto", but it wasn't properly hooked up to the new `walk_directory` implementation. This PR fixes that and introduces new unit tests to ensure the correct behaviour going forward.

### Types of change
bug fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
