### PR TITLE
[WIP] Support adding pipeline component instances

### DIFF
--- a/spacy/__init__.py
+++ b/spacy/__init__.py
@@ -35,6 +35,7 @@ def load(
     enable: Union[str, Iterable[str]] = util._DEFAULT_EMPTY_PIPES,
     exclude: Union[str, Iterable[str]] = util._DEFAULT_EMPTY_PIPES,
     config: Union[Dict[str, Any], Config] = util.SimpleFrozenDict(),
+    pipe_instances: Dict[str, Any] = util.SimpleFrozenDict(),
 ) -> Language:
     """Load a spaCy model from an installed package or a local path.
 
@@ -58,6 +59,7 @@ def load(
         enable=enable,
         exclude=exclude,
         config=config,
+        pipe_instances=pipe_instances,
     )
 
 

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -215,6 +215,11 @@ class Warnings(metaclass=ErrorsWithCodes):
     W123 = ("Argument `enable` with value {enable} does not contain all values specified in the config option "
             "`enabled` ({enabled}). Be aware that this might affect other components in your pipeline.")
     W124 = ("{host}:{port} is already in use, using the nearest available port {serve_port} as an alternative.")
+    W125 = (
+        "Pipe instance '{name}' is being added with a vocab "
+        "instance that will not match other components. This is "
+        "usually an error."
+    )
 
 
 class Errors(metaclass=ErrorsWithCodes):
@@ -970,6 +975,7 @@ class Errors(metaclass=ErrorsWithCodes):
     E1050 = ("Port {port} is already in use. Please specify an available port with `displacy.serve(doc, port=port)` "
              "or use `auto_select_port=True` to pick an available port automatically.")
     E1051 = ("'allow_overlap' can only be False when max_positive is 1, but found 'max_positive': {max_positive}.")
+    E1052 = ("Cannot create Language instance from config: missing pipeline components. The following components were added by instance (rather than config) via the 'Language.add_pipe_instance()' method, but are not present in the 'pipe_instances' variable: {names}")
 
 
 # Deprecated model shortcuts, only used in errors and warnings

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -801,8 +801,11 @@ class Language:
         self._components.insert(pipe_index, (name, pipe_component))
         return pipe_component
 
-    def add_pipe_instance(self, component: PipeCallable,
-        /, name: Optional[str] = None,
+    def add_pipe_instance(
+        self,
+        component: PipeCallable,
+        /,
+        name: Optional[str] = None,
         *,
         before: Optional[Union[str, int]] = None,
         after: Optional[Union[str, int]] = None,
@@ -1743,7 +1746,7 @@ class Language:
         meta: Dict[str, Any] = SimpleFrozenDict(),
         auto_fill: bool = True,
         validate: bool = True,
-        pipe_instances: Dict[str, Any] = SimpleFrozenDict()
+        pipe_instances: Dict[str, Any] = SimpleFrozenDict(),
     ) -> "Language":
         """Create the nlp object from a loaded config. Will set up the tokenizer
         and language data, add pipeline components etc. If no config is provided,
@@ -1844,7 +1847,7 @@ class Language:
         # and aren't built by factory.
         missing_components = _find_missing_components(pipeline, pipe_instances, exclude)
         if missing_components:
-            raise ValueError(Errors.E1052.format(", ",join(missing_components)))
+            raise ValueError(Errors.E1052.format(", ", join(missing_components)))
         # If components are loaded from a source (existing models), we cache
         # them here so they're only loaded once
         source_nlps = {}
@@ -1858,9 +1861,7 @@ class Language:
                 if pipe_name in exclude:
                     continue
                 else:
-                    nlp.add_pipe_instance(
-                        pipe_instances[pipe_name]
-                    )
+                    nlp.add_pipe_instance(pipe_instances[pipe_name])
             # Is it important that we instantiate pipes that
             # aren't excluded? It seems like we would want
             # the exclude check above. I've left it how it
@@ -2384,7 +2385,9 @@ class _Sender:
             self.send()
 
 
-def _get_instantiated_vocab(vocab: Union[bool, Vocab], pipe_instances: Dict[str, Any]) -> Union[bool, Vocab]:
+def _get_instantiated_vocab(
+    vocab: Union[bool, Vocab], pipe_instances: Dict[str, Any]
+) -> Union[bool, Vocab]:
     vocab_instances = {}
     for name, instance in pipe_instances.items():
         if hasattr(instance, "vocab") and isinstance(instance.vocab, Vocab):
@@ -2410,8 +2413,8 @@ def _get_instantiated_vocab(vocab: Union[bool, Vocab], pipe_instances: Dict[str,
 
 
 def _find_missing_components(
-    pipeline: List[str],
-    pipe_instances: Dict[str, Any],
-    exclude: List[str]
+    pipeline: List[str], pipe_instances: Dict[str, Any], exclude: List[str]
 ) -> List[str]:
-    return [name for name in pipeline if name not in pipe_instances and name not in exclude]
+    return [
+        name for name in pipeline if name not in pipe_instances and name not in exclude
+    ]

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1847,7 +1847,7 @@ class Language:
         # and aren't built by factory.
         missing_components = _find_missing_components(pipeline, pipe_instances, exclude)
         if missing_components:
-            raise ValueError(Errors.E1052.format(", ", join(missing_components)))
+            raise ValueError(Errors.E1052.format(names=", ".join(missing_components)))
         # If components are loaded from a source (existing models), we cache
         # them here so they're only loaded once
         source_nlps = {}
@@ -2413,8 +2413,10 @@ def _get_instantiated_vocab(
 
 
 def _find_missing_components(
-    pipeline: List[str], pipe_instances: Dict[str, Any], exclude: List[str]
+    pipeline: Dict[str, Dict[str, Any]], pipe_instances: Dict[str, Any], exclude: Iterable[str]
 ) -> List[str]:
-    return [
-        name for name in pipeline if name not in pipe_instances and name not in exclude
-    ]
+    missing = []
+    for name, config in pipeline.items():
+        if config.get("factory") == INSTANCE_FACTORY_NAME and name not in pipe_instances and name not in exclude:
+            missing.append(name)
+    return missing

--- a/spacy/tests/test_language.py
+++ b/spacy/tests/test_language.py
@@ -799,3 +799,36 @@ def test_component_return():
     nlp.add_pipe("test_component_bad_pipe")
     with pytest.raises(ValueError, match="instead of a Doc"):
         nlp("text")
+
+
+@pytest.mark.parametrize("components,kwargs,position", [
+    (["t1", "t2"], {"before": "t1"}, 0),
+    (["t1", "t2"], {"after": "t1"}, 1),
+    (["t1", "t2"], {"after": "t1"}, 1),
+    (["t1", "t2"], {"first": True}, 0),
+    (["t1", "t2"], {"last": True}, 2),
+    (["t1", "t2"], {"last": False}, 2),
+    (["t1", "t2"], {"first": False}, ValueError),
+])
+def test_add_pipe_instance(components, kwargs, position):
+    nlp = Language()
+    for name in components:
+        nlp.add_pipe("textcat", name=name)
+    pipe_names = list(nlp.pipe_names)
+    if isinstance(position, int):
+        result = nlp.add_pipe_instance(evil_component, name="new_component", **kwargs)
+        assert result is evil_component
+        pipe_names.insert(position, "new_component")
+        assert nlp.pipe_names == pipe_names
+    else:
+        with pytest.raises(ValueError):
+            result = nlp.add_pipe_instance(evil_component, name="new_component", **kwargs)
+
+
+def test_add_pipe_instance_to_bytes():
+    nlp = Language()
+    nlp.add_pipe("textcat", name="t1")
+    nlp.add_pipe("textcat", name="t2")
+    nlp.add_pipe_instance(evil_component, name="new_component")
+    b = nlp.to_bytes()
+ 

--- a/spacy/tests/test_language.py
+++ b/spacy/tests/test_language.py
@@ -801,15 +801,18 @@ def test_component_return():
         nlp("text")
 
 
-@pytest.mark.parametrize("components,kwargs,position", [
-    (["t1", "t2"], {"before": "t1"}, 0),
-    (["t1", "t2"], {"after": "t1"}, 1),
-    (["t1", "t2"], {"after": "t1"}, 1),
-    (["t1", "t2"], {"first": True}, 0),
-    (["t1", "t2"], {"last": True}, 2),
-    (["t1", "t2"], {"last": False}, 2),
-    (["t1", "t2"], {"first": False}, ValueError),
-])
+@pytest.mark.parametrize(
+    "components,kwargs,position",
+    [
+        (["t1", "t2"], {"before": "t1"}, 0),
+        (["t1", "t2"], {"after": "t1"}, 1),
+        (["t1", "t2"], {"after": "t1"}, 1),
+        (["t1", "t2"], {"first": True}, 0),
+        (["t1", "t2"], {"last": True}, 2),
+        (["t1", "t2"], {"last": False}, 2),
+        (["t1", "t2"], {"first": False}, ValueError),
+    ],
+)
 def test_add_pipe_instance(components, kwargs, position):
     nlp = Language()
     for name in components:
@@ -822,7 +825,9 @@ def test_add_pipe_instance(components, kwargs, position):
         assert nlp.pipe_names == pipe_names
     else:
         with pytest.raises(ValueError):
-            result = nlp.add_pipe_instance(evil_component, name="new_component", **kwargs)
+            result = nlp.add_pipe_instance(
+                evil_component, name="new_component", **kwargs
+            )
 
 
 def test_add_pipe_instance_to_bytes():
@@ -831,4 +836,3 @@ def test_add_pipe_instance_to_bytes():
     nlp.add_pipe("textcat", name="t2")
     nlp.add_pipe_instance(evil_component, name="new_component")
     b = nlp.to_bytes()
- 

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -415,7 +415,7 @@ def load_model(
     enable: Union[str, Iterable[str]] = _DEFAULT_EMPTY_PIPES,
     exclude: Union[str, Iterable[str]] = _DEFAULT_EMPTY_PIPES,
     config: Union[Dict[str, Any], Config] = SimpleFrozenDict(),
-    pipe_instances: Dict[str, Any] = SimpleFrozenDict()
+    pipe_instances: Dict[str, Any] = SimpleFrozenDict(),
 ) -> "Language":
     """Load a model from a package or data path.
 
@@ -427,7 +427,7 @@ def load_model(
     exclude (Union[str, Iterable[str]]):  Name(s) of pipeline component(s) to exclude.
     config (Dict[str, Any] / Config): Config overrides as nested dict or dict
         keyed by section values in dot notation.
-    pipe_instances (Dict[str, Any]): Dictionary of components 
+    pipe_instances (Dict[str, Any]): Dictionary of components
         to be added to the pipeline directly (not created from
         config)
     RETURNS (Language): The loaded nlp object.
@@ -438,7 +438,7 @@ def load_model(
         "enable": enable,
         "exclude": exclude,
         "config": config,
-        "pipe_instances": pipe_instances
+        "pipe_instances": pipe_instances,
     }
     if isinstance(name, str):  # name or string path
         if name.startswith("blank:"):  # shortcut for blank model
@@ -462,7 +462,7 @@ def load_model_from_package(
     enable: Union[str, Iterable[str]] = _DEFAULT_EMPTY_PIPES,
     exclude: Union[str, Iterable[str]] = _DEFAULT_EMPTY_PIPES,
     config: Union[Dict[str, Any], Config] = SimpleFrozenDict(),
-    pipe_instances: Dict[str, Any] = SimpleFrozenDict()
+    pipe_instances: Dict[str, Any] = SimpleFrozenDict(),
 ) -> "Language":
     """Load a model from an installed package.
 
@@ -478,7 +478,7 @@ def load_model_from_package(
         components won't be loaded.
     config (Dict[str, Any] / Config): Config overrides as nested dict or dict
         keyed by section values in dot notation.
-    pipe_instances (Dict[str, Any]): Dictionary of components 
+    pipe_instances (Dict[str, Any]): Dictionary of components
         to be added to the pipeline directly (not created from
         config)
     RETURNS (Language): The loaded nlp object.
@@ -496,7 +496,7 @@ def load_model_from_path(
     enable: Union[str, Iterable[str]] = _DEFAULT_EMPTY_PIPES,
     exclude: Union[str, Iterable[str]] = _DEFAULT_EMPTY_PIPES,
     config: Union[Dict[str, Any], Config] = SimpleFrozenDict(),
-    pipe_instances: Dict[str, Any] = SimpleFrozenDict()
+    pipe_instances: Dict[str, Any] = SimpleFrozenDict(),
 ) -> "Language":
     """Load a model from a data directory path. Creates Language class with
     pipeline from config.cfg and then calls from_disk() with path.
@@ -533,7 +533,7 @@ def load_model_from_path(
         enable=enable,
         exclude=exclude,
         meta=meta,
-        pipe_instances=pipe_instances
+        pipe_instances=pipe_instances,
     )
     return nlp.from_disk(model_path, exclude=exclude, overrides=overrides)
 
@@ -548,7 +548,7 @@ def load_model_from_config(
     exclude: Union[str, Iterable[str]] = _DEFAULT_EMPTY_PIPES,
     auto_fill: bool = False,
     validate: bool = True,
-    pipe_instances: Dict[str, Any] = SimpleFrozenDict()
+    pipe_instances: Dict[str, Any] = SimpleFrozenDict(),
 ) -> "Language":
     """Create an nlp object from a config. Expects the full config file including
     a section "nlp" containing the settings for the nlp object.
@@ -588,7 +588,7 @@ def load_model_from_config(
         auto_fill=auto_fill,
         validate=validate,
         meta=meta,
-        pipe_instances=pipe_instances
+        pipe_instances=pipe_instances,
     )
     return nlp
 

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -415,6 +415,7 @@ def load_model(
     enable: Union[str, Iterable[str]] = _DEFAULT_EMPTY_PIPES,
     exclude: Union[str, Iterable[str]] = _DEFAULT_EMPTY_PIPES,
     config: Union[Dict[str, Any], Config] = SimpleFrozenDict(),
+    pipe_instances: Dict[str, Any] = SimpleFrozenDict()
 ) -> "Language":
     """Load a model from a package or data path.
 
@@ -426,6 +427,9 @@ def load_model(
     exclude (Union[str, Iterable[str]]):  Name(s) of pipeline component(s) to exclude.
     config (Dict[str, Any] / Config): Config overrides as nested dict or dict
         keyed by section values in dot notation.
+    pipe_instances (Dict[str, Any]): Dictionary of components 
+        to be added to the pipeline directly (not created from
+        config)
     RETURNS (Language): The loaded nlp object.
     """
     kwargs = {
@@ -434,6 +438,7 @@ def load_model(
         "enable": enable,
         "exclude": exclude,
         "config": config,
+        "pipe_instances": pipe_instances
     }
     if isinstance(name, str):  # name or string path
         if name.startswith("blank:"):  # shortcut for blank model
@@ -457,6 +462,7 @@ def load_model_from_package(
     enable: Union[str, Iterable[str]] = _DEFAULT_EMPTY_PIPES,
     exclude: Union[str, Iterable[str]] = _DEFAULT_EMPTY_PIPES,
     config: Union[Dict[str, Any], Config] = SimpleFrozenDict(),
+    pipe_instances: Dict[str, Any] = SimpleFrozenDict()
 ) -> "Language":
     """Load a model from an installed package.
 
@@ -472,10 +478,13 @@ def load_model_from_package(
         components won't be loaded.
     config (Dict[str, Any] / Config): Config overrides as nested dict or dict
         keyed by section values in dot notation.
+    pipe_instances (Dict[str, Any]): Dictionary of components 
+        to be added to the pipeline directly (not created from
+        config)
     RETURNS (Language): The loaded nlp object.
     """
     cls = importlib.import_module(name)
-    return cls.load(vocab=vocab, disable=disable, enable=enable, exclude=exclude, config=config)  # type: ignore[attr-defined]
+    return cls.load(vocab=vocab, disable=disable, enable=enable, exclude=exclude, config=config, pipe_instances=pipe_instances)  # type: ignore[attr-defined]
 
 
 def load_model_from_path(
@@ -487,6 +496,7 @@ def load_model_from_path(
     enable: Union[str, Iterable[str]] = _DEFAULT_EMPTY_PIPES,
     exclude: Union[str, Iterable[str]] = _DEFAULT_EMPTY_PIPES,
     config: Union[Dict[str, Any], Config] = SimpleFrozenDict(),
+    pipe_instances: Dict[str, Any] = SimpleFrozenDict()
 ) -> "Language":
     """Load a model from a data directory path. Creates Language class with
     pipeline from config.cfg and then calls from_disk() with path.
@@ -504,6 +514,9 @@ def load_model_from_path(
         components won't be loaded.
     config (Dict[str, Any] / Config): Config overrides as nested dict or dict
         keyed by section values in dot notation.
+    pipe_instances (Dict[str, Any]): Dictionary of components
+        to be added to the pipeline directly (not created from
+        config)
     RETURNS (Language): The loaded nlp object.
     """
     if not model_path.exists():
@@ -520,6 +533,7 @@ def load_model_from_path(
         enable=enable,
         exclude=exclude,
         meta=meta,
+        pipe_instances=pipe_instances
     )
     return nlp.from_disk(model_path, exclude=exclude, overrides=overrides)
 
@@ -534,6 +548,7 @@ def load_model_from_config(
     exclude: Union[str, Iterable[str]] = _DEFAULT_EMPTY_PIPES,
     auto_fill: bool = False,
     validate: bool = True,
+    pipe_instances: Dict[str, Any] = SimpleFrozenDict()
 ) -> "Language":
     """Create an nlp object from a config. Expects the full config file including
     a section "nlp" containing the settings for the nlp object.
@@ -551,6 +566,9 @@ def load_model_from_config(
         components won't be loaded.
     auto_fill (bool): Whether to auto-fill config with missing defaults.
     validate (bool): Whether to show config validation errors.
+    pipe_instances (Dict[str, Any]): Dictionary of components
+        to be added to the pipeline directly (not created from
+        config)
     RETURNS (Language): The loaded nlp object.
     """
     if "nlp" not in config:
@@ -570,6 +588,7 @@ def load_model_from_config(
         auto_fill=auto_fill,
         validate=validate,
         meta=meta,
+        pipe_instances=pipe_instances
     )
     return nlp
 


### PR DESCRIPTION
Add a method `Language.add_pipe_instance` that allows you to add component instances to the pipeline. This is primarily intended to make it easier to assemble a pipeline dynamically in a script, which is useful for exploration or for situations where you don't care so much about serialisation.

Components that are added this way cannot be reconstructed automatically during deserialisation. Instead, a `pipe_instances` argument is added to `spacy.load()`.

Example usage 1: creating an NLP object with a function, and using `nlp.to_disk()` and `nlp.from_disk()`.

If users wish to assemble the pipeline themselves in a function, they don't need to worry about the config system. They just have to make sure they use the same function to construct the pipeline each time.

```python
def make_nlp():
    nlp = spacy.blank("en")
    tagger = Tagger(nlp.vocab, model=DEFAULT_TAGGER_MODEL, overwrite=False, scorer=tagger_score, neg_prefix="!", label_smoothing=0.0)
    nlp.add_pipe_instance(tagger)
    return nlp

nlp = make_nlp()
nlp.to_disk("/tmp/my_nlp")
# Later
nlp = make_nlp()
nlp.from_disk("/tmp/my_nlp")
```

Example usage 2: Passing component instances to `spacy.load()`

If pipe instances are added directly, we won't be able to reconstruct them in `spacy.load()`. Instead of just making the pipeline impossible to load this way, you can pass the missing instances using the `pipe_instances` argument. This approach is kind of impractical for components that need the `Vocab` instance, but I definitely think it's better than just not supporting it.

```python
vocab = Vocab()
tagger = Tagger(vocab, model=DEFAULT_TAGGER_MODEL, overwrite=False, scorer=tagger_score, neg_prefix="!", label_smoothing=0.0)
nlp = spacy.load("/tmp/my_nlp", vocab=vocab, pipe_instances={"tagger": my_tagger})
```

I added some logic to fetch the `vocab` instance from a pipe instance, so that `nlp = spacy.load("/tmp/my_nlp", pipe_instances={"tagger": my_tagger})` would work. The value of that logic is a bit dubious.

## Questions for discussion

* We could overload `add_pipe`, so that you can just pass the pipe instance in there. I've kept this separate to avoid interaction with existing features, at least until we're happy with it. In the long term I think the overload is a bit more consistent with the general design of the API.
* We could support pipe metadata in `add_pipe_instance`, but then how would we serialise it? I felt it was better to avoid the complication, and if you want those things to be correct you can assemble the pipeline via the config system. I could easily be missing implications of this metadata not being there though.
* Naming of `pipe_instance` argument?
* Fishing the `vocab` instance out of the pipe instances seems dubious. Probably we should just not do this, and ask that the `vocab` argument be set?
* Wording of the warnings about `vocab` instances?
* Should we check for `vocab` instances more robustly? We could go through the `__dict__`, but that still doesn't cover nested objects. I felt that the `vocab` member was a decent value thing to check, albeit not watertight.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
