### PR TITLE
Fix aria hidden element

### DIFF
--- a/website/src/components/accordion.js
+++ b/website/src/components/accordion.js
@@ -33,7 +33,7 @@ export default function Accordion({ title, id, expanded = false, spaced = false,
                                 <Link
                                     to={`#${id}`}
                                     className={classes.anchor}
-                                    hidden
+                                    noLinkLayout
                                     onClick={(event) => event.stopPropagation()}
                                 >
                                     &para;

--- a/website/src/components/card.js
+++ b/website/src/components/card.js
@@ -10,7 +10,7 @@ export default function Card({ title, to, image, header, small, onClick, childre
     return (
         <div className={classNames(classes.root, { [classes.small]: !!small })}>
             {header && (
-                <Link to={to} onClick={onClick} hidden>
+                <Link to={to} onClick={onClick} noLinkLayout>
                     {header}
                 </Link>
             )}
@@ -23,13 +23,13 @@ export default function Card({ title, to, image, header, small, onClick, childre
                         </div>
                     )}
                     {title && (
-                        <Link to={to} onClick={onClick} hidden>
+                        <Link to={to} onClick={onClick} noLinkLayout>
                             {title}
                         </Link>
                     )}
                 </H5>
             )}
-            <Link to={to} onClick={onClick} hidden>
+            <Link to={to} onClick={onClick} noLinkLayout>
                 {children}
             </Link>
         </div>

--- a/website/src/components/code.js
+++ b/website/src/components/code.js
@@ -363,7 +363,7 @@ const JuniperWrapper = ({ title, lang, children }) => {
                 {juniperTitle}
                 <span className={classes['juniper-meta']}>
                     spaCy v{binderVersion} &middot; Python 3 &middot; via{' '}
-                    <Link to="https://mybinder.org/" hidden>
+                    <Link to="https://mybinder.org/" noLinkLayout>
                         Binder
                     </Link>
                 </span>

--- a/website/src/components/embed.js
+++ b/website/src/components/embed.js
@@ -88,7 +88,7 @@ const Image = ({ src, alt, title, href, ...props }) => {
     const markdownComponents = { code: InlineCode, p: Fragment, a: Link }
     return (
         <figure className="gatsby-resp-image-figure">
-            <Link className={linkClassNames} href={href ?? src} hidden forceExternal>
+            <Link className={linkClassNames} href={href ?? src} noLinkLayout forceExternal>
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img className={classes.image} src={src} alt={alt} width={650} height="auto" />
             </Link>

--- a/website/src/components/footer.js
+++ b/website/src/components/footer.js
@@ -21,7 +21,7 @@ export default function Footer({ wide = false }) {
                             <li className={classes.label}>{label}</li>
                             {items.map(({ text, url }, j) => (
                                 <li key={j}>
-                                    <Link to={url} hidden>
+                                    <Link to={url} noLinkLayout>
                                         {text}
                                     </Link>
                                 </li>
@@ -42,14 +42,14 @@ export default function Footer({ wide = false }) {
             <div className={classNames(classes.content, classes.copy)}>
                 <span>
                     &copy; 2016-{new Date().getFullYear()}{' '}
-                    <Link to={companyUrl} hidden>
+                    <Link to={companyUrl} noLinkLayout>
                         {company}
                     </Link>
                 </span>
-                <Link to={companyUrl} aria-label={company} hidden className={classes.logo}>
+                <Link to={companyUrl} aria-label={company} noLinkLayout className={classes.logo}>
                     <SVG src={explosionLogo.src} width={45} height={45} />
                 </Link>
-                <Link to={`${companyUrl}/legal`} hidden>
+                <Link to={`${companyUrl}/legal`} noLinkLayout>
                     Legal / Imprint
                 </Link>
             </div>

--- a/website/src/components/github.js
+++ b/website/src/components/github.js
@@ -42,7 +42,7 @@ const GitHubCode = ({ url, lang, errorMsg = defaultErrorMsg, className }) => {
     return (
         <>
             <header className={classes.header}>
-                <Link to={url} hidden>
+                <Link to={url} noLinkLayout>
                     <Icon name="github" width={16} inline />
                     <code
                         className={classNames(classes['inline-code'], classes['inline-code-dark'])}

--- a/website/src/components/landing.js
+++ b/website/src/components/landing.js
@@ -124,7 +124,7 @@ export const LandingBanner = ({
                                 <span className={classes['label']}>{label}</span>
                             </div>
                         )}
-                        <Link to={to} hidden>
+                        <Link to={to} noLinkLayout>
                             {title}
                         </Link>
                     </Heading>

--- a/website/src/components/link.js
+++ b/website/src/components/link.js
@@ -26,7 +26,7 @@ export default function Link({
     to,
     href,
     onClick,
-    hidden = false,
+    noLinkLayout = false,
     hideIcon = false,
     ws = false,
     forceExternal = false,
@@ -36,10 +36,10 @@ export default function Link({
     const dest = to || href
     const external = forceExternal || /(http(s?)):\/\//gi.test(dest)
     const icon = getIcon(dest)
-    const withIcon = !hidden && !hideIcon && !!icon && !isImage(children)
+    const withIcon = !noLinkLayout && !hideIcon && !!icon && !isImage(children)
     const sourceWithText = withIcon && isString(children)
     const linkClassNames = classNames(classes.root, className, {
-        [classes.noLinkLayout]: hidden,
+        [classes['no-link-layout']]: noLinkLayout,
         [classes.nowrap]: (withIcon && !sourceWithText) || icon === 'network',
         [classes['with-icon']]: withIcon,
     })
@@ -97,7 +97,7 @@ Link.propTypes = {
     to: PropTypes.string,
     href: PropTypes.string,
     onClick: PropTypes.func,
-    hidden: PropTypes.bool,
+    noLinkLayout: PropTypes.bool,
     hideIcon: PropTypes.bool,
     ws: PropTypes.bool,
     className: PropTypes.string,

--- a/website/src/components/link.js
+++ b/website/src/components/link.js
@@ -39,7 +39,7 @@ export default function Link({
     const withIcon = !hidden && !hideIcon && !!icon && !isImage(children)
     const sourceWithText = withIcon && isString(children)
     const linkClassNames = classNames(classes.root, className, {
-        [classes.hidden]: hidden,
+        [classes.noLinkLayout]: hidden,
         [classes.nowrap]: (withIcon && !sourceWithText) || icon === 'network',
         [classes['with-icon']]: withIcon,
     })

--- a/website/src/components/navigation.js
+++ b/website/src/components/navigation.js
@@ -30,7 +30,7 @@ const NavigationDropdown = ({ items = [], section }) => {
 
 export default function Navigation({ title, items = [], section, search, alert, children }) {
     const logo = (
-        <Link to="/" aria-label={title} hidden>
+        <Link to="/" aria-label={title} noLinkLayout>
             <h1 className={classes.title}>{title}</h1>
             <SVG src={logoSpacy.src} className={classes.logo} width={300} height={96} />
         </Link>
@@ -57,7 +57,7 @@ export default function Navigation({ title, items = [], section, search, alert, 
                         })
                         return (
                             <li key={i} className={itemClassNames}>
-                                <Link to={url} tabIndex={isActive ? '-1' : null} hidden>
+                                <Link to={url} tabIndex={isActive ? '-1' : null} noLinkLayout>
                                     {text}
                                 </Link>
                             </li>

--- a/website/src/components/readnext.js
+++ b/website/src/components/readnext.js
@@ -9,15 +9,15 @@ import classes from '../styles/readnext.module.sass'
 
 export default function ReadNext({ title, to }) {
     return (
-        <div className={classes.root}>
-            <Link to={to} noLinkLayout>
+        <Link to={to} noLinkLayout className={classes.root}>
+            <span>
                 <Label>Read next</Label>
                 {title}
-            </Link>
-            <Link to={to} noLinkLayout className={classes.icon}>
+            </span>
+            <span className={classes.icon}>
                 <Icon name="arrowright" aria-hidden="true" />
-            </Link>
-        </div>
+            </span>
+        </Link>
     )
 }
 

--- a/website/src/components/readnext.js
+++ b/website/src/components/readnext.js
@@ -10,11 +10,11 @@ import classes from '../styles/readnext.module.sass'
 export default function ReadNext({ title, to }) {
     return (
         <div className={classes.root}>
-            <Link to={to} hidden>
+            <Link to={to} noLinkLayout>
                 <Label>Read next</Label>
                 {title}
             </Link>
-            <Link to={to} hidden className={classes.icon} aria-hidden="true">
+            <Link to={to} noLinkLayout className={classes.icon} aria-hidden="true">
                 <Icon name="arrowright" />
             </Link>
         </div>

--- a/website/src/components/readnext.js
+++ b/website/src/components/readnext.js
@@ -14,8 +14,8 @@ export default function ReadNext({ title, to }) {
                 <Label>Read next</Label>
                 {title}
             </Link>
-            <Link to={to} noLinkLayout className={classes.icon} aria-hidden="true">
-                <Icon name="arrowright" />
+            <Link to={to} noLinkLayout className={classes.icon}>
+                <Icon name="arrowright" aria-hidden="true" />
             </Link>
         </div>
     )

--- a/website/src/styles/link.module.sass
+++ b/website/src/styles/link.module.sass
@@ -7,7 +7,7 @@
     &:hover
         color: var(--color-theme-dark)
 
-.hidden
+.no-link-layout
     border: none
     color: inherit
 

--- a/website/src/templates/universe.js
+++ b/website/src/templates/universe.js
@@ -93,14 +93,14 @@ const UniverseContent = ({ content = [], categories, theme, pageContext, mdxComp
                                     )
                                     return cover ? (
                                         <p key={id}>
-                                            <Link key={id} to={url} hidden>
+                                            <Link key={id} to={url} noLinkLayout>
                                                 {/* eslint-disable-next-line @next/next/no-img-element */}
                                                 <img src={cover} alt={title || id} />
                                             </Link>
                                         </p>
                                     ) : data.id === 'videos' ? (
                                         <div>
-                                            <Link key={id} to={url} hidden>
+                                            <Link key={id} to={url} noLinkLayout>
                                                 {header}
                                                 <H5>{title}</H5>
                                             </Link>
@@ -202,7 +202,7 @@ const Project = ({ data, components }) => (
                 <p>
                     {data.spacy_version && <SpaCyVersion version={data.spacy_version} />}
                     {data.github && (
-                        <Link to={`https://github.com/${data.github}`} hidden>
+                        <Link to={`https://github.com/${data.github}`} noLinkLayout>
                             {[
                                 `release/${data.github}/all.svg?style=flat-square`,
                                 `license/${data.github}.svg?style=flat-square`,
@@ -293,7 +293,7 @@ const Project = ({ data, components }) => (
                             {data.author_links && data.author_links.twitter && (
                                 <Link
                                     to={`https://twitter.com/${data.author_links.twitter}`}
-                                    hidden
+                                    noLinkLayout
                                     ws
                                 >
                                     <Icon width={18} name="twitter" inline />
@@ -302,14 +302,14 @@ const Project = ({ data, components }) => (
                             {data.author_links && data.author_links.github && (
                                 <Link
                                     to={`https://github.com/${data.author_links.github}`}
-                                    hidden
+                                    noLinkLayout
                                     ws
                                 >
                                     <Icon width={18} name="github" inline />
                                 </Link>
                             )}
                             {data.author_links && data.author_links.website && (
-                                <Link to={data.author_links.website} hidden ws>
+                                <Link to={data.author_links.website} noLinkLayout ws>
                                     <Icon width={18} name="website" inline />
                                 </Link>
                             )}

--- a/website/src/widgets/styleguide.js
+++ b/website/src/widgets/styleguide.js
@@ -76,7 +76,7 @@ export const Patterns = () => {
                     <Label>{name}</Label>
                     <span style={textStyle}>
                         by
-                        <Link to="https://dribbble.com/kemal" hidden style={linkStyle} ws>
+                        <Link to="https://dribbble.com/kemal" noLinkLayout style={linkStyle} ws>
                             Kemal Şanlı
                         </Link>
                     </span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
This renames the prop `hidden` on `Link` components to `noLinkLayout` to make it more clear what the prop is doing.

Main change is fixing two accessibility issues with the _"Read next"_ link. (`website/src/components/readnext.js`)

- removing a double link
- removing a link that only contains an element with `aria-hidden`

### Types of change
- Website frontend improvements

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
