### PR TITLE
Fix wrong HTML element attribute in website front page

### DIFF
--- a/website/src/components/embed.js
+++ b/website/src/components/embed.js
@@ -104,7 +104,7 @@ const Image = ({ src, alt, title, href, ...props }) => {
 const ImageFill = ({ image, ...props }) => {
     return (
         <span
-            class={classes['figure-fill']}
+            className={classes['figure-fill']}
             style={{ paddingBottom: `${(image.height / image.width) * 100}%` }}
         >
             <ImageNext src={image.src} {...props} fill />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
Originally introduced in 62b9c9c6d711584cea91244bc765e56e74337fdd (https://github.com/explosion/spaCy/pull/12005)

Original error: 

> `Warning: Invalid DOM property `class`. Did you mean `className`?`

React doesn't have `class`, it uses `className`.

### Types of change
- Website frontend bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
