### PR TITLE
Fix sentence indexing bug in `Span.sents`

### DIFF
--- a/spacy/tests/doc/test_span.py
+++ b/spacy/tests/doc/test_span.py
@@ -7,7 +7,6 @@ from spacy.lang.en import English
 from spacy.tokens import Doc, Span, Token
 from spacy.vocab import Vocab
 from spacy.util import filter_spans
-from spacy.training import Example
 from thinc.api import get_current_ops
 
 from ..util import add_vecs_to_vocab

--- a/spacy/tests/doc/test_span.py
+++ b/spacy/tests/doc/test_span.py
@@ -7,6 +7,7 @@ from spacy.lang.en import English
 from spacy.tokens import Doc, Span, Token
 from spacy.vocab import Vocab
 from spacy.util import filter_spans
+from spacy.training import Example
 from thinc.api import get_current_ops
 
 from ..util import add_vecs_to_vocab
@@ -700,3 +701,18 @@ def test_span_group_copy(doc):
     assert len(doc.spans["test"]) == 3
     # check that the copy spans were not modified and this is an isolated doc
     assert len(doc_copy.spans["test"]) == 2
+
+
+def test_for_partial_ent_sents():
+    """Spans may be associated with multiple sentences. These .sents should always be complete, not partial, sentences,
+    which this tests for.
+    """
+    nlp = English()
+    text = ["Mahler's", "Symphony", "No.", "8", "was", "beautiful."]
+    doc = Doc(nlp.vocab, words=text, sent_starts=[1, 0, 0, 1, 0, 0])
+    doc.set_ents([Span(doc, 1, 4, "WORK")])
+    # The specified entity is associated with both sentences in this doc, so we expect all sentences in the doc to be
+    # equal to the sentences referenced in ent.sents.
+    for doc_sent, ent_sent in zip(doc.sents, doc.ents[0].sents):
+        assert doc_sent == ent_sent
+

--- a/spacy/tests/doc/test_span.py
+++ b/spacy/tests/doc/test_span.py
@@ -706,12 +706,13 @@ def test_for_partial_ent_sents():
     """Spans may be associated with multiple sentences. These .sents should always be complete, not partial, sentences,
     which this tests for.
     """
-    nlp = English()
-    text = ["Mahler's", "Symphony", "No.", "8", "was", "beautiful."]
-    doc = Doc(nlp.vocab, words=text, sent_starts=[1, 0, 0, 1, 0, 0])
+    doc = Doc(
+        English().vocab,
+        words=["Mahler's", "Symphony", "No.", "8", "was", "beautiful."],
+        sent_starts=[1, 0, 0, 1, 0, 0],
+    )
     doc.set_ents([Span(doc, 1, 4, "WORK")])
     # The specified entity is associated with both sentences in this doc, so we expect all sentences in the doc to be
     # equal to the sentences referenced in ent.sents.
     for doc_sent, ent_sent in zip(doc.sents, doc.ents[0].sents):
         assert doc_sent == ent_sent
-

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -460,9 +460,8 @@ cdef class Span:
                     start = i
                     if start >= self.end:
                         break
-            if start < self.end:
-                yield Span(self.doc, start, self.end)
-
+                elif i == self.doc.length - 1:
+                    yield Span(self.doc, start, i + 1)
 
     @property
     def ents(self):

--- a/spacy/tokens/span.pyx
+++ b/spacy/tokens/span.pyx
@@ -461,7 +461,7 @@ cdef class Span:
                     if start >= self.end:
                         break
                 elif i == self.doc.length - 1:
-                    yield Span(self.doc, start, i + 1)
+                    yield Span(self.doc, start, self.doc.length)
 
     @property
     def ents(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Spans may be associated with multiple sentences. These `.sents` should always be complete, not partial, sentences. The implementation of `Span.sents` in `main` however truncates the last sentence if the end of the executing `Span` instance isn't equal with the end of that sentence.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
