### PR TITLE
Fix GitHub badge

### DIFF
--- a/website/src/templates/universe.js
+++ b/website/src/templates/universe.js
@@ -195,11 +195,11 @@ const SpaCyVersion = ({ version }) => {
     ))
 }
 
-const ImageGitHub = ({ url }) => (
+const ImageGitHub = ({ url, isRounded }) => (
     // eslint-disable-next-line @next/next/no-img-element
     <img
         style={{
-            borderRadius: '1em',
+            borderRadius: isRounded ? '1em' : 0,
             marginRight: '0.5rem',
             verticalAlign: 'middle',
         }}
@@ -216,8 +216,14 @@ const Project = ({ data, components }) => (
                     {data.spacy_version && <SpaCyVersion version={data.spacy_version} />}
                     {data.github && (
                         <Link to={`https://github.com/${data.github}`} hidden>
-                            <ImageGitHub url={`release/${data.github}/all.svg?style=flat-square`} />
-                            <ImageGitHub url={`license/${data.github}.svg?style=flat-square`} />
+                            <ImageGitHub
+                                url={`release/${data.github}/all.svg?style=flat-square`}
+                                isRounded
+                            />
+                            <ImageGitHub
+                                url={`license/${data.github}.svg?style=flat-square`}
+                                isRounded
+                            />
                             <ImageGitHub
                                 url={`stars/${data.github}.svg?style=social&label=Stars`}
                             />

--- a/website/src/templates/universe.js
+++ b/website/src/templates/universe.js
@@ -195,7 +195,7 @@ const SpaCyVersion = ({ version }) => {
     ))
 }
 
-const ImageGitHub = ({ url, isRounded }) => (
+const ImageGitHub = ({ url, isRounded, title }) => (
     // eslint-disable-next-line @next/next/no-img-element
     <img
         style={{
@@ -204,7 +204,7 @@ const ImageGitHub = ({ url, isRounded }) => (
             verticalAlign: 'middle',
         }}
         src={`https://img.shields.io/github/${url}`}
-        alt=""
+        alt={`${title} on GitHub`}
     />
 )
 
@@ -217,14 +217,17 @@ const Project = ({ data, components }) => (
                     {data.github && (
                         <Link to={`https://github.com/${data.github}`} hidden>
                             <ImageGitHub
+                                title={data.title || data.id}
                                 url={`release/${data.github}/all.svg?style=flat-square`}
                                 isRounded
                             />
                             <ImageGitHub
+                                title={data.title || data.id}
                                 url={`license/${data.github}.svg?style=flat-square`}
                                 isRounded
                             />
                             <ImageGitHub
+                                title={data.title || data.id}
                                 url={`stars/${data.github}.svg?style=social&label=Stars`}
                             />
                         </Link>

--- a/website/src/templates/universe.js
+++ b/website/src/templates/universe.js
@@ -195,6 +195,19 @@ const SpaCyVersion = ({ version }) => {
     ))
 }
 
+const ImageGitHub = ({ url }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+        style={{
+            borderRadius: '1em',
+            marginRight: '0.5rem',
+            verticalAlign: 'middle',
+        }}
+        src={`https://img.shields.io/github/${url}`}
+        alt=""
+    />
+)
+
 const Project = ({ data, components }) => (
     <>
         <Title title={data.title || data.id} teaser={data.slogan} image={data.thumb}>
@@ -203,23 +216,11 @@ const Project = ({ data, components }) => (
                     {data.spacy_version && <SpaCyVersion version={data.spacy_version} />}
                     {data.github && (
                         <Link to={`https://github.com/${data.github}`} hidden>
-                            {[
-                                `release/${data.github}/all.svg?style=flat-square`,
-                                `license/${data.github}.svg?style=flat-square`,
-                                `stars/${data.github}.svg?style=social&label=Stars`,
-                            ].map((url, i) => (
-                                // eslint-disable-next-line @next/next/no-img-element
-                                <img
-                                    style={{
-                                        borderRadius: '1em',
-                                        marginRight: '0.5rem',
-                                        verticalAlign: 'middle',
-                                    }}
-                                    key={i}
-                                    src={`https://img.shields.io/github/${url}`}
-                                    alt=""
-                                />
-                            ))}
+                            <ImageGitHub url={`release/${data.github}/all.svg?style=flat-square`} />
+                            <ImageGitHub url={`license/${data.github}.svg?style=flat-square`} />
+                            <ImageGitHub
+                                url={`stars/${data.github}.svg?style=social&label=Stars`}
+                            />
                         </Link>
                     )}
                 </p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
This fixes a rendering issue with the GitHub badge on Universe projects.

### Before (with cut of cornerns)
<img width="170" alt="GitHub Badge before with cut of corners" src="https://user-images.githubusercontent.com/4087618/214253659-bc9403c6-71e1-4298-bf1f-a48e8012c088.png">

### After
<img width="172" alt="GitHub Badge after" src="https://user-images.githubusercontent.com/4087618/214253672-af4facac-a9a7-4a2e-929d-8f0b308cfff6.png">


### Types of change
- Website frontend improvements

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.