### PR TITLE
Add spans in spacy benchmark

### DIFF
--- a/spacy/cli/evaluate.py
+++ b/spacy/cli/evaluate.py
@@ -122,6 +122,8 @@ def evaluate(
         docs = list(nlp.pipe(ex.reference.text for ex in dev_dataset[:displacy_limit]))
         render_deps = "parser" in factory_names
         render_ents = "ner" in factory_names
+        render_spans = "spancat" in factory_names
+        
         render_parses(
             docs,
             displacy_path,
@@ -129,6 +131,7 @@ def evaluate(
             limit=displacy_limit,
             deps=render_deps,
             ents=render_ents,
+            spans=render_spans,
         )
         msg.good(f"Generated {displacy_limit} parses as HTML", displacy_path)
 
@@ -182,6 +185,7 @@ def render_parses(
     limit: int = 250,
     deps: bool = True,
     ents: bool = True,
+    spans: bool = True,
 ):
     docs[0].user_data["title"] = model_name
     if ents:
@@ -193,6 +197,11 @@ def render_parses(
             docs[:limit], style="dep", page=True, options={"compact": True}
         )
         with (output_path / "parses.html").open("w", encoding="utf8") as file_:
+            file_.write(html)
+
+    if spans:
+        html = displacy.render(docs[:limit], style="spans", page=True)
+        with (output_path / "spans.html").open("w", encoding="utf8") as file_:
             file_.write(html)
 
 

--- a/spacy/cli/evaluate.py
+++ b/spacy/cli/evaluate.py
@@ -123,7 +123,7 @@ def evaluate(
         render_deps = "parser" in factory_names
         render_ents = "ner" in factory_names
         render_spans = "spancat" in factory_names
-        
+
         render_parses(
             docs,
             displacy_path,

--- a/spacy/cli/evaluate.py
+++ b/spacy/cli/evaluate.py
@@ -200,7 +200,7 @@ def render_parses(
             file_.write(html)
 
     if spans:
-        html = displacy.render(docs[:limit], style="spans", page=True)
+        html = displacy.render(docs[:limit], style="span", page=True)
         with (output_path / "spans.html").open("w", encoding="utf8") as file_:
             file_.write(html)
 

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -178,26 +178,27 @@ def test_issue12566(factory: str, output_file: str):
             "text": "Niedawno czytał em nową książkę znakomitego szkockiego medioznawcy , "
             "Briana McNaira - Cultural Chaos .",
             "tokens": [
-                {"end": 8, "id": 0, "start": 0},
-                {"end": 15, "id": 1, "start": 9},
-                {"end": 18, "id": 2, "start": 16},
-                {"end": 23, "id": 3, "start": 19},
-                {"end": 31, "id": 4, "start": 24},
-                {"end": 43, "id": 5, "start": 32},
-                {"end": 54, "id": 6, "start": 44},
-                {"end": 66, "id": 7, "start": 55},
-                {"end": 68, "id": 8, "start": 67},
-                {"end": 75, "id": 9, "start": 69},
-                {"end": 83, "id": 10, "start": 76},
-                {"end": 85, "id": 11, "start": 84},
-                {"end": 94, "id": 12, "start": 86},
-                {"end": 100, "id": 13, "start": 95},
-                {"end": 102, "id": 14, "start": 101},
+                # fmt: off
+                {"id": 0, "start": 0, "end": 8, "tag": "ADV", "pos": "ADV", "morph": "Degree=Pos", "lemma": "niedawno", "dep": "advmod", "head": 1, },
+                {"id": 1, "start": 9, "end": 15, "tag": "PRAET", "pos": "VERB", "morph": "Animacy=Hum|Aspect=Imp|Gender=Masc|Mood=Ind|Number=Sing|Tense=Past|VerbForm=Fin|Voice=Act", "lemma": "czytać", "dep": "ROOT", "head": 1, },
+                {"id": 2, "start": 16, "end": 18, "tag": "AGLT", "pos": "NOUN", "morph": "Animacy=Inan|Case=Ins|Gender=Masc|Number=Sing", "lemma": "em", "dep": "iobj", "head": 1, },
+                {"id": 3, "start": 19, "end": 23, "tag": "ADJ", "pos": "ADJ", "morph": "Case=Acc|Degree=Pos|Gender=Fem|Number=Sing", "lemma": "nowy", "dep": "amod", "head": 4, },
+                {"id": 4, "start": 24, "end": 31, "tag": "SUBST", "pos": "NOUN", "morph": "Case=Acc|Gender=Fem|Number=Sing", "lemma": "książka", "dep": "obj", "head": 1, },
+                {"id": 5, "start": 32, "end": 43, "tag": "ADJ", "pos": "ADJ", "morph": "Animacy=Nhum|Case=Gen|Degree=Pos|Gender=Masc|Number=Sing", "lemma": "znakomit", "dep": "acl", "head": 4, },
+                {"id": 6, "start": 44, "end": 54, "tag": "ADJ", "pos": "ADJ", "morph": "Animacy=Hum|Case=Gen|Degree=Pos|Gender=Masc|Number=Sing", "lemma": "szkockiy", "dep": "amod", "head": 7, },
+                {"id": 7, "start": 55, "end": 66, "tag": "SUBST", "pos": "NOUN", "morph": "Animacy=Hum|Case=Gen|Gender=Masc|Number=Sing", "lemma": "medioznawca", "dep": "iobj", "head": 5, },
+                {"id": 8, "start": 67, "end": 68, "tag": "INTERP", "pos": "PUNCT", "morph": "PunctType=Comm", "lemma": ",", "dep": "punct", "head": 9, },
+                {"id": 9, "start": 69, "end": 75, "tag": "SUBST", "pos": "PROPN", "morph": "Animacy=Hum|Case=Gen|Gender=Masc|Number=Sing", "lemma": "Brian", "dep": "nmod", "head": 4, },
+                {"id": 10, "start": 76, "end": 83, "tag": "SUBST", "pos": "PROPN", "morph": "Animacy=Hum|Case=Gen|Gender=Masc|Number=Sing", "lemma": "McNair", "dep": "flat", "head": 9, },
+                {"id": 11, "start": 84, "end": 85, "tag": "INTERP", "pos": "PUNCT", "morph": "PunctType=Dash", "lemma": "-", "dep": "punct", "head": 12, },
+                {"id": 12, "start": 86, "end": 94, "tag": "SUBST", "pos": "PROPN", "morph": "Animacy=Inan|Case=Nom|Gender=Masc|Number=Sing", "lemma": "Cultural", "dep": "conj", "head": 4, },
+                {"id": 13, "start": 95, "end": 100, "tag": "SUBST", "pos": "NOUN", "morph": "Animacy=Inan|Case=Nom|Gender=Masc|Number=Sing", "lemma": "Chaos", "dep": "flat", "head": 12, },
+                {"id": 14, "start": 101, "end": 102, "tag": "INTERP", "pos": "PUNCT", "morph": "PunctType=Peri", "lemma": ".", "dep": "punct", "head": 1, },
+                # fmt: on
             ],
         }
 
         # Create a .spacy file
-        test_data_path = tmp_dir / "test.spacy"
         nlp = spacy.blank("pl")
         doc = Doc(nlp.vocab).from_json(doc_json)
 

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -28,7 +28,7 @@ from spacy.cli.debug_data import _get_span_characteristics
 from spacy.cli.debug_data import _print_span_characteristics
 from spacy.cli.debug_data import _get_spans_length_freq_dist
 from spacy.cli.download import get_compatibility, get_version
-from spacy.cli.evaluate import evaluate
+from spacy.cli.evaluate import render_parses
 from spacy.cli.init_config import RECOMMENDATIONS, init_config, fill_config
 from spacy.cli.init_pipeline import _init_labels
 from spacy.cli.package import get_third_party_dependencies
@@ -148,10 +148,10 @@ def test_issue11235():
 
 @pytest.mark.issue(12566)
 @pytest.mark.parametrize(
-    "displacy_type,output_file",
-    [("parser", "parsers.html"), ("ner", "entities.html"), ("spancat", "spans.html")],
+    "factory,output_file",
+    [("deps", "parses.html"), ("ents", "entities.html"), ("spans", "spans.html")],
 )
-def test_issue12566(displacy_type: str, output_file: str):
+def test_issue12566(factory: str, output_file: str):
     """
     Test if all displaCy types (ents, dep, spans) produce an HTML file
     """
@@ -200,23 +200,9 @@ def test_issue12566(displacy_type: str, output_file: str):
         test_data_path = tmp_dir / "test.spacy"
         nlp = spacy.blank("pl")
         doc = Doc(nlp.vocab).from_json(doc_json)
-        doc_bin = DocBin(docs=[doc])
-        doc_bin.to_disk(test_data_path)
-
-        # Add 'spancat' to en_core_web_sm so that it shows up in the
-        # factory_names
-        test_model_path = tmp_dir / "test-model"
-        nlp_sm = spacy.load("en_core_web_sm")
-        if displacy_type == "spancat":
-            nlp_sm.add_pipe("spancat")
-        nlp_sm.to_disk(test_model_path)
 
         # Run the evaluate command and check if the html files exist
-        evaluate(
-            model=str(test_model_path),
-            data_path=tmp_dir / "test.spacy",
-            displacy_path=tmp_dir,
-        )
+        render_parses(docs=[doc], output_path=tmp_dir, **{factory: True})
 
         assert (tmp_dir / output_file).is_file()
 

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -202,7 +202,9 @@ def test_issue12566(factory: str, output_file: str):
         doc = Doc(nlp.vocab).from_json(doc_json)
 
         # Run the evaluate command and check if the html files exist
-        render_parses(docs=[doc], output_path=tmp_dir, **{factory: True})
+        render_parses(
+            docs=[doc], output_path=tmp_dir, model_name="", limit=1, **{factory: True}
+        )
 
         assert (tmp_dir / output_file).is_file()
 


### PR DESCRIPTION

This PR attempts to fix that by creating a new parameter for "spans" and calling the appropriate displaCy value.


## Description

#12566 

The current implementation of spaCy benchmark accuracy / spacy evaluate doesn't include the "spans" type, so calling the command doesn't render the HTML displaCy file needed. The reason why it wasn't included in the first place was *probably* because the "spans" feature in displaCy is relatively new.

### Types of change

Bugfix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
