### PR TITLE
Fix typo in LatinCy 'code_example'

### DIFF
--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -11,7 +11,7 @@
                 "# pip install https://huggingface.co/latincy/la_core_web_lg/resolve/main/la_core_web_lg-any-py3-none-any.whl",
                 "import spacy",
                 "nlp = spacy.load('la_core_web_lg')",
-                "doc = nlp('Haec narranatur a poetis de Perseo')",
+                "doc = nlp('Haec narrantur a poetis de Perseo')",
                 "",
                 "print(f'{doc[0].text}, {doc[0].norm_}, {doc[0].lemma_}, {doc[0].pos_}')",
                 "",


### PR DESCRIPTION
## Description
As mentioned in the discussion for #12597, this PR corrects a typo in the LatinCy `code_example` in universe.json.

### Types of change
Minor correction

## Checklist
- [X] My changes don't require a change to the documentation, or if they do, I've added all required information.
