### PR TITLE
Restore v2 token_acc score implementation

### DIFF
--- a/spacy/scorer.py
+++ b/spacy/scorer.py
@@ -174,7 +174,7 @@ class Scorer:
             prf_score.score_set(pred_spans, gold_spans)
         if len(acc_score) > 0:
             return {
-                "token_acc": acc_score.fscore,
+                "token_acc": acc_score.precision,
                 "token_p": prf_score.precision,
                 "token_r": prf_score.recall,
                 "token_f": prf_score.fscore,

--- a/spacy/tests/test_scorer.py
+++ b/spacy/tests/test_scorer.py
@@ -110,7 +110,7 @@ def test_tokenization(sented_doc):
     )
     example.predicted[1].is_sent_start = False
     scores = scorer.score([example])
-    assert scores["token_acc"] == approx(0.66666666)
+    assert scores["token_acc"] == 0.5
     assert scores["token_p"] == 0.5
     assert scores["token_r"] == approx(0.33333333)
     assert scores["token_f"] == 0.4

--- a/website/docs/api/scorer.md
+++ b/website/docs/api/scorer.md
@@ -76,7 +76,7 @@ core pipeline components, the individual score names start with the `Token` or
 
 Scores the tokenization:
 
-- `token_acc`: number of correct tokens / number of gold tokens
+- `token_acc`: number of correct tokens / number of predicted tokens
 - `token_p`, `token_r`, `token_f`: precision, recall and F-score for token
   character spans
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

In the v3 scorer refactoring, `token_acc` was implemented incorrectly. It should use `precision` instead of `fscore` for the measure of correctly aligned tokens / number of predicted tokens.

Fix the docs to reflect that the measure uses the number of predicted tokens rather than the number of gold tokens.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bug fix, docs.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
