### PR TITLE
warn for unsupported key in dependency matcher

### DIFF
--- a/spacy/errors.py
+++ b/spacy/errors.py
@@ -219,6 +219,7 @@ class Warnings(metaclass=ErrorsWithCodes):
     W125 = ("The StaticVectors key_attr is no longer used. To set a custom "
             "key attribute for vectors, configure it through Vectors(attr=) or "
             "'spacy init vectors --attr'")
+    W126 = ("These keys are unsupported: {unsupported}")
 
 
 class Errors(metaclass=ErrorsWithCodes):

--- a/spacy/matcher/dependencymatcher.pyx
+++ b/spacy/matcher/dependencymatcher.pyx
@@ -129,12 +129,20 @@ cdef class DependencyMatcher:
             else:
                 required_keys = {"RIGHT_ID", "RIGHT_ATTRS", "REL_OP", "LEFT_ID"}
                 relation_keys = set(relation.keys())
+                # Identify required keys that have not been specified
                 missing = required_keys - relation_keys
                 if missing:
                     missing_txt = ", ".join(list(missing))
                     raise ValueError(Errors.E100.format(
                         required=required_keys,
                         missing=missing_txt
+                    ))
+                # Identify additional, unsupported keys
+                unsupported = relation_keys - required_keys
+                if unsupported:
+                    unsupported_txt = ", ".join(list(unsupported))
+                    warnings.warn(Warnings.W126.format(
+                        unsupported=unsupported_txt
                     ))
                 if (
                     relation["RIGHT_ID"] in visited_nodes

--- a/spacy/tests/matcher/test_dependency_matcher.py
+++ b/spacy/tests/matcher/test_dependency_matcher.py
@@ -216,6 +216,11 @@ def test_dependency_matcher_pattern_validation(en_vocab):
         pattern2 = copy.deepcopy(pattern)
         pattern2[1]["RIGHT_ID"] = "fox"
         matcher.add("FOUNDED", [pattern2])
+    # invalid key
+    with pytest.warns(UserWarning):
+        pattern2 = copy.deepcopy(pattern)
+        pattern2[1]["FOO"] = "BAR"
+        matcher.add("FOUNDED", [pattern2])
 
 
 def test_dependency_matcher_callback(en_vocab, doc):


### PR DESCRIPTION
Follow-up to https://github.com/explosion/spaCy/issues/12926.

## Description
The Dependency Matcher only supports 4 specific keys in the (sub)pattern dictionaries. While it may be reasonable to assume that e.g. `'OP'` is supported, it's not, and currently this would be entirely ignored if you do try to specify it. Instead, this PR ensures a warning is printed:
```
UserWarning: [W126] These keys are unsupported: OP, FOO
```

### Types of change
UX enhancement

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
