### PR TITLE
Fixed e941 link rendering by removing the dot

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -739,8 +739,8 @@ class Errors(metaclass=ErrorsWithCodes):
             "model from a shortcut, which is obsolete as of spaCy v3.0. To "
             "load the model, use its full name instead:\n\n"
             "nlp = spacy.load(\"{full}\")\n\nFor more details on the available "
-            "models, see the models directory: https://spacy.io/models. If you "
-            "want to create a blank model, use spacy.blank: "
+            "models, see the models directory: https://spacy.io/models and if "
+            "you want to create a blank model, use spacy.blank: "
             "nlp = spacy.blank(\"{name}\")")
     E942 = ("Executing `after_{name}` callback failed. Expected the function to "
             "return an initialized nlp object but got: {value}. Maybe "


### PR DESCRIPTION
Removed the dot in the link

## Description
Removed the dot in the link of spaCy's models as that dot was rendered as part
of the link when raised in a jupyter notebook, and when that happens, the hyperlink
leads to a broken webpage, [https://spacy.io/models.](https://spacy.io/models.) instead of [https://spacy.io/models](https://spacy.io/models)

### Types of change
Minor change to the link

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
