### PR TITLE
fix types

### DIFF
--- a/spacy/lexeme.pyi
+++ b/spacy/lexeme.pyi
@@ -25,7 +25,8 @@ class Lexeme:
     def orth_(self) -> str: ...
     @property
     def text(self) -> str: ...
-    lower: str
+    orth: int
+    lower: int
     norm: int
     shape: int
     prefix: int

--- a/spacy/lexeme.pyx
+++ b/spacy/lexeme.pyx
@@ -199,7 +199,7 @@ cdef class Lexeme:
         return self.orth_
 
     property lower:
-        """RETURNS (str): Lowercase form of the lexeme."""
+        """RETURNS (uint64): Lowercase form of the lexeme."""
         def __get__(self):
             return self.c.lower
 


### PR DESCRIPTION

## Description
- add `orth` as property to `lexeme.pyi`
- fix type of `lower` which is an `int` (correctly documented at https://spacy.io/api/lexeme but incorrect in the doc string of `lexeme.pyx`

### Types of change
type fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
