### PR TITLE
Allow setting last=False when adding a component

### DIFF
--- a/spacy/language.py
+++ b/spacy/language.py
@@ -743,6 +743,7 @@ class Language:
         """Add a component to the processing pipeline. Valid components are
         callables that take a `Doc` object, modify it and return it. Only one
         of before/after/first/last can be set. Default behaviour is "last".
+        If "last" is set to False, then the default is "first".
 
         factory_name (str): Name of the component factory.
         name (str): Name of pipeline component. Overwrites existing
@@ -816,10 +817,10 @@ class Language:
             raise ValueError(
                 Errors.E006.format(args=all_args, opts=self.component_names)
             )
-        if last or not any(value is not None for value in [first, before, after]):
-            return len(self._components)
-        elif first:
+        if first or last is False:
             return 0
+        elif last or not any(value is not None for value in [first, before, after]):
+            return len(self._components)
         elif isinstance(before, str):
             if before not in self.component_names:
                 raise ValueError(

--- a/spacy/tests/pipeline/test_pipe_methods.py
+++ b/spacy/tests/pipeline/test_pipe_methods.py
@@ -188,6 +188,14 @@ def test_add_pipe_last(nlp, name1, name2):
     assert nlp.pipeline[-1][0] == name1
 
 
+@pytest.mark.parametrize("name1,name2", [("parser", "lambda_pipe")])
+def test_add_pipe_not_last(nlp, name1, name2):
+    Language.component("new_pipe2", func=lambda doc: doc)
+    nlp.add_pipe("new_pipe2", name=name2)
+    nlp.add_pipe("new_pipe", name=name1, last=False)
+    assert nlp.pipeline[-1][0] != name1
+
+
 def test_cant_add_pipe_first_and_last(nlp):
     with pytest.raises(ValueError):
         nlp.add_pipe("new_pipe", first=True, last=True)


### PR DESCRIPTION

## Description
When a component is added, the default order is "last". However, when you specify specifically that `last=False`, arguably the pipeline should honour that. Here, I propose to set it as the first component in that case. 

### Types of change
feature

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
