### PR TITLE
Fix FUZZY operator definition

### DIFF
--- a/website/docs/usage/rule-based-matching.mdx
+++ b/website/docs/usage/rule-based-matching.mdx
@@ -384,10 +384,10 @@ the more specific attributes `FUZZY1`..`FUZZY9` you can specify the maximum
 allowed edit distance directly.
 
 ```python
-# Match lowercase with fuzzy matching (allows 3 edits)
+# Match lowercase with fuzzy matching (allows 2 edits by default)
 pattern = [{"LOWER": {"FUZZY": "definitely"}}]
 
-# Match custom attribute values with fuzzy matching (allows 3 edits)
+# Match custom attribute values with fuzzy matching (allows 2 edits by default)
 pattern = [{"_": {"country": {"FUZZY": "Kyrgyzstan"}}}]
 
 # Match with exact Levenshtein edit distance limits (allows 4 edits)

--- a/website/docs/usage/v3-5.mdx
+++ b/website/docs/usage/v3-5.mdx
@@ -70,13 +70,13 @@ distance of 2 and up to 30% of the pattern string length. `FUZZY1`..`FUZZY9` can
 be used to specify the exact number of allowed edits.
 
 ```python
-# Match lowercase with fuzzy matching (allows up to 2 edits)
+# Match lowercase with fuzzy matching (allows 2 edits by default)
 pattern = [{"LOWER": {"FUZZY": "definitely"}}]
 
-# Match custom attribute values with fuzzy matching (allows up to 2 edits)
+# Match custom attribute values with fuzzy matching (allows 2 edits by default)
 pattern = [{"_": {"country": {"FUZZY": "Kyrgyzstan"}}}]
 
-# Match with exact Levenshtein edit distance limits (allows up to 4 edits)
+# Match with exact Levenshtein edit distance limits (allows 4 edits)
 pattern = [{"_": {"country": {"FUZZY4": "Kyrgyzstan"}}}]
 ```
 

--- a/website/docs/usage/v3-5.mdx
+++ b/website/docs/usage/v3-5.mdx
@@ -70,10 +70,10 @@ distance of 2 and up to 30% of the pattern string length. `FUZZY1`..`FUZZY9` can
 be used to specify the exact number of allowed edits.
 
 ```python
-# Match lowercase with fuzzy matching (allows up to 3 edits)
+# Match lowercase with fuzzy matching (allows up to 2 edits)
 pattern = [{"LOWER": {"FUZZY": "definitely"}}]
 
-# Match custom attribute values with fuzzy matching (allows up to 3 edits)
+# Match custom attribute values with fuzzy matching (allows up to 2 edits)
 pattern = [{"_": {"country": {"FUZZY": "Kyrgyzstan"}}}]
 
 # Match with exact Levenshtein edit distance limits (allows up to 4 edits)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
The default length of the FUZZY operator is 2 and not 3. 

Example:
````
pattern = [{"LOWER": {"FUZZY": "kitten"}}]
matcher.add("KITTEN", [pattern])
doc = nlp("kitten -> sitten -> sittin -> sitting")
matches = matcher(doc)
````

Returns matches on 'kitten' (0 edits),' sitten' (1 edit), and 'sittin' (2 edits).

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Bug fix
## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [X] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
