### PR TITLE
corrected example code

### DIFF
--- a/website/docs/api/coref.mdx
+++ b/website/docs/api/coref.mdx
@@ -64,7 +64,7 @@ details on the architectures and their arguments and hyperparameters.
 > config={
 >     "model": DEFAULT_COREF_MODEL,
 >     "span_cluster_prefix": DEFAULT_CLUSTER_PREFIX,
-> },
+> }
 > nlp.add_pipe("experimental_coref", config=config)
 > ```
 


### PR DESCRIPTION


## Description
In the file `website/docs/api/coref.mdx` ,the comma in line 6 of example under subheading `Config and implementation {id="config”}` is unnecessary and generates error while executing code.
The link to colab notebook displaying the same: [link](https://colab.research.google.com/drive/1mVtfeKPXmDfh--iAFjKoYhqtNnthJWfj?usp=sharing)

### Types of change
change to the documentation
