### PR TITLE
`Language.replace_listeners`: Pass the replaced listener and the `tok2vec` pipe to the callback

### DIFF
--- a/extra/DEVELOPER_DOCS/Listeners.md
+++ b/extra/DEVELOPER_DOCS/Listeners.md
@@ -1,14 +1,18 @@
 # Listeners
 
-1. [Overview](#1-overview)
-2. [Initialization](#2-initialization)
-   - [A. Linking listeners to the embedding component](#2a-linking-listeners-to-the-embedding-component)
-   - [B. Shape inference](#2b-shape-inference)
-3. [Internal communication](#3-internal-communication)
-   - [A. During prediction](#3a-during-prediction)
-   - [B. During training](#3b-during-training)
-   - [C. Frozen components](#3c-frozen-components)
-4. [Replacing listener with standalone](#4-replacing-listener-with-standalone)
+- [Listeners](#listeners)
+  - [1. Overview](#1-overview)
+  - [2. Initialization](#2-initialization)
+    - [2A. Linking listeners to the embedding component](#2a-linking-listeners-to-the-embedding-component)
+    - [2B. Shape inference](#2b-shape-inference)
+  - [3. Internal communication](#3-internal-communication)
+    - [3A. During prediction](#3a-during-prediction)
+    - [3B. During training](#3b-during-training)
+      - [Training with multiple listeners](#training-with-multiple-listeners)
+    - [3C. Frozen components](#3c-frozen-components)
+      - [The Tok2Vec or Transformer is frozen](#the-tok2vec-or-transformer-is-frozen)
+      - [The upstream component is frozen](#the-upstream-component-is-frozen)
+  - [4. Replacing listener with standalone](#4-replacing-listener-with-standalone)
 
 ## 1. Overview
 
@@ -62,7 +66,7 @@ of this `find_listener()` method will specifically identify sublayers of a model
 
 If it's a Transformer-based pipeline, a
 [`transformer` component](https://github.com/explosion/spacy-transformers/blob/master/spacy_transformers/pipeline_component.py)
-has a similar implementation but its `find_listener()` function will specifically look for `TransformerListener` 
+has a similar implementation but its `find_listener()` function will specifically look for `TransformerListener`
 sublayers of downstream components.
 
 ### 2B. Shape inference
@@ -154,7 +158,7 @@ as a tagger or a parser. This used to be impossible before 3.1, but has become s
 embedding component in the [`annotating_components`](https://spacy.io/usage/training#annotating-components)
 list of the config. This works like any other "annotating component" because it relies on the `Doc` attributes.
 
-However, if the `Tok2Vec` or `Transformer` is frozen, and not present in `annotating_components`, and a related 
+However, if the `Tok2Vec` or `Transformer` is frozen, and not present in `annotating_components`, and a related
 listener isn't frozen, then a `W086` warning is shown and further training of the pipeline will likely end with `E954`.
 
 #### The upstream component is frozen
@@ -216,5 +220,12 @@ new_model = tok2vec_model.attrs["replace_listener"](new_model)
 ```
 
 The new config and model are then properly stored on the `nlp` object.
-Note that this functionality (running the replacement for a transformer listener) was broken prior to 
+Note that this functionality (running the replacement for a transformer listener) was broken prior to
 `spacy-transformers` 1.0.5.
+
+As of spaCy 3.7, the `replace_listener` callback accepts three arguments instead of just one: the new (copied) model,
+the listener to be replaced, the `tok2vec`/`transformer` pipe from which the new model was copied.
+
+```
+new_model = tok2vec_model.attrs["replace_listener"](new_model, replaced_listener, tok2vec)
+```

--- a/extra/DEVELOPER_DOCS/Listeners.md
+++ b/extra/DEVELOPER_DOCS/Listeners.md
@@ -223,9 +223,15 @@ The new config and model are then properly stored on the `nlp` object.
 Note that this functionality (running the replacement for a transformer listener) was broken prior to
 `spacy-transformers` 1.0.5.
 
-As of spaCy 3.7, the `replace_listener` callback accepts three arguments instead of just one: the new (copied) model,
-the listener to be replaced, the `tok2vec`/`transformer` pipe from which the new model was copied.
+In spaCy 3.7, `Language.replace_listeners` was updated to pass the following additional arguments to the `replace_listener` callback:
+the listener to be replaced, the `tok2vec`/`transformer` pipe from which the new model was copied. To maintain backwards-compatiblity,
+the method only passes these extra arguments for callbacks that support them:
 
 ```
-new_model = tok2vec_model.attrs["replace_listener"](new_model, replaced_listener, tok2vec)
+def replace_listener_pre_37(copied_tok2vec_model):
+  ...
+
+def replace_listener_post_37(copied_tok2vec_model, replaced_listener, tok2vec_pipe):
+  ...
+
 ```

--- a/extra/DEVELOPER_DOCS/Listeners.md
+++ b/extra/DEVELOPER_DOCS/Listeners.md
@@ -1,18 +1,17 @@
 # Listeners
 
-- [Listeners](#listeners)
-  - [1. Overview](#1-overview)
-  - [2. Initialization](#2-initialization)
-    - [2A. Linking listeners to the embedding component](#2a-linking-listeners-to-the-embedding-component)
-    - [2B. Shape inference](#2b-shape-inference)
-  - [3. Internal communication](#3-internal-communication)
-    - [3A. During prediction](#3a-during-prediction)
-    - [3B. During training](#3b-during-training)
-      - [Training with multiple listeners](#training-with-multiple-listeners)
-    - [3C. Frozen components](#3c-frozen-components)
-      - [The Tok2Vec or Transformer is frozen](#the-tok2vec-or-transformer-is-frozen)
-      - [The upstream component is frozen](#the-upstream-component-is-frozen)
-  - [4. Replacing listener with standalone](#4-replacing-listener-with-standalone)
+- [1. Overview](#1-overview)
+- [2. Initialization](#2-initialization)
+  - [2A. Linking listeners to the embedding component](#2a-linking-listeners-to-the-embedding-component)
+  - [2B. Shape inference](#2b-shape-inference)
+- [3. Internal communication](#3-internal-communication)
+  - [3A. During prediction](#3a-during-prediction)
+  - [3B. During training](#3b-during-training)
+    - [Training with multiple listeners](#training-with-multiple-listeners)
+  - [3C. Frozen components](#3c-frozen-components)
+    - [The Tok2Vec or Transformer is frozen](#the-tok2vec-or-transformer-is-frozen)
+    - [The upstream component is frozen](#the-upstream-component-is-frozen)
+- [4. Replacing listener with standalone](#4-replacing-listener-with-standalone)
 
 ## 1. Overview
 
@@ -224,7 +223,7 @@ Note that this functionality (running the replacement for a transformer listener
 `spacy-transformers` 1.0.5.
 
 In spaCy 3.7, `Language.replace_listeners` was updated to pass the following additional arguments to the `replace_listener` callback:
-the listener to be replaced, the `tok2vec`/`transformer` pipe from which the new model was copied. To maintain backwards-compatiblity,
+the listener to be replaced and the `tok2vec`/`transformer` pipe from which the new model was copied. To maintain backwards-compatiblity,
 the method only passes these extra arguments for callbacks that support them:
 
 ```
@@ -233,5 +232,4 @@ def replace_listener_pre_37(copied_tok2vec_model):
 
 def replace_listener_post_37(copied_tok2vec_model, replaced_listener, tok2vec_pipe):
   ...
-
 ```

--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -981,6 +981,8 @@ class Errors(metaclass=ErrorsWithCodes):
              " 'min_length': {min_length}, 'max_length': {max_length}")
     E1054 = ("The text, including whitespace, must match between reference and "
              "predicted docs when training {component}.")
+    E1055 = ("The 'replace_listener' callback expects {num_params} parameters, "
+             "but only callbacks with one or three parameters are supported")
 
 
 # Deprecated model shortcuts, only used in errors and warnings

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 import itertools
 import multiprocessing as mp
 import random
@@ -30,6 +31,7 @@ from typing import (
 )
 
 import srsly
+
 from thinc.api import Config, CupyOps, Optimizer, get_current_ops
 
 from . import about, ty, util
@@ -2033,8 +2035,18 @@ class Language:
             # Go over the listener layers and replace them
             for listener in pipe_listeners:
                 new_model = tok2vec_model.copy()
-                if "replace_listener" in tok2vec_model.attrs:
-                    new_model = tok2vec_model.attrs["replace_listener"](new_model)
+                replace_listener_func = tok2vec_model.attrs.get("replace_listener")
+                if replace_listener_func is not None:
+                    # Pass the extra args to the callback without breaking compatibility with
+                    # old library versions that only expect a single parameter.
+                    num_params = len(
+                        inspect.signature(replace_listener_func).parameters
+                    )
+                    assert num_params in (1, 3)
+                    if num_params == 1:
+                        new_model = replace_listener_func(new_model)
+                    else:
+                        new_model = replace_listener_func(new_model, listener, tok2vec)
                 util.replace_model_node(pipe.model, listener, new_model)  # type: ignore[attr-defined]
                 tok2vec.remove_listener(listener, pipe_name)
 

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -31,7 +31,6 @@ from typing import (
 )
 
 import srsly
-
 from thinc.api import Config, CupyOps, Optimizer, get_current_ops
 
 from . import about, ty, util

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -2041,14 +2041,13 @@ class Language:
                     num_params = len(
                         inspect.signature(replace_listener_func).parameters
                     )
-                    assert num_params in (
-                        1,
-                        3,
-                    ), f"'replace_listener' callback expects {num_params} parameters, but we only support one or three"
                     if num_params == 1:
                         new_model = replace_listener_func(new_model)
-                    else:
+                    elif num_params == 3:
                         new_model = replace_listener_func(new_model, listener, tok2vec)
+                    else:
+                        raise ValueError(Errors.E1055.format(num_params=num_params))
+
                 util.replace_model_node(pipe.model, listener, new_model)  # type: ignore[attr-defined]
                 tok2vec.remove_listener(listener, pipe_name)
 

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -2041,7 +2041,10 @@ class Language:
                     num_params = len(
                         inspect.signature(replace_listener_func).parameters
                     )
-                    assert num_params in (1, 3)
+                    assert num_params in (
+                        1,
+                        3,
+                    ), f"'replace_listener' callback expects {num_params} parameters, but we only support one or three"
                     if num_params == 1:
                         new_model = replace_listener_func(new_model)
                     else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Prior to this PR, `Language.replace_listeners` only passed the copied `tok2vec`/`transformer` model to the `replace_listener` callback. This worked for `spacy-transformers` as the library only uses a single `TransformerListener` class, i.e., the replacement model was always the same. However, `spacy-curated-transformers` introduces the concept of different listener classes for downstream components. So, the replacement process needs to provide extra information about the listener model being replaced to correctly select the target model.

This PR adds support for such situations by passing the following extra arguments to the `replace_listener` callback: the replaced listener instance and the `tok2vec` pipe whose model is copied into the downstream component. These argumentss are only passed when the callback accepts them, so the implementation is backwards-compatible with the callback used in `spacy-transformers`.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
