### PR TITLE
Add info that Vocab and StringStore are not static in docs

### DIFF
--- a/website/docs/api/stringstore.mdx
+++ b/website/docs/api/stringstore.mdx
@@ -10,8 +10,8 @@ different `StringStores`.
 
 <Infobox variant="warning">
 
-Please note that `StringStore` instances are not static. It increases in size as 
-texts with new tokens are processed.
+Note that a `StringStore` instance is not static. It increases in size as texts
+with new tokens are processed.
 
 </Infobox>
 

--- a/website/docs/api/stringstore.mdx
+++ b/website/docs/api/stringstore.mdx
@@ -8,6 +8,13 @@ Look up strings by 64-bit hashes. As of v2.0, spaCy uses hash values instead of
 integer IDs. This ensures that strings always map to the same ID, even from
 different `StringStores`.
 
+<Infobox variant="warning">
+
+Please note that the `StringStore` size is not static and increases as texts are
+processed and new tokens are seen.
+
+</Infobox>
+
 ## StringStore.\_\_init\_\_ {id="init",tag="method"}
 
 Create the `StringStore`.

--- a/website/docs/api/stringstore.mdx
+++ b/website/docs/api/stringstore.mdx
@@ -10,8 +10,8 @@ different `StringStores`.
 
 <Infobox variant="warning">
 
-Please note that the `StringStore` size is not static and increases as texts are
-processed and new tokens are seen.
+Please note that `StringStore` instances are not static. It increases in size as 
+texts with new tokens are processed.
 
 </Infobox>
 

--- a/website/docs/api/vocab.mdx
+++ b/website/docs/api/vocab.mdx
@@ -12,8 +12,8 @@ between `Doc` objects.
 
 <Infobox variant="warning">
 
-Please note that `Vocab` instances are not static. It increases in size as 
-texts with new tokens are processed.
+Note that a `Vocab` instance is not static. It increases in size as texts with
+new tokens are processed.
 
 </Infobox>
 

--- a/website/docs/api/vocab.mdx
+++ b/website/docs/api/vocab.mdx
@@ -10,6 +10,13 @@ The `Vocab` object provides a lookup table that allows you to access
 [`StringStore`](/api/stringstore). It also owns underlying C-data that is shared
 between `Doc` objects.
 
+<Infobox variant="warning">
+
+Please note that the `Vocab` size is not static and increases as texts are
+processed and new tokens are seen.
+
+</Infobox>
+
 ## Vocab.\_\_init\_\_ {id="init",tag="method"}
 
 Create the vocabulary.

--- a/website/docs/api/vocab.mdx
+++ b/website/docs/api/vocab.mdx
@@ -12,8 +12,8 @@ between `Doc` objects.
 
 <Infobox variant="warning">
 
-Please note that the `Vocab` size is not static and increases as texts are
-processed and new tokens are seen.
+Please note that `Vocab` instances are not static. It increases in size as 
+texts with new tokens are processed.
 
 </Infobox>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Adds a warning to the `Vocab` and `StringStore` docs that their size is not static and increases with every newly seen token. This adjustment resulted from this [discussion](https://github.com/explosion/spaCy/discussions/10015).

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Documentation

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
