### PR TITLE
Don't re-download installed models

### DIFF
--- a/.github/azure-steps.yml
+++ b/.github/azure-steps.yml
@@ -63,6 +63,11 @@ steps:
 #      python -W error -c "import ca_core_news_sm; nlp = ca_core_news_sm.load(); doc=nlp('test')"
 #    displayName: 'Test no warnings on load (#11713)'
 #    condition: eq(variables['python_version'], '3.8')
+#
+#  - script: |
+#      python -m spacy download ca_core_news_sm 2>&1 | grep -q skipping
+#    displayName: 'Test skip re-download (#12188)'
+#    condition: eq(variables['python_version'], '3.8')
 
   - script: |
       python -m spacy convert extra/example_data/ner_example_data/ner-token-per-line-conll2003.json .

--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -3,11 +3,12 @@ import requests
 import sys
 from wasabi import msg
 import typer
+import srsly
 
 from ._util import app, Arg, Opt, WHEEL_SUFFIX, SDIST_SUFFIX
 from .. import about
 from ..util import is_package, get_minor_version, run_command
-from ..util import is_prerelease_version
+from ..util import is_prerelease_version, get_installed_models, get_package_path
 
 
 @app.command(
@@ -62,6 +63,16 @@ def download(
         model_name = model
         compatibility = get_compatibility()
         version = get_version(model_name, compatibility)
+
+    # If we already have this version installed, skip downloading
+    installed = get_installed_models()
+    if model_name in installed:
+        model_path = get_package_path(model_name)
+        meta_path = model_path / "meta.json"
+        meta = srsly.read_json(meta_path)
+        if meta["version"] == version:
+            msg.warn(f"{model_name} v{version} already installed, skipping")
+            return
 
     filename = get_model_filename(model_name, version, sdist)
 

--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -3,12 +3,12 @@ import requests
 import sys
 from wasabi import msg
 import typer
-import srsly
+import importlib.metadata as importlib_metadata
 
 from ._util import app, Arg, Opt, WHEEL_SUFFIX, SDIST_SUFFIX
 from .. import about
 from ..util import is_package, get_minor_version, run_command
-from ..util import is_prerelease_version, get_installed_models, get_package_path
+from ..util import is_prerelease_version, get_installed_models
 
 
 @app.command(
@@ -67,10 +67,8 @@ def download(
     # If we already have this version installed, skip downloading
     installed = get_installed_models()
     if model_name in installed:
-        model_path = get_package_path(model_name)
-        meta_path = model_path / "meta.json"
-        meta = srsly.read_json(meta_path)
-        if meta["version"] == version:
+        installed_version = importlib_metadata.version(model_name)
+        if installed_version == version:
             msg.warn(f"{model_name} v{version} already installed, skipping")
             return
 

--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -3,12 +3,12 @@ import requests
 import sys
 from wasabi import msg
 import typer
-import importlib.metadata as importlib_metadata
 
 from ._util import app, Arg, Opt, WHEEL_SUFFIX, SDIST_SUFFIX
 from .. import about
 from ..util import is_package, get_minor_version, run_command
 from ..util import is_prerelease_version, get_installed_models
+from ..util import get_package_version
 
 
 @app.command(
@@ -67,7 +67,7 @@ def download(
     # If we already have this version installed, skip downloading
     installed = get_installed_models()
     if model_name in installed:
-        installed_version = importlib_metadata.version(model_name)
+        installed_version = get_package_version(model_name)
         if installed_version == version:
             msg.warn(f"{model_name} v{version} already installed, skipping")
             return


### PR DESCRIPTION
## Description

When downloading a model, this checks if the same version of the same model is already installed. If it is then the download is skipped.

This is necessary because pip uses the final download URL for its caching feature, but because of the way models are hosted on Github, their URLs change every few minutes, so pip is unable to cache downloads correctly. This is basically a workaround for that caching issue. 


### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
minor enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
