### PR TITLE
Fix navigation alert

### DIFF
--- a/website/src/templates/index.js
+++ b/website/src/templates/index.js
@@ -58,7 +58,7 @@ const AlertSpace = ({ nightly, legacy }) => {
 }
 
 const navAlert = (
-    <Link to="/usage/v3-5" hidden>
+    <Link to="/usage/v3-5" noLinkLayout>
         <strong>💥 Out now:</strong> spaCy v3.5
     </Link>
 )


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title. -->

## Description
Fixes a regression introduced in #12163, which hid the alert in the navigation

### Before 
![Screenshot 2023-01-24 at 16 19 46](https://user-images.githubusercontent.com/4087618/214333750-f364dfb6-cf5e-4691-89c3-17767b4c758f.png)


### After (as well as before #12163)
![Screenshot 2023-01-24 at 16 19 58](https://user-images.githubusercontent.com/4087618/214333820-8ee748bc-0037-45c9-870b-0a74be5daf74.png)

### Types of change
- Fix missing navigation alert in docs
 
## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
