### PR TITLE
Fix problem with missing syntax highlighting languages causing runtime crash on the website

### DIFF
--- a/website/src/components/code.js
+++ b/website/src/components/code.js
@@ -14,6 +14,7 @@ import 'prismjs/components/prism-markdown.min.js'
 import 'prismjs/components/prism-python.min.js'
 import 'prismjs/components/prism-yaml.min.js'
 import 'prismjs/components/prism-docker.min.js'
+import 'prismjs/components/prism-r.min.js'
 
 import { isString } from './util'
 import Link, { OptionalLink } from './link'

--- a/website/src/components/code.js
+++ b/website/src/components/code.js
@@ -174,7 +174,7 @@ const convertLine = ({ line, prompt, lang }) => {
         return handlePromot({ lineFlat, prompt })
     }
 
-    return lang === 'none' || !lineFlat ? (
+    return lang === 'none' || !lineFlat || !(lang in Prism.languages) ? (
         lineFlat
     ) : (
         <span

--- a/website/src/components/code.js
+++ b/website/src/components/code.js
@@ -13,6 +13,7 @@ import 'prismjs/components/prism-json.min.js'
 import 'prismjs/components/prism-markdown.min.js'
 import 'prismjs/components/prism-python.min.js'
 import 'prismjs/components/prism-yaml.min.js'
+import 'prismjs/components/prism-docker.min.js'
 
 import { isString } from './util'
 import Link, { OptionalLink } from './link'


### PR DESCRIPTION
## Description
This fixes a bug with some pages not rendering correctly, because they use a code language (for syntax highlighting), that isn't loaded. 

### Types of change
- Add missing `docker` and `r` languages
- Default to no syntax-highlighting for pages using an unknown language (instead of runtime failing)

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
