### PR TITLE
Make Korean tokenizer easier to use

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -120,7 +120,7 @@ ja =
     sudachipy>=0.5.2,!=0.6.1
     sudachidict_core>=20211220
 ko =
-    natto-py>=0.9.0
+    python-mecab-ko>=1.3.3
 th =
     pythainlp>=2.0
 

--- a/spacy/tests/conftest.py
+++ b/spacy/tests/conftest.py
@@ -239,7 +239,7 @@ def hsb_tokenizer():
 
 @pytest.fixture(scope="session")
 def ko_tokenizer():
-    pytest.importorskip("natto")
+    pytest.importorskip("mecab")
     return get_lang_class("ko")().tokenizer
 
 

--- a/spacy/tests/lang/ko/test_lemmatization.py
+++ b/spacy/tests/lang/ko/test_lemmatization.py
@@ -2,7 +2,14 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "word,lemma", [("새로운", "새롭"), ("빨간", "빨갛"), ("클수록", "크"), ("뭡니까", "뭣"), ("됐다", "되")]
+    "word,lemma",
+    [
+        ("새로운", "새롭+ᆫ"),
+        ("빨간", "빨갛+ᆫ"),
+        ("클수록", "크+ᆯ수록"),
+        ("뭡니까", "뭣+이+ᄇ니까"),
+        ("됐다", "되+었"),
+    ],
 )
 def test_ko_lemmatizer_assigns(ko_tokenizer, word, lemma):
     test_lemma = ko_tokenizer(word)[0].lemma_

--- a/spacy/tests/lang/ko/test_tokenizer.py
+++ b/spacy/tests/lang/ko/test_tokenizer.py
@@ -8,10 +8,7 @@ TOKENIZER_TESTS = [("서울 타워 근처에 살고 있습니다.", "서울 타�
 TAG_TESTS = [("서울 타워 근처에 살고 있습니다.",
               "NNP NNG NNG JKB VV EC VX EF SF"),
              ("영등포구에 있는 맛집 좀 알려주세요.",
-              "NNP JKB VV ETM NNG MAG VV VX EP SF")]
-
-FULL_TAG_TESTS = [("영등포구에 있는 맛집 좀 알려주세요.",
-                   "NNP JKB VV ETM NNG MAG VV+EC VX EP+EF SF")]
+              "NNP JKB VV ETM NNG MAG VV+EC VX EP+EF SF")]
 
 POS_TESTS = [("서울 타워 근처에 살고 있습니다.",
               "PROPN NOUN NOUN ADP VERB X AUX X PUNCT"),
@@ -29,12 +26,6 @@ def test_ko_tokenizer(ko_tokenizer, text, expected_tokens):
 @pytest.mark.parametrize("text,expected_tags", TAG_TESTS)
 def test_ko_tokenizer_tags(ko_tokenizer, text, expected_tags):
     tags = [token.tag_ for token in ko_tokenizer(text)]
-    assert tags == expected_tags.split()
-
-
-@pytest.mark.parametrize("text,expected_tags", FULL_TAG_TESTS)
-def test_ko_tokenizer_full_tags(ko_tokenizer, text, expected_tags):
-    tags = ko_tokenizer(text).user_data["full_tags"]
     assert tags == expected_tags.split()
 
 

--- a/spacy/tests/package/test_requirements.py
+++ b/spacy/tests/package/test_requirements.py
@@ -22,7 +22,7 @@ def test_build_dependencies():
     # ignore language-specific packages that shouldn't be installed by all
     libs_ignore_setup = [
         "fugashi",
-        "natto-py",
+        "python-mecab-ko",
         "pythainlp",
         "sudachipy",
         "sudachidict_core",

--- a/website/docs/usage/models.mdx
+++ b/website/docs/usage/models.mdx
@@ -272,9 +272,7 @@ used for training the current [Japanese pipelines](/models/ja).
 
 The default MeCab-based Korean tokenizer requires:
 
-- [mecab-ko](https://bitbucket.org/eunjeon/mecab-ko/src/master/README.md)
-- [mecab-ko-dic](https://bitbucket.org/eunjeon/mecab-ko-dic)
-- [natto-py](https://github.com/buruzaemon/natto-py)
+- [python-mecab-ko](https://github.com/jonghwanhyeon/python-mecab-ko)
 
 For some Korean datasets and tasks, the
 [rule-based tokenizer](/usage/linguistic-features#tokenization) is better-suited

--- a/website/meta/languages.json
+++ b/website/meta/languages.json
@@ -198,16 +198,8 @@
             "name": "Korean",
             "dependencies": [
                 {
-                    "name": "mecab-ko",
-                    "url": "https://bitbucket.org/eunjeon/mecab-ko/src/master/README.md"
-                },
-                {
-                    "name": "mecab-ko-dic",
-                    "url": "https://bitbucket.org/eunjeon/mecab-ko-dic"
-                },
-                {
-                    "name": "natto-py",
-                    "url": "https://github.com/buruzaemon/natto-py"
+                    "name": "python-mecab-ko",
+                    "url": "https://github.com/jonghwanhyeon/python-mecab-ko"
                 }
             ],
             "example": "이것은 문장입니다.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Currently to use the Korean tokenizer, [mecab-ko](https://bitbucket.org/eunjeon/mecab-ko/src/master/README.md) and [mecab-ko-dic](https://bitbucket.org/eunjeon/mecab-ko-dic) must be installed separately outside of python, which causes considerable inconvenience in many cases.

This change replaces [mecab-ko](https://bitbucket.org/eunjeon/mecab-ko/src/master/README.md), [mecab-ko-dic](https://bitbucket.org/eunjeon/mecab-ko-dic) and [natto-py](https://github.com/buruzaemon/natto-py) with [python-mecab-ko](https://github.com/jonghwanhyeon/python-mecab-ko), a python binding for mecab-ko, which doesn't require installing additional dependencies.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
* enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
