### PR TITLE
Add `aria-label` to quickstart widget

### DIFF
--- a/website/src/components/quickstart.js
+++ b/website/src/components/quickstart.js
@@ -251,7 +251,12 @@ const Quickstart = ({
                     </menu>
                 </pre>
                 {showCopy && (
-                    <textarea ref={copyAreaRef} className={classes['copy-area']} rows={1} />
+                    <textarea
+                        ref={copyAreaRef}
+                        className={classes['copy-area']}
+                        rows={1}
+                        aria-label={`Interactive code example for ${title}`}
+                    />
                 )}
             </div>
         </Container>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
Adds a label to the Quickstart widget for screenreader support.
### Types of change
- Accessibility improvement for docs

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
