### PR TITLE
Fix EL failure with sentence-crossing entities

### DIFF
--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -476,26 +476,7 @@ class EntityLinker(TrainablePipe):
                 for j, ent in enumerate(ent_batch):
                     assert hasattr(ent, "sents")
                     sents = list(ent.sents)
-                    # Note: the last sentence associated with an sentence-crossing entity isn't complete. E. g. if you
-                    # have "Mahler's Symphony No. 8 was beautiful", the entity being "No. 8", ent.sents would be:
-                    #   1. "Mahler's Symphony No."
-                    #   2. "8"
-                    # whereas doc.sents would be:
-                    #   1. "Mahler's Symphony No."
-                    #   2. "8 was beautiful"
-                    # This makes it tricky to receive the last sentence by indexing doc.sents - hence we use an offset
-                    # to determine sent_indices[1].
-                    sent_indices = (
-                        (
-                            sentences.index(sents[0]),
-                            sentences.index(sents[0]) + len(sents) - 1,
-                        )
-                        if len(sents) > 1
-                        else (
-                            sentences.index(ent.sent),
-                            sentences.index(ent.sent),
-                        )
-                    )
+                    sent_indices = (sentences.index(sents[0]), sentences.index(sents[-1]))
                     assert all([si >= 0 for si in sent_indices])
 
                     if self.incl_context:

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -484,10 +484,13 @@ class EntityLinker(TrainablePipe):
                     #   2. "8 was beautiful"
                     # This makes it tricky to receive the last sentence by indexing doc.sents - hence we use an offset
                     # to determine sent_indices[1].
-                    sent_indices = (
-                        sentences.index(sents[0]),
-                        sentences.index(sents[0]) + len(sents) - 1,
-                    )
+                    if len(sents) > 1:
+                        sent_indices = (
+                            sentences.index(sents[0]),
+                            sentences.index(sents[0]) + len(sents) - 1,
+                        )
+                    else:
+                        sent_indices = (sentences.index(ent.sent), sentences.index(ent.sent))
                     assert all([si >= 0 for si in sent_indices])
 
                     if self.incl_context:

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -474,18 +474,29 @@ class EntityLinker(TrainablePipe):
 
                 # Looping through each entity in batch (TODO: rewrite)
                 for j, ent in enumerate(ent_batch):
-                    sent_index = sentences.index(ent.sent)
-                    assert sent_index >= 0
+                    sents = list(ent.sents)
+                    # Note: the last sentence associated with an sentence-crossing entity isn't complete. E. g. if you
+                    # have "Mahler's Symphony No. 8 was beautiful", the entity being "No. 8", ent.sents would be:
+                    #   1. "Mahler's Symphony No."
+                    #   2. "8"
+                    # whereas doc.sents would be:
+                    #   1. "Mahler's Symphony No."
+                    #   2. "8 was beautiful"
+                    # This makes it tricky to receive the last sentence by indexing doc.sents - hence we use an offset
+                    # to determine sent_indices[1].
+                    sent_indices = (sentences.index(sents[0]), sentences.index(sents[0]) + len(sents) - 1)
+                    assert all([si >= 0 for si in sent_indices])
 
                     if self.incl_context:
                         # get n_neighbour sentences, clipped to the length of the document
-                        start_sentence = max(0, sent_index - self.n_sents)
+                        start_sentence = max(0, sent_indices[0] - self.n_sents)
                         end_sentence = min(
-                            len(sentences) - 1, sent_index + self.n_sents
+                            len(sentences) - 1, sent_indices[1] + self.n_sents
                         )
                         start_token = sentences[start_sentence].start
                         end_token = sentences[end_sentence].end
                         sent_doc = doc[start_token:end_token].as_doc()
+
                         # currently, the context is the same for each entity in a sentence (should be refined)
                         sentence_encoding = self.model.predict([sent_doc])[0]
                         sentence_encoding_t = sentence_encoding.T

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -474,6 +474,7 @@ class EntityLinker(TrainablePipe):
 
                 # Looping through each entity in batch (TODO: rewrite)
                 for j, ent in enumerate(ent_batch):
+                    assert hasattr(ent, "sents")
                     sents = list(ent.sents)
                     # Note: the last sentence associated with an sentence-crossing entity isn't complete. E. g. if you
                     # have "Mahler's Symphony No. 8 was beautiful", the entity being "No. 8", ent.sents would be:

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -476,8 +476,11 @@ class EntityLinker(TrainablePipe):
                 for j, ent in enumerate(ent_batch):
                     assert hasattr(ent, "sents")
                     sents = list(ent.sents)
-                    sent_indices = (sentences.index(sents[0]), sentences.index(sents[-1]))
-                    assert all([si >= 0 for si in sent_indices])
+                    sent_indices = (
+                        sentences.index(sents[0]),
+                        sentences.index(sents[-1]),
+                    )
+                    assert sent_indices[-1] >= sent_indices[0] >= 0
 
                     if self.incl_context:
                         # get n_neighbour sentences, clipped to the length of the document

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -490,7 +490,10 @@ class EntityLinker(TrainablePipe):
                             sentences.index(sents[0]) + len(sents) - 1,
                         )
                     else:
-                        sent_indices = (sentences.index(ent.sent), sentences.index(ent.sent))
+                        sent_indices = (
+                            sentences.index(ent.sent),
+                            sentences.index(ent.sent),
+                        )
                     assert all([si >= 0 for si in sent_indices])
 
                     if self.incl_context:

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -484,16 +484,13 @@ class EntityLinker(TrainablePipe):
                     #   2. "8 was beautiful"
                     # This makes it tricky to receive the last sentence by indexing doc.sents - hence we use an offset
                     # to determine sent_indices[1].
-                    if len(sents) > 1:
-                        sent_indices = (
-                            sentences.index(sents[0]),
-                            sentences.index(sents[0]) + len(sents) - 1,
-                        )
-                    else:
-                        sent_indices = (
-                            sentences.index(ent.sent),
-                            sentences.index(ent.sent),
-                        )
+                    sent_indices = (
+                        sentences.index(sents[0]),
+                        sentences.index(sents[0]) + len(sents) - 1,
+                    ) if len(sents) > 1 else (
+                        sentences.index(ent.sent),
+                        sentences.index(ent.sent),
+                    )
                     assert all([si >= 0 for si in sent_indices])
 
                     if self.incl_context:

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -485,11 +485,15 @@ class EntityLinker(TrainablePipe):
                     # This makes it tricky to receive the last sentence by indexing doc.sents - hence we use an offset
                     # to determine sent_indices[1].
                     sent_indices = (
-                        sentences.index(sents[0]),
-                        sentences.index(sents[0]) + len(sents) - 1,
-                    ) if len(sents) > 1 else (
-                        sentences.index(ent.sent),
-                        sentences.index(ent.sent),
+                        (
+                            sentences.index(sents[0]),
+                            sentences.index(sents[0]) + len(sents) - 1,
+                        )
+                        if len(sents) > 1
+                        else (
+                            sentences.index(ent.sent),
+                            sentences.index(ent.sent),
+                        )
                     )
                     assert all([si >= 0 for si in sent_indices])
 

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -484,7 +484,10 @@ class EntityLinker(TrainablePipe):
                     #   2. "8 was beautiful"
                     # This makes it tricky to receive the last sentence by indexing doc.sents - hence we use an offset
                     # to determine sent_indices[1].
-                    sent_indices = (sentences.index(sents[0]), sentences.index(sents[0]) + len(sents) - 1)
+                    sent_indices = (
+                        sentences.index(sents[0]),
+                        sentences.index(sents[0]) + len(sents) - 1,
+                    )
                     assert all([si >= 0 for si in sent_indices])
 
                     if self.incl_context:

--- a/spacy/pipeline/entity_linker.py
+++ b/spacy/pipeline/entity_linker.py
@@ -480,7 +480,7 @@ class EntityLinker(TrainablePipe):
                         sentences.index(sents[0]),
                         sentences.index(sents[-1]),
                     )
-                    assert sent_indices[-1] >= sent_indices[0] >= 0
+                    assert sent_indices[1] >= sent_indices[0] >= 0
 
                     if self.incl_context:
                         # get n_neighbour sentences, clipped to the length of the document

--- a/spacy/tests/pipeline/test_entity_linker.py
+++ b/spacy/tests/pipeline/test_entity_linker.py
@@ -1220,6 +1220,7 @@ def test_span_maker_forward_with_empty():
     span_maker = build_span_maker()
     span_maker([doc1, doc2], False)
 
+
 @pytest.mark.skip(reason="Not fixed yet, expected to fail")
 def test_sentence_crossing_ents():
     """Tests if NEL crashes if entities cross sentence boundaries and the first associated sentence doesn't have an
@@ -1230,7 +1231,8 @@ def test_sentence_crossing_ents():
     nlp.add_pipe("sentencizer")
     text = "Mahler 's Symphony No. 8 was beautiful."
     entities = [(10, 24, "WORK")]
-    links = {(10, 24): {"Q7304": 0.0, "Q270853": 1.0},
+    links = {
+        (10, 24): {"Q7304": 0.0, "Q270853": 1.0},
     }
     sent_starts = [1, -1, 0, 0, 0, 1, 0, 0, 0]
     doc = nlp(text)
@@ -1261,4 +1263,3 @@ def test_sentence_crossing_ents():
 
     # This shouldn't crash.
     entity_linker.predict([example.reference])
-

--- a/spacy/tests/pipeline/test_entity_linker.py
+++ b/spacy/tests/pipeline/test_entity_linker.py
@@ -118,7 +118,6 @@ def test_sentence_crossing_ents(entity_in_first_sentence: bool):
     # Test that the NEL doesn't crash when an entity crosses a sentence boundary
     nlp = English()
     vector_length = 3
-    nlp.add_pipe("sentencizer")
     text = "Mahler 's Symphony No. 8 was beautiful."
     entities = [(10, 24, "WORK")]
     links = {(10, 24): {"Q7304": 0.0, "Q270853": 1.0}}

--- a/spacy/tests/pipeline/test_entity_linker.py
+++ b/spacy/tests/pipeline/test_entity_linker.py
@@ -1221,7 +1221,6 @@ def test_span_maker_forward_with_empty():
     span_maker([doc1, doc2], False)
 
 
-@pytest.mark.skip(reason="Not fixed yet, expected to fail")
 def test_sentence_crossing_ents():
     """Tests if NEL crashes if entities cross sentence boundaries and the first associated sentence doesn't have an
     entity.
@@ -1239,6 +1238,7 @@ def test_sentence_crossing_ents():
     example = Example.from_dict(
         doc, {"entities": entities, "links": links, "sent_starts": sent_starts}
     )
+    assert len(list(example.reference.ents[0].sents)) == 2
     train_examples = [example]
 
     def create_kb(vocab):

--- a/spacy/tests/pipeline/test_entity_linker.py
+++ b/spacy/tests/pipeline/test_entity_linker.py
@@ -150,15 +150,14 @@ def test_sentence_crossing_ents(entity_in_first_sentence: bool):
 
     # Create the Entity Linker component and add it to the pipeline
     entity_linker = nlp.add_pipe("entity_linker", last=True)
-    entity_linker.set_kb(create_kb)
+    entity_linker.set_kb(create_kb)  # type: ignore
     # train the NEL pipe
     optimizer = nlp.initialize(get_examples=lambda: train_examples)
     for i in range(2):
-        losses = {}
-        nlp.update(train_examples, sgd=optimizer, losses=losses)
+        nlp.update(train_examples, sgd=optimizer)
 
     # This shouldn't crash.
-    entity_linker.predict([example.reference])
+    entity_linker.predict([example.reference])  # type: ignore
 
 
 def test_no_entities():

--- a/spacy/tests/pipeline/test_entity_linker.py
+++ b/spacy/tests/pipeline/test_entity_linker.py
@@ -1,9 +1,9 @@
-from typing import Callable, Iterable, Dict, Any
+from typing import Callable, Iterable, Dict, Any, Tuple
 
 import pytest
 from numpy.testing import assert_equal
 
-from spacy import registry, util
+from spacy import registry, util, Language
 from spacy.attrs import ENT_KB_ID
 from spacy.compat import pickle
 from spacy.kb import Candidate, InMemoryLookupKB, get_candidates, KnowledgeBase
@@ -108,18 +108,24 @@ def test_issue7065():
 
 
 @pytest.mark.issue(7065)
-def test_issue7065_b():
+@pytest.mark.parametrize("entity_in_first_sentence", [True, False])
+def test_sentence_crossing_ents(entity_in_first_sentence: bool):
+    """Tests if NEL crashes if entities cross sentence boundaries and the first associated sentence doesn't have an
+    entity.
+    entity_in_prior_sentence (bool): Whether to include an entity in the first sentence associated with the
+    sentence-crossing entity.
+    """
     # Test that the NEL doesn't crash when an entity crosses a sentence boundary
     nlp = English()
     vector_length = 3
     nlp.add_pipe("sentencizer")
     text = "Mahler 's Symphony No. 8 was beautiful."
-    entities = [(0, 6, "PERSON"), (10, 24, "WORK")]
-    links = {
-        (0, 6): {"Q7304": 1.0, "Q270853": 0.0},
-        (10, 24): {"Q7304": 0.0, "Q270853": 1.0},
-    }
-    sent_starts = [1, -1, 0, 0, 0, 0, 0, 0, 0]
+    entities = [(10, 24, "WORK")]
+    links = {(10, 24): {"Q7304": 0.0, "Q270853": 1.0}}
+    if entity_in_first_sentence:
+        entities.append((0, 6, "PERSON"))
+        links[(0, 6)] = {"Q7304": 1.0, "Q270853": 0.0}
+    sent_starts = [1, -1, 0, 0, 0, 1, 0, 0, 0]
     doc = nlp(text)
     example = Example.from_dict(
         doc, {"entities": entities, "links": links, "sent_starts": sent_starts}
@@ -152,24 +158,8 @@ def test_issue7065_b():
         losses = {}
         nlp.update(train_examples, sgd=optimizer, losses=losses)
 
-    # Add a custom rule-based component to mimick NER
-    patterns = [
-        {"label": "PERSON", "pattern": [{"LOWER": "mahler"}]},
-        {
-            "label": "WORK",
-            "pattern": [
-                {"LOWER": "symphony"},
-                {"LOWER": "no"},
-                {"LOWER": "."},
-                {"LOWER": "8"},
-            ],
-        },
-    ]
-    ruler = nlp.add_pipe("entity_ruler", before="entity_linker")
-    ruler.add_patterns(patterns)
-    # test the trained model - this should not throw E148
-    doc = nlp(text)
-    assert doc
+    # This shouldn't crash.
+    entity_linker.predict([example.reference])
 
 
 def test_no_entities():
@@ -1219,47 +1209,3 @@ def test_span_maker_forward_with_empty():
     # just to get a model
     span_maker = build_span_maker()
     span_maker([doc1, doc2], False)
-
-
-def test_sentence_crossing_ents():
-    """Tests if NEL crashes if entities cross sentence boundaries and the first associated sentence doesn't have an
-    entity.
-    """
-    nlp = English()
-    vector_length = 3
-    nlp.add_pipe("sentencizer")
-    text = "Mahler 's Symphony No. 8 was beautiful."
-    entities = [(10, 24, "WORK")]
-    links = {
-        (10, 24): {"Q7304": 0.0, "Q270853": 1.0},
-    }
-    sent_starts = [1, -1, 0, 0, 0, 1, 0, 0, 0]
-    doc = nlp(text)
-    example = Example.from_dict(
-        doc, {"entities": entities, "links": links, "sent_starts": sent_starts}
-    )
-    assert len(list(example.reference.ents[0].sents)) == 2
-    train_examples = [example]
-
-    def create_kb(vocab):
-        # create artificial KB
-        mykb = InMemoryLookupKB(vocab, entity_vector_length=vector_length)
-        mykb.add_entity(entity="Q270853", freq=12, entity_vector=[9, 1, -7])
-        mykb.add_alias(
-            alias="No. 8",
-            entities=["Q270853"],
-            probabilities=[1.0],
-        )
-        return mykb
-
-    # Create the Entity Linker component and add it to the pipeline
-    entity_linker = nlp.add_pipe("entity_linker", last=True)
-    entity_linker.set_kb(create_kb)
-    # train the NEL pipe
-    optimizer = nlp.initialize(get_examples=lambda: train_examples)
-    for i in range(2):
-        losses = {}
-        nlp.update(train_examples, sgd=optimizer, losses=losses)
-
-    # This shouldn't crash.
-    entity_linker.predict([example.reference])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
`EntityLinker` crashes when `incl_context is True and `len(list(ent.sents)) > 1` and the first of the sentences in `ent.sents` (which is the one used in the context calculation) doesn't have an entity. 

This currently adds a test to reproduce this behavior. A fix will be added later - probably in this PR, hence this is marked as draft.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
