### PR TITLE
Fix regression with links in prompts

### DIFF
--- a/website/src/components/code.js
+++ b/website/src/components/code.js
@@ -235,7 +235,7 @@ const handlePromot = ({ lineFlat, prompt }) => {
                     <Fragment key={j}>
                         {j !== 0 && ' '}
                         <span className={itemClassNames}>
-                            <OptionalLink hidden hideIcon to={url}>
+                            <OptionalLink noLinkLayout hideIcon to={url}>
                                 {text}
                             </OptionalLink>
                         </span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
Fixes a similar regression as in #12169, introduced in #12163


### Before

![Screenshot 2023-01-24 at 18 20 49](https://user-images.githubusercontent.com/4087618/214363233-577620da-86f7-4bd7-991a-71243249a7ad.png)

### After (as well as before #12163)

![Screenshot 2023-01-24 at 18 20 54](https://user-images.githubusercontent.com/4087618/214363237-7741e16c-364c-4530-b138-c2402d87607d.png)

### Types of change
- Fixes docs regression
 
## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
