### PR TITLE
Remove unnecessary links on website

### DIFF
--- a/website/src/components/embed.js
+++ b/website/src/components/embed.js
@@ -88,10 +88,16 @@ const Image = ({ src, alt, title, href, ...props }) => {
     const markdownComponents = { code: InlineCode, p: Fragment, a: Link }
     return (
         <figure className="gatsby-resp-image-figure">
-            <Link className={linkClassNames} href={href ?? src} hidden forceExternal>
-                {/* eslint-disable-next-line @next/next/no-img-element */}
+            {href ? (
+                <Link className={linkClassNames} href={href} hidden forceExternal>
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img className={classes.image} src={src} alt={alt} width={650} height="auto" />
+                </Link>
+            ) : (
+                /* eslint-disable-next-line @next/next/no-img-element */
                 <img className={classes.image} src={src} alt={alt} width={650} height="auto" />
-            </Link>
+            )}
+
             {title && (
                 <figcaption className="gatsby-resp-image-figcaption">
                     <MarkdownToReact markdown={title} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
This removes links on images, that just link to themself. There is no need to link to the image we are already viewing and this is also considered an accessibility issue by Lighthouse, because there is no text description for the link.

### Types of change
- Website frontend/accessibility improvements
 
## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
