### PR TITLE
Spancat speed improvement

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
     name: Test
     needs: Validate
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python_version: ["3.11"]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
     name: Test
     needs: Validate
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python_version: ["3.11"]

--- a/spacy/ml/extract_spans.py
+++ b/spacy/ml/extract_spans.py
@@ -57,9 +57,9 @@ def _get_span_indices(ops, spans: Ragged, lengths: Ints1d) -> Ints1d:
     for i, length in enumerate(lengths):
         spans_i = spans[i].dataXd + offset
         for j in range(spans_i.shape[0]):
-            indices += list(range(spans_i[j, 0], spans_i[j, 1]))  # type: ignore
+            indices.extend(range(spans_i[j, 0], spans_i[j, 1]))
         offset += length
-    return ops.xp.asarray(indices, dtype="int")
+    return ops.asarray1i(indices)
 
 
 def _ensure_cpu(spans: Ragged, lengths: Ints1d) -> Tuple[Ragged, Ints1d]:

--- a/spacy/ml/extract_spans.py
+++ b/spacy/ml/extract_spans.py
@@ -57,7 +57,7 @@ def _get_span_indices(ops, spans: Ragged, lengths: Ints1d) -> Ints1d:
     for i, length in enumerate(lengths):
         spans_i = spans[i].dataXd + offset
         for j in range(spans_i.shape[0]):
-            indices.extend(range(spans_i[j, 0], spans_i[j, 1]))
+            indices.extend(range(spans_i[j, 0], spans_i[j, 1]))  # type: ignore[arg-type, call-overload]
         offset += length
     return ops.asarray1i(indices)
 

--- a/spacy/ml/extract_spans.py
+++ b/spacy/ml/extract_spans.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Callable
+from typing import List, Tuple, Callable
 from thinc.api import Model, to_numpy
 from thinc.types import Ragged, Ints1d
 
@@ -52,7 +52,7 @@ def _get_span_indices(ops, spans: Ragged, lengths: Ints1d) -> Ints1d:
     indices will be [5, 6, 7, 8, 8, 9].
     """
     spans, lengths = _ensure_cpu(spans, lengths)
-    indices = []
+    indices: List[int] = []
     offset = 0
     for i, length in enumerate(lengths):
         spans_i = spans[i].dataXd + offset

--- a/spacy/ml/extract_spans.py
+++ b/spacy/ml/extract_spans.py
@@ -57,7 +57,7 @@ def _get_span_indices(ops, spans: Ragged, lengths: Ints1d) -> Ints1d:
     for i, length in enumerate(lengths):
         spans_i = spans[i].dataXd + offset
         for j in range(spans_i.shape[0]):
-            indices += list(range(spans_i[j, 0], spans_i[j, 1]))  # type: ignore[call-overload, index]
+            indices += list(range(spans_i[j, 0], spans_i[j, 1]))  # type: ignore
         offset += length
     return ops.xp.asarray(indices, dtype="int")
 

--- a/spacy/ml/extract_spans.py
+++ b/spacy/ml/extract_spans.py
@@ -57,9 +57,9 @@ def _get_span_indices(ops, spans: Ragged, lengths: Ints1d) -> Ints1d:
     for i, length in enumerate(lengths):
         spans_i = spans[i].dataXd + offset
         for j in range(spans_i.shape[0]):
-            indices.append(ops.xp.arange(spans_i[j, 0], spans_i[j, 1]))  # type: ignore[call-overload, index]
+            indices += list(range(spans_i[j, 0], spans_i[j, 1]))  # type: ignore[call-overload, index]
         offset += length
-    return ops.flatten(indices, dtype="i", ndim_if_empty=1)
+    return ops.xp.asarray(indices, dtype="int")
 
 
 def _ensure_cpu(spans: Ragged, lengths: Ints1d) -> Tuple[Ragged, Ints1d]:


### PR DESCRIPTION
## Description
During out Slack discussion @adrianeboyd identified a hotspot that slows `spancat` down. It only required a small change to speed it up. 

To estimate the difference I trained the default `spancat` for a few epochs on `LitBank` using this codebase: https://github.com/explosion/princetondh/tree/master/litbank_pipeline. I ran the command:

```
python -m spacy project run spancat
```

According to tqdm the time elapsed between evaluations using the old function the time elapsed between evaluations is~50 seconds with about 3.8it/s . The output of the evaluation command is:

```
SPEED    6431
```
 With the new code the time elapsed is ~10 seconds with about 16it/s and the output of the evaluation command is:
 
 ```
 SPEED    18358
 ```

### Types of change
Small bug-fix to improve speed.

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
