### PR TITLE
Remove zoom locking

### DIFF
--- a/website/pages/_app.tsx
+++ b/website/pages/_app.tsx
@@ -17,7 +17,7 @@ export default function App({ Component, pageProps }: AppProps) {
                 <link rel="manifest" href="/manifest.webmanifest" />
                 <meta
                     name="viewport"
-                    content="width=device-width, initial-scale=1.0, minimum-scale=1 maximum-scale=1.0, user-scalable=0, shrink-to-fit=no, viewport-fit=cover"
+                    content="width=device-width, initial-scale=1.0, minimum-scale=1, maximum-scale=1.0, user-scalable=0, shrink-to-fit=no, viewport-fit=cover"
                 />
                 <meta name="theme-color" content="#09a3d5" />
                 <link rel="apple-touch-icon" sizes="192x192" href="/icons/icon-192x192.png" />

--- a/website/pages/_app.tsx
+++ b/website/pages/_app.tsx
@@ -17,7 +17,7 @@ export default function App({ Component, pageProps }: AppProps) {
                 <link rel="manifest" href="/manifest.webmanifest" />
                 <meta
                     name="viewport"
-                    content="width=device-width, initial-scale=1.0, minimum-scale=1, maximum-scale=1.0, user-scalable=0, shrink-to-fit=no, viewport-fit=cover"
+                    content="width=device-width, initial-scale=1.0, minimum-scale=1, maximum-scale=5.0, shrink-to-fit=no, viewport-fit=cover"
                 />
                 <meta name="theme-color" content="#09a3d5" />
                 <link rel="apple-touch-icon" sizes="192x192" href="/icons/icon-192x192.png" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
This removes the zoom locking from `head`, which allows users with visual impairment to zoom the page (especially on mobile devices). This was flagged by Lighthouse. The value is already ignored by iOS anyway for these a11y reasons.

### Types of change
- Website accessibility improvements

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.