### PR TITLE
Fix broken syntax for type annotations

### DIFF
--- a/website/docs/api/cli.mdx
+++ b/website/docs/api/cli.mdx
@@ -270,10 +270,10 @@ $ python -m spacy convert [input_file] [output_dir] [--converter] [--file-type] 
 | `--file-type`, `-t`       | Type of file to create. Either `spacy` (default) for binary [`DocBin`](/api/docbin) data or `json` for v2.x JSON format. ~~str (option)~~ |
 | `--n-sents`, `-n`         | Number of sentences per document. Supported for: `conll`, `conllu`, `iob`, `ner` ~~int (option)~~                                         |
 | `--seg-sents`, `-s`       | Segment sentences. Supported for: `conll`, `ner` ~~bool (flag)~~                                                                          |
-| `--base`, `-b`, `--model` | Trained spaCy pipeline for sentence segmentation to use as base (for `--seg-sents`). ~~Optional[str](option)~~                            |
+| `--base`, `-b`, `--model` | Trained spaCy pipeline for sentence segmentation to use as base (for `--seg-sents`). ~~Optional[str] (option)~~                           |
 | `--morphology`, `-m`      | Enable appending morphology to tags. Supported for: `conllu` ~~bool (flag)~~                                                              |
 | `--merge-subtokens`, `-T` | Merge CoNLL-U subtokens ~~bool (flag)~~                                                                                                   |
-| `--ner-map`, `-nm`        | NER tag mapping (as JSON-encoded dict of entity types). Supported for: `conllu` ~~Optional[Path](option)~~                                |
+| `--ner-map`, `-nm`        | NER tag mapping (as JSON-encoded dict of entity types). Supported for: `conllu` ~~Optional[Path] (option)~~                               |
 | `--lang`, `-l`            | Language code (if tokenizer required). ~~Optional[str] \(option)~~                                                                        |
 | `--concatenate`, `-C`     | Concatenate output to a single file ~~bool (flag)~~                                                                                       |
 | `--help`, `-h`            | Show help message and available arguments. ~~bool (flag)~~                                                                                |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
Fixes a regression after #12058 where some type annotations where interpreted as links by MDX, which then broke the component handling them.

As far as I can tell, those are the only places affected by that.

![Screenshot 2023-01-24 at 18 01 15](https://user-images.githubusercontent.com/4087618/214358649-7d342720-d374-4ea3-b49e-0d30862d969d.png)


### Types of change
- Fix for regression in docs
- 
## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
