### PR TITLE
Add displaCy data structures to docs

### DIFF
--- a/spacy/displacy/render.py
+++ b/spacy/displacy/render.py
@@ -300,6 +300,8 @@ class DependencyRenderer:
                 self.lang = settings.get("lang", DEFAULT_LANG)
             render_id = f"{id_prefix}-{i}"
             svg = self.render_svg(render_id, p["words"], p["arcs"])
+            if p.get("title"):
+                svg = TPL_TITLE.format(title=p.get("title")) + svg
             rendered.append(svg)
         if page:
             content = "".join([TPL_FIGURE.format(content=svg) for svg in rendered])

--- a/spacy/tests/test_displacy.py
+++ b/spacy/tests/test_displacy.py
@@ -336,6 +336,77 @@ def test_displacy_render_wrapper(en_vocab):
     displacy.set_render_wrapper(lambda html: html)
 
 
+def test_displacy_render_manual_dep():
+    """Test displacy.render with manual data for dep style"""
+    parsed_dep = {
+        "words": [
+            {"text": "This", "tag": "DT"},
+            {"text": "is", "tag": "VBZ"},
+            {"text": "a", "tag": "DT"},
+            {"text": "sentence", "tag": "NN"},
+        ],
+        "arcs": [
+            {"start": 0, "end": 1, "label": "nsubj", "dir": "left"},
+            {"start": 2, "end": 3, "label": "det", "dir": "left"},
+            {"start": 1, "end": 3, "label": "attr", "dir": "right"},
+        ],
+    }
+    html = displacy.render([parsed_dep], style="dep", manual=True)
+    for word in parsed_dep["words"]:
+        assert word["text"] in html
+        assert word["tag"] in html
+
+
+def test_displacy_render_manual_ent():
+    """Test displacy.render with manual data for ent style"""
+    parsed_ents = [
+        {
+            "text": "But Google is starting from behind.",
+            "ents": [{"start": 4, "end": 10, "label": "ORG"}],
+        },
+        {
+            "text": "But Google is starting from behind.",
+            "ents": [{"start": -100, "end": 100, "label": "COMPANY"}],
+            "title": "Title",
+        },
+    ]
+
+    html = displacy.render(parsed_ents, style="ent", manual=True)
+    for parsed_ent in parsed_ents:
+        assert parsed_ent["ents"][0]["label"] in html
+        if "title" in parsed_ent:
+            assert parsed_ent["title"] in html
+
+
+def test_displacy_render_manual_span():
+    """Test displacy.render with manual data for span style"""
+    parsed_spans = [
+        {
+            "text": "Welcome to the Bank of China.",
+            "spans": [
+                {"start_token": 3, "end_token": 6, "label": "ORG"},
+                {"start_token": 5, "end_token": 6, "label": "GPE"},
+            ],
+            "tokens": ["Welcome", "to", "the", "Bank", "of", "China", "."],
+        },
+        {
+            "text": "Welcome to the Bank of China.",
+            "spans": [
+                {"start_token": 3, "end_token": 6, "label": "ORG"},
+                {"start_token": 5, "end_token": 6, "label": "GPE"},
+            ],
+            "tokens": ["Welcome", "to", "the", "Bank", "of", "China", "."],
+            "title": "Title",
+        },
+    ]
+
+    html = displacy.render(parsed_spans, style="span", manual=True)
+    for parsed_span in parsed_spans:
+        assert parsed_span["spans"][0]["label"] in html
+        if "title" in parsed_span:
+            assert parsed_span["title"] in html
+
+
 def test_displacy_options_case():
     ents = ["foo", "BAR"]
     colors = {"FOO": "red", "bar": "green"}

--- a/spacy/tests/test_displacy.py
+++ b/spacy/tests/test_displacy.py
@@ -350,6 +350,7 @@ def test_displacy_render_manual_dep():
             {"start": 2, "end": 3, "label": "det", "dir": "left"},
             {"start": 1, "end": 3, "label": "attr", "dir": "right"},
         ],
+        "title": "Title",
     }
     html = displacy.render([parsed_dep], style="dep", manual=True)
     for word in parsed_dep["words"]:

--- a/website/docs/api/top-level.mdx
+++ b/website/docs/api/top-level.mdx
@@ -343,7 +343,7 @@ use with the `manual=True` argument in `displacy.render`.
 ### Visualizer data structures {id="displacy_structures"}
 
 You can use displaCy's data format to manually render data. This can be useful
-if you want to visualize output from other libaries. You can find examples of
+if you want to visualize output from other libraries. You can find examples of
 displaCy's different data formats below.
 
 > #### DEP example data structure

--- a/website/docs/api/top-level.mdx
+++ b/website/docs/api/top-level.mdx
@@ -397,11 +397,10 @@ displaCy's different data formats below.
 > #### ENT example data structure
 >
 > ```json
->  {
->    "text": "But Google is starting from behind.",
->    "ents": [{"start": 4, "end": 10, "label": "ORG"}],
->    "title": None
->  }
+> {
+>   "text": "But Google is starting from behind.",
+>   "ents": [{ "start": 4, "end": 10, "label": "ORG" }]
+> }
 > ```
 
 #### Named Entity Recognition data structure {id="structure-ent"}
@@ -410,20 +409,20 @@ displaCy's different data formats below.
 | -------------- | ------------------------------------------------------------------------------------------- |
 | `text`         | String representation of the document text. ~~str~~                                         |
 | `ents`         | List of dictionaries describing entities (see structure below). ~~List[Dict[str, Any]]~~    |
-| `title`        | Title of the visualization. ~~str~~                                                         |
 | _Optional_     |                                                                                             |
+| `title`        | Title of the visualization. ~~Optional[str]~~                                               |
 | `settings`     | Entity Visualizer options (see [here](/api/top-level#displacy_options)). ~~Dict[str, Any]~~ |
 
 <Accordion title="Ents data structure">
 
-| Dictionary Key | Description                                         |
-| -------------- | --------------------------------------------------- |
-| `start`        | The index of the first token of the entity. ~~int~~ |
-| `end`          | The index of the last token of the entity. ~~int~~  |
-| `label`        | Label attached to the entity. ~~str~~               |
-| _Optional_     |                                                     |
-| `kb_id`        | `KnowledgeBase` ID. ~~str~~                         |
-| `kb_url`       | `KnowledgeBase` URL. ~~str~~                        |
+| Dictionary Key | Description                                                            |
+| -------------- | ---------------------------------------------------------------------- |
+| `start`        | The index of the first character of the entity. ~~int~~                |
+| `end`          | The index of the last character of the entity. (not inclusive) ~~int~~ |
+| `label`        | Label attached to the entity. ~~str~~                                  |
+| _Optional_     |                                                                        |
+| `kb_id`        | `KnowledgeBase` ID. ~~str~~                                            |
+| `kb_url`       | `KnowledgeBase` URL. ~~str~~                                           |
 
 </Accordion>
 
@@ -446,17 +445,15 @@ displaCy's different data formats below.
 | -------------- | ----------------------------------------------------------------------------------------- |
 | `text`         | String representation of the document text. ~~str~~                                       |
 | `spans`        | List of dictionaries describing spans (see structure below). ~~List[Dict[str, Any]]~~     |
-| `title`        | Title of the visualization. ~~str~~                                                       |
 | `tokens`       | List of word tokens. ~~List[str]~~                                                        |
 | _Optional_     |                                                                                           |
+| `title`        | Title of the visualization. ~~Optional[str]~~                                             |
 | `settings`     | Span Visualizer options (see [here](/api/top-level#displacy_options)). ~~Dict[str, Any]~~ |
 
 <Accordion title="Spans data structure">
 
 | Dictionary Key | Description                                                   |
 | -------------- | ------------------------------------------------------------- |
-| `start`        | The index of the first token of the span. ~~int~~             |
-| `end`          | The index of the last token of the span. ~~int~~              |
 | `start_token`  | The index of the first token of the span in `tokens`. ~~int~~ |
 | `end_token`    | The index of the last token of the span in `tokens`. ~~int~~  |
 | `label`        | Label attached to the span. ~~str~~                           |

--- a/website/docs/api/top-level.mdx
+++ b/website/docs/api/top-level.mdx
@@ -342,12 +342,11 @@ use with the `manual=True` argument in `displacy.render`.
 
 ### Visualizer data structures {id="displacy_structures"}
 
-You can also use displaCy's data format to manually render data. This can be
-useful if you want to visualize output from other libaries. You can find
-examples of displaCy's data format on the
-[usage page](/usage/visualizers#manual-usage).
+You can use displaCy's data format to manually render data. This can be useful
+if you want to visualize output from other libaries. You can find examples of
+displaCy's different data formats below.
 
-> #### DEP data structure
+> #### DEP example data structure
 >
 > ```json
 > {
@@ -367,34 +366,34 @@ examples of displaCy's data format on the
 
 #### Dependency Visualizer data structure {id="structure-dep"}
 
-| Dictionary Key | Description                               |
-| -------------- | ----------------------------------------- |
-| `words`        | List of words. ~~List[Dict[str, Any]]~~   |
-| `arcs`         | List of arcs. ~~List[Dict[str, Any]]~~    |
-| `settings`     | Visualization options. ~~Dict[str, Any]~~ |
+| Dictionary Key | Description                                                                                                 |
+| -------------- | ----------------------------------------------------------------------------------------------------------- |
+| `words`        | List of dictionaries describing a word token (see structure below). ~~List[Dict[str, Any]]~~                |
+| `arcs`         | List of dictionaries describing the relations between words (see structure below). ~~List[Dict[str, Any]]~~ |
+| `settings`     | Dependency Visualizer options (see [here](/api/top-level#displacy_options)). ~~Dict[str, Any]~~             |
 
-<Accordion title="Word data structure">
+<Accordion title="Words data structure">
 
-| Dictionary Key | Description                          |
-| -------------- | ------------------------------------ |
-| `text`         | The string of the word. ~~str~~      |
-| `tag`          | Dependency tag of the word. ~~str~~  |
-| `lemma`        | Lemma of the word. ~~Optional[str]~~ |
-
-</Accordion>
-
-<Accordion title="Arc data structure">
-
-| Dictionary Key | Description                                     |
-| -------------- | ----------------------------------------------- |
-| `start`        | Start index. ~~int~~                            |
-| `end`          | End index. ~~int~~                              |
-| `label`        | Label of the arc. ~~str~~                       |
-| `dir`          | Direction of the arc (`left`, `right`). ~~str~~ |
+| Dictionary Key | Description                              |
+| -------------- | ---------------------------------------- |
+| `text`         | Text content of the word. ~~str~~        |
+| `tag`          | Fine-grained part-of-speech. ~~str~~     |
+| `lemma`        | Base form of the word. ~~Optional[str]~~ |
 
 </Accordion>
 
-> #### ENT data structure
+<Accordion title="Arcs data structure">
+
+| Dictionary Key | Description                                          |
+| -------------- | ---------------------------------------------------- |
+| `start`        | The index of the starting token. ~~int~~             |
+| `end`          | The index of the ending token. ~~int~~               |
+| `label`        | The type of dependency relation. ~~str~~             |
+| `dir`          | Direction of the relation (`left`, `right`). ~~str~~ |
+
+</Accordion>
+
+> #### ENT example data structure
 >
 > ```json
 >  {
@@ -406,26 +405,26 @@ examples of displaCy's data format on the
 
 #### Named Entity Recognition data structure {id="structure-ent"}
 
-| Dictionary Key | Description                                |
-| -------------- | ------------------------------------------ |
-| `text`         | Text of the document. ~~str~~              |
-| `ents`         | List of entities. ~~List[Dict[str, Any]]~~ |
-| `title`        | Title of the visualization. ~~str~~        |
-| `settings`     | Visualization options. ~~Dict[str, Any]~~  |
+| Dictionary Key | Description                                                                                 |
+| -------------- | ------------------------------------------------------------------------------------------- |
+| `text`         | String representation of the document text. ~~str~~                                         |
+| `ents`         | List of dictionaries describing entities (see structure below). ~~List[Dict[str, Any]]~~    |
+| `title`        | Title of the visualization. ~~str~~                                                         |
+| `settings`     | Entity Visualizer options (see [here](/api/top-level#displacy_options)). ~~Dict[str, Any]~~ |
 
-<Accordion title="Entity data structure">
+<Accordion title="Ents data structure">
 
-| Dictionary Key | Description                  |
-| -------------- | ---------------------------- |
-| `start`        | Start index. ~~int~~         |
-| `end`          | End index. ~~int~~           |
-| `label`        | Label of the entity. ~~str~~ |
-| `kb_id`        | Knowledgebase ID. ~~str~~    |
-| `kb_url`       | Knowledgebase URL. ~~str~~   |
+| Dictionary Key | Description                                         |
+| -------------- | --------------------------------------------------- |
+| `start`        | The index of the first token of the entity. ~~int~~ |
+| `end`          | The index of the last token of the entity. ~~int~~  |
+| `label`        | Label attached to the entity. ~~str~~               |
+| `kb_id`        | `KnowledgeBase` ID. ~~str~~                         |
+| `kb_url`       | `KnowledgeBase` URL. ~~str~~                        |
 
 </Accordion>
 
-> #### SPAN data structure
+> #### SPAN example data structure
 >
 > ```json
 > {
@@ -440,25 +439,25 @@ examples of displaCy's data format on the
 
 #### Span Classification data structure {id="structure-span"}
 
-| Dictionary Key | Description                               |
-| -------------- | ----------------------------------------- |
-| `text`         | Text of the document. ~~str~~             |
-| `spans`        | List of spans. ~~List[Dict[str, Any]]~~   |
-| `title`        | Title of the visualization. ~~str~~       |
-| `tokens`       | List of tokens. ~~List[str]~~             |
-| `settings`     | Visualization options. ~~Dict[str, Any]~~ |
+| Dictionary Key | Description                                                                               |
+| -------------- | ----------------------------------------------------------------------------------------- |
+| `text`         | String representation of the document text. ~~str~~                                       |
+| `spans`        | List of dictionaries describing spans (see structure below). ~~List[Dict[str, Any]]~~     |
+| `title`        | Title of the visualization. ~~str~~                                                       |
+| `tokens`       | List of word tokens. ~~List[str]~~                                                        |
+| `settings`     | Span Visualizer options (see [here](/api/top-level#displacy_options)). ~~Dict[str, Any]~~ |
 
-<Accordion title="Span data structure">
+<Accordion title="Spans data structure">
 
-| Dictionary Key | Description                |
-| -------------- | -------------------------- |
-| `start`        | Start index. ~~int~~       |
-| `end`          | End index. ~~int~~         |
-| `start_token`  | Start token. ~~int~~       |
-| `end_token`    | End token. ~~int~~         |
-| `label`        | Label of the span. ~~str~~ |
-| `kb_id`        | Knowledgebase ID. ~~str~~  |
-| `kb_url`       | Knowledgebase URL. ~~str~~ |
+| Dictionary Key | Description                                                   |
+| -------------- | ------------------------------------------------------------- |
+| `start`        | The index of the first token of the span. ~~int~~             |
+| `end`          | The index of the last token of the span. ~~int~~              |
+| `start_token`  | The index of the first token of the span in `tokens`. ~~int~~ |
+| `end_token`    | The index of the last token of the span in `tokens`. ~~int~~  |
+| `label`        | Label attached to the span. ~~str~~                           |
+| `kb_id`        | `KnowledgeBase` ID. ~~str~~                                   |
+| `kb_url`       | `KnowledgeBase` URL. ~~str~~                                  |
 
 </Accordion>
 

--- a/website/docs/api/top-level.mdx
+++ b/website/docs/api/top-level.mdx
@@ -371,6 +371,7 @@ displaCy's different data formats below.
 | `words`        | List of dictionaries describing a word token (see structure below). ~~List[Dict[str, Any]]~~                |
 | `arcs`         | List of dictionaries describing the relations between words (see structure below). ~~List[Dict[str, Any]]~~ |
 | _Optional_     |                                                                                                             |
+| `title`        | Title of the visualization. ~~Optional[str]~~                                                               |
 | `settings`     | Dependency Visualizer options (see [here](/api/top-level#displacy_options)). ~~Dict[str, Any]~~             |
 
 <Accordion title="Words data structure">

--- a/website/docs/api/top-level.mdx
+++ b/website/docs/api/top-level.mdx
@@ -370,6 +370,7 @@ displaCy's different data formats below.
 | -------------- | ----------------------------------------------------------------------------------------------------------- |
 | `words`        | List of dictionaries describing a word token (see structure below). ~~List[Dict[str, Any]]~~                |
 | `arcs`         | List of dictionaries describing the relations between words (see structure below). ~~List[Dict[str, Any]]~~ |
+| _Optional_     |                                                                                                             |
 | `settings`     | Dependency Visualizer options (see [here](/api/top-level#displacy_options)). ~~Dict[str, Any]~~             |
 
 <Accordion title="Words data structure">
@@ -410,6 +411,7 @@ displaCy's different data formats below.
 | `text`         | String representation of the document text. ~~str~~                                         |
 | `ents`         | List of dictionaries describing entities (see structure below). ~~List[Dict[str, Any]]~~    |
 | `title`        | Title of the visualization. ~~str~~                                                         |
+| _Optional_     |                                                                                             |
 | `settings`     | Entity Visualizer options (see [here](/api/top-level#displacy_options)). ~~Dict[str, Any]~~ |
 
 <Accordion title="Ents data structure">
@@ -419,6 +421,7 @@ displaCy's different data formats below.
 | `start`        | The index of the first token of the entity. ~~int~~ |
 | `end`          | The index of the last token of the entity. ~~int~~  |
 | `label`        | Label attached to the entity. ~~str~~               |
+| _Optional_     |                                                     |
 | `kb_id`        | `KnowledgeBase` ID. ~~str~~                         |
 | `kb_url`       | `KnowledgeBase` URL. ~~str~~                        |
 
@@ -445,6 +448,7 @@ displaCy's different data formats below.
 | `spans`        | List of dictionaries describing spans (see structure below). ~~List[Dict[str, Any]]~~     |
 | `title`        | Title of the visualization. ~~str~~                                                       |
 | `tokens`       | List of word tokens. ~~List[str]~~                                                        |
+| _Optional_     |                                                                                           |
 | `settings`     | Span Visualizer options (see [here](/api/top-level#displacy_options)). ~~Dict[str, Any]~~ |
 
 <Accordion title="Spans data structure">
@@ -456,6 +460,7 @@ displaCy's different data formats below.
 | `start_token`  | The index of the first token of the span in `tokens`. ~~int~~ |
 | `end_token`    | The index of the last token of the span in `tokens`. ~~int~~  |
 | `label`        | Label attached to the span. ~~str~~                           |
+| _Optional_     |                                                               |
 | `kb_id`        | `KnowledgeBase` ID. ~~str~~                                   |
 | `kb_url`       | `KnowledgeBase` URL. ~~str~~                                  |
 

--- a/website/docs/api/top-level.mdx
+++ b/website/docs/api/top-level.mdx
@@ -340,6 +340,128 @@ use with the `manual=True` argument in `displacy.render`.
 | `options`   | Span-specific visualisation options. ~~Dict[str, Any]~~             |
 | **RETURNS** | Generated entities keyed by text (original text) and ents. ~~dict~~ |
 
+### Visualizer data structures {id="displacy_structures"}
+
+You can also use displaCy's data format to manually render data. This can be
+useful if you want to visualize output from other libaries. You can find
+examples of displaCy's data format on the
+[usage page](/usage/visualizers#manual-usage).
+
+> #### DEP data structure
+>
+> ```json
+> {
+>   "words": [
+>     { "text": "This", "tag": "DT" },
+>     { "text": "is", "tag": "VBZ" },
+>     { "text": "a", "tag": "DT" },
+>     { "text": "sentence", "tag": "NN" }
+>   ],
+>   "arcs": [
+>     { "start": 0, "end": 1, "label": "nsubj", "dir": "left" },
+>     { "start": 2, "end": 3, "label": "det", "dir": "left" },
+>     { "start": 1, "end": 3, "label": "attr", "dir": "right" }
+>   ]
+> }
+> ```
+
+#### Dependency Visualizer data structure {id="structure-dep"}
+
+| Dictionary Key | Description                               |
+| -------------- | ----------------------------------------- |
+| `words`        | List of words. ~~List[Dict[str, Any]]~~   |
+| `arcs`         | List of arcs. ~~List[Dict[str, Any]]~~    |
+| `settings`     | Visualization options. ~~Dict[str, Any]~~ |
+
+<Accordion title="Word data structure">
+
+| Dictionary Key | Description                          |
+| -------------- | ------------------------------------ |
+| `text`         | The string of the word. ~~str~~      |
+| `tag`          | Dependency tag of the word. ~~str~~  |
+| `lemma`        | Lemma of the word. ~~Optional[str]~~ |
+
+</Accordion>
+
+<Accordion title="Arc data structure">
+
+| Dictionary Key | Description                                     |
+| -------------- | ----------------------------------------------- |
+| `start`        | Start index. ~~int~~                            |
+| `end`          | End index. ~~int~~                              |
+| `label`        | Label of the arc. ~~str~~                       |
+| `dir`          | Direction of the arc (`left`, `right`). ~~str~~ |
+
+</Accordion>
+
+> #### ENT data structure
+>
+> ```json
+>  {
+>    "text": "But Google is starting from behind.",
+>    "ents": [{"start": 4, "end": 10, "label": "ORG"}],
+>    "title": None
+>  }
+> ```
+
+#### Named Entity Recognition data structure {id="structure-ent"}
+
+| Dictionary Key | Description                                |
+| -------------- | ------------------------------------------ |
+| `text`         | Text of the document. ~~str~~              |
+| `ents`         | List of entities. ~~List[Dict[str, Any]]~~ |
+| `title`        | Title of the visualization. ~~str~~        |
+| `settings`     | Visualization options. ~~Dict[str, Any]~~  |
+
+<Accordion title="Entity data structure">
+
+| Dictionary Key | Description                  |
+| -------------- | ---------------------------- |
+| `start`        | Start index. ~~int~~         |
+| `end`          | End index. ~~int~~           |
+| `label`        | Label of the entity. ~~str~~ |
+| `kb_id`        | Knowledgebase ID. ~~str~~    |
+| `kb_url`       | Knowledgebase URL. ~~str~~   |
+
+</Accordion>
+
+> #### SPAN data structure
+>
+> ```json
+> {
+>   "text": "Welcome to the Bank of China.",
+>   "spans": [
+>     { "start_token": 3, "end_token": 6, "label": "ORG" },
+>     { "start_token": 5, "end_token": 6, "label": "GPE" }
+>   ],
+>   "tokens": ["Welcome", "to", "the", "Bank", "of", "China", "."]
+> }
+> ```
+
+#### Span Classification data structure {id="structure-span"}
+
+| Dictionary Key | Description                               |
+| -------------- | ----------------------------------------- |
+| `text`         | Text of the document. ~~str~~             |
+| `spans`        | List of spans. ~~List[Dict[str, Any]]~~   |
+| `title`        | Title of the visualization. ~~str~~       |
+| `tokens`       | List of tokens. ~~List[str]~~             |
+| `settings`     | Visualization options. ~~Dict[str, Any]~~ |
+
+<Accordion title="Span data structure">
+
+| Dictionary Key | Description                |
+| -------------- | -------------------------- |
+| `start`        | Start index. ~~int~~       |
+| `end`          | End index. ~~int~~         |
+| `start_token`  | Start token. ~~int~~       |
+| `end_token`    | End token. ~~int~~         |
+| `label`        | Label of the span. ~~str~~ |
+| `kb_id`        | Knowledgebase ID. ~~str~~  |
+| `kb_url`       | Knowledgebase URL. ~~str~~ |
+
+</Accordion>
+
 ### Visualizer options {id="displacy_options"}
 
 The `options` argument lets you specify additional settings for each visualizer.

--- a/website/docs/usage/visualizers.mdx
+++ b/website/docs/usage/visualizers.mdx
@@ -344,7 +344,8 @@ or
 [SyntaxNet](https://github.com/tensorflow/models/tree/master/research/syntaxnet).
 If you set `manual=True` on either `render()` or `serve()`, you can pass in data
 in displaCy's format as a dictionary (instead of `Doc` objects). There are
-helper functions for converting `Doc` objects to displaCy's format for use with
+helper functions for converting `Doc` objects to
+[displaCy's format](/api/top-level#displacy_structures) for use with
 `manual=True`: [`displacy.parse_deps`](/api/top-level#displacy.parse_deps),
 [`displacy.parse_ents`](/api/top-level#displacy.parse_ents), and
 [`displacy.parse_spans`](/api/top-level#displacy.parse_spans).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

This PR adds a new section to the `api/top-level#functions` documentation for displaCy: `Visualizer data structures`. The section shows examples of the three data structures (`Dependency Parsing`, `Entity Recognition`, and `Span Classification`) and their types formatted as tables. To reduce cluttering, the nested dictionary types are formatted as a collapsable table.

The idea for this PR initially came from this discussion https://github.com/explosion/spaCy/pull/10950
The types are based on [this gist](https://gist.github.com/pmbaumgartner/85b3a0256131e86fbdd78a8b4060d361) by @pmbaumgartner  

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Documentation

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
