### PR TITLE
Universe docs: Use 'exclude' instead of 'disable'

### DIFF
--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -4372,7 +4372,7 @@
             "code_example": [
                 "import spacy",
                 "",
-                "nlp = spacy.load(\"en_core_web_sm\", disable=[\"ner\"])",
+                "nlp = spacy.load(\"en_core_web_sm\", exclude=[\"ner\"])",
                 "nlp.add_pipe(\"span_marker\", config={\"model\": \"tomaarsen/span-marker-roberta-large-ontonotes5\"})",
                 "",
                 "text = \"\"\"Cleopatra VII, also known as Cleopatra the Great, was the last active ruler of the \\",


### PR DESCRIPTION
Hello!

## Description
Replace `disable` with `exclude`, as the former will unnecessarily load the unused "ner" model still.

Thank you @svlandeg for the suggestion on LinkedIn.

### Types of change
Documentation.

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [-] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

---

- Tom Aarsen