### PR TITLE
Fix #12716 does not update the `config` generation section

### DIFF
--- a/website/src/components/quickstart.js
+++ b/website/src/components/quickstart.js
@@ -215,15 +215,17 @@ const Quickstart = ({
                     }
                 )}
                 <pre className={classes['code']}>
-                    <code
-                        className={classNames(classes['results'], {
-                            [classes['small']]: !!small,
-                            [`language-${codeLang}`]: !!codeLang,
-                        })}
-                        data-quickstart-results=""
-                        ref={contentRef}
-                    >
-                        {Children.toArray(children).flat().filter(isRelevant)}
+                    <code>
+                        <div
+                            className={classNames(classes['results'], {
+                                [classes['small']]: !!small,
+                                [`language-${codeLang}`]: !!codeLang,
+                            })}
+                            data-quickstart-results=""
+                            ref={contentRef}
+                        >
+                            {Children.toArray(children).flat().filter(isRelevant)}
+                        </div>
                     </code>
 
                     <menu className={classes['menu']}>


### PR DESCRIPTION
## Description

This is a really odd bug, where Firefox doesn't re-render the `code` element, even though `children` changed.

I couldn't find any explanation for why this is happening and why it only happens in Firefox. I assume it is a bug caused by one of our many dependencies (or their interplay). Updating dependencies didn't fix the bug.

To make matters worse: This bug *doesn't* occure when running the site in dev mode. You have to build and serve the site to recreate it.

<!--- Provide a general summary of your changes in the title. -->

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

### Types of change
Two things fixed that:
- remove the `language-ini` `className`
- replace the `code` block with a `div`

Both are not ideal. Therefor this solution adds an inner `div` that now has the classes while still maintaining the semantic `code` element.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
