### PR TITLE
fix the regular expression matching on the full text

### DIFF
--- a/website/docs/usage/rule-based-matching.mdx
+++ b/website/docs/usage/rule-based-matching.mdx
@@ -311,7 +311,7 @@ import re
 nlp = spacy.load("en_core_web_sm")
 doc = nlp("The United States of America (USA) are commonly known as the United States (U.S. or US) or America.")
 
-expression = r"[Uu](nited|\\.?) ?[Ss](tates|\\.?)"
+expression = r"[Uu](nited|\.?) ?[Ss](tates|\.?)"
 for match in re.finditer(expression, doc.text):
     start, end = match.span()
     span = doc.char_span(start, end)


### PR DESCRIPTION
There was a mistake in the regex pattern which caused not matching all the desired spans. The problem was that when we use r string literal prefix to demonstrate a raw text, we should not use two backslashes to be interpreted as a single backslash.

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
The regular expression that was written in the documentation was supposed to match 4 substrings in the given sentence:
- United States (4, 17)
- United States (61, 74)
- U.S. (76, 80)
- US (84, 86)
But it only matches the first two spans. The problem was caused by writing redundant backslashes in the regular expression, i.e. for stating a dot character in the raw string, we should use `\.` in our regular expression, but it was written in the form `\\.` mistakenly.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Documentation

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
