### PR TITLE
add explanation about overwriting behaviour

### DIFF
--- a/website/docs/api/spancategorizer.mdx
+++ b/website/docs/api/spancategorizer.mdx
@@ -20,8 +20,8 @@ output class probabilities are independent for each class. However, if you need
 to predict at most one true class for a span, then use `spancat_singlelabel`. It
 uses a `Softmax` layer and treats the task as a multi-class problem.
 
-Predicted spans will be saved in a [`SpanGroup`](/api/spangroup) on the `doc.spans["spans_key"]`,
-where `"spans_key"` can be specified for the component.
+Predicted spans will be saved in a [`SpanGroup`](/api/spangroup) on the doc under `doc.spans[spans_key]`,
+where `spans_key` is a component config setting.
 Individual span scores are stored in `spangroup.attrs["scores"]`.
 
 ## Assigned Attributes {id="assigned-attributes"}

--- a/website/docs/api/spancategorizer.mdx
+++ b/website/docs/api/spancategorizer.mdx
@@ -31,8 +31,7 @@ Predictions will be saved to `Doc.spans[spans_key]` as a
 be saved in `SpanGroup.attrs["scores"]`.
 
 `spans_key` defaults to `"sc"`, but can be passed as a parameter.
-If spans are already stored in the provided `"spans_key"` the `spancat` component will
-overwrite the existing ones.
+The `spancat` component will overwrite any existing spans under the spans key `doc.spans[spans_key]`.
 
 | Location                               | Value                                                    |
 | -------------------------------------- | -------------------------------------------------------- |

--- a/website/docs/api/spancategorizer.mdx
+++ b/website/docs/api/spancategorizer.mdx
@@ -20,8 +20,8 @@ output class probabilities are independent for each class. However, if you need
 to predict at most one true class for a span, then use `spancat_singlelabel`. It
 uses a `Softmax` layer and treats the task as a multi-class problem.
 
-Predicted spans will be saved in a [`SpanGroup`](/api/spangroup) on the doc under `doc.spans[spans_key]`,
-where `spans_key` is a component config setting.
+Predicted spans will be saved in a [`SpanGroup`](/api/spangroup) on the doc
+under `doc.spans[spans_key]`, where `spans_key` is a component config setting.
 Individual span scores are stored in `doc.spans[spans_key].attrs["scores"]`.
 
 ## Assigned Attributes {id="assigned-attributes"}
@@ -30,8 +30,9 @@ Predictions will be saved to `Doc.spans[spans_key]` as a
 [`SpanGroup`](/api/spangroup). The scores for the spans in the `SpanGroup` will
 be saved in `SpanGroup.attrs["scores"]`.
 
-`spans_key` defaults to `"sc"`, but can be passed as a parameter.
-The `spancat` component will overwrite any existing spans under the spans key `doc.spans[spans_key]`.
+`spans_key` defaults to `"sc"`, but can be passed as a parameter. The `spancat`
+component will overwrite any existing spans under the spans key
+`doc.spans[spans_key]`.
 
 | Location                               | Value                                                    |
 | -------------------------------------- | -------------------------------------------------------- |

--- a/website/docs/api/spancategorizer.mdx
+++ b/website/docs/api/spancategorizer.mdx
@@ -20,8 +20,9 @@ output class probabilities are independent for each class. However, if you need
 to predict at most one true class for a span, then use `spancat_singlelabel`. It
 uses a `Softmax` layer and treats the task as a multi-class problem.
 
-Predicted spans will be saved in a [`SpanGroup`](/api/spangroup) on the doc.
-Individual span scores can be found in `spangroup.attrs["scores"]`.
+Predicted spans will be saved in a [`SpanGroup`](/api/spangroup) on the `doc.spans["spans_key"]`,
+where `"spans_key"` can be specified for the component.
+Individual span scores are stored in `spangroup.attrs["scores"]`.
 
 ## Assigned Attributes {id="assigned-attributes"}
 
@@ -30,6 +31,8 @@ Predictions will be saved to `Doc.spans[spans_key]` as a
 be saved in `SpanGroup.attrs["scores"]`.
 
 `spans_key` defaults to `"sc"`, but can be passed as a parameter.
+If spans are already stored in the provided `"spans_key"` the `spancat` component will
+overwrite the existing ones.
 
 | Location                               | Value                                                    |
 | -------------------------------------- | -------------------------------------------------------- |

--- a/website/docs/api/spancategorizer.mdx
+++ b/website/docs/api/spancategorizer.mdx
@@ -22,7 +22,7 @@ uses a `Softmax` layer and treats the task as a multi-class problem.
 
 Predicted spans will be saved in a [`SpanGroup`](/api/spangroup) on the doc under `doc.spans[spans_key]`,
 where `spans_key` is a component config setting.
-Individual span scores are stored in `spangroup.attrs["scores"]`.
+Individual span scores are stored in `doc.spans[spans_key].attrs["scores"]`.
 
 ## Assigned Attributes {id="assigned-attributes"}
 


### PR DESCRIPTION
Minor addition to the `spancat` docs to warn about overwriting spans.

## Description
Warn users about `spancat` overwriting existing `SpanGroup`.

### Types of change
Small documentation update. 

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
