### PR TITLE
Add spaCysee to Universe

### DIFF
--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -1,6 +1,33 @@
 {
     "resources": [
         {
+            "id": "spacysee",
+            "title": "spaCysee",
+            "slogan": "Visualize spaCy's Dependency Parsing, POS tagging, and morphological analysis",
+            "description": "A project that helps you visualize your spaCy docs in Jupyter notebooks. Each of the dependency tags, POS tags and morphological features are clickable. Clicking on a tag will bring up the relevant documentation for that tag.",
+            "github": "moxley01/spacysee",
+            "pip": "spacysee",
+            "code_example": [
+                "import spacy",
+                "from spacysee import render",
+                "",
+                "nlp = spacy.load('en_core_web_sm')",
+                "doc = nlp('This is a neat way to visualize your spaCy docs')",
+                "render(doc, width='500', height='500')"
+            ],
+            "code_language": "python",
+            "thumb": "https://www.mattoxley.com/static/images/spacysee_logo.svg",
+            "image": "https://www.mattoxley.com/static/images/spacysee_logo.svg",
+            "author": "Matt Oxley",
+            "author_links": {
+                "twitter": "matt0xley",
+                "github": "moxley01",
+                "website": "https://mattoxley.com"
+            },
+            "category": ["visualizers"],
+            "tags": ["visualization"]
+        },
+        {
             "id": "grecy",
             "title": "greCy",
             "slogan": "Ancient Greek pipelines for spaCy",


### PR DESCRIPTION
## Description

Adds `spaCysee` to the universe json. It is a visualizer that is designed to work with Jupyter notebooks and allows you to scroll through the dependency parse output for a given doc.

### Types of change
Adds `spaCysee` to the universe json

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ x] I ran the tests, and all new and existing tests passed.
- [x ] My changes don't require a change to the documentation, or if they do, I've added all required information.
