### PR TITLE
Add error handling if import of info function in __init__.py fails

### DIFF
--- a/spacy/__init__.py
+++ b/spacy/__init__.py
@@ -21,7 +21,7 @@ try:
     from .cli.info import info  # noqa: F401
 except ImportError:
 
-    def info(*args, **kwargs):
+    def info(*args, **kwargs):  # type: ignore
         raise RuntimeError("Importing the CLI failed. Info function not available.")
 
 

--- a/spacy/__init__.py
+++ b/spacy/__init__.py
@@ -13,14 +13,18 @@ from thinc.api import Config, prefer_gpu, require_cpu, require_gpu  # noqa: F401
 from . import pipeline  # noqa: F401
 from . import util
 from .about import __version__  # noqa: F401
-try:  
+
+try:
     # Emscripten does not make use of the CLI and can not use the CLI libraries
     # (typer etc.) that are imported here. Additionally importing requests,
     # which is also done here, requires a workaround on this platform.
     from .cli.info import info  # noqa: F401
 except ImportError:
+
     def info(*args, **kwargs):
         raise RuntimeError("Importing the CLI failed. Info function not available.")
+
+
 from .errors import Errors
 from .glossary import explain  # noqa: F401
 from .language import Language

--- a/spacy/__init__.py
+++ b/spacy/__init__.py
@@ -13,7 +13,13 @@ from thinc.api import Config, prefer_gpu, require_cpu, require_gpu  # noqa: F401
 from . import pipeline  # noqa: F401
 from . import util
 from .about import __version__  # noqa: F401
-from .cli.info import info  # noqa: F401
+try:  
+    # Emscripten does not make use of the CLI and can not use the CLI libraries
+    # (typer etc.) that are imported here. Additionally importing requests,
+    # which is also done here, requires a workaround on this platform.
+    from .cli.info import info  # noqa: F401
+except ImportError:
+    info = lambda *args: "Importing the CLI failed. Info function not available."
 from .errors import Errors
 from .glossary import explain  # noqa: F401
 from .language import Language

--- a/spacy/__init__.py
+++ b/spacy/__init__.py
@@ -19,7 +19,8 @@ try:
     # which is also done here, requires a workaround on this platform.
     from .cli.info import info  # noqa: F401
 except ImportError:
-    info = lambda *args: "Importing the CLI failed. Info function not available."
+    def info(*args, **kwargs):
+        raise RuntimeError("Importing the CLI failed. Info function not available.")
 from .errors import Errors
 from .glossary import explain  # noqa: F401
 from .language import Language


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
The info function import currently imports the entire CLI. So it imports packages like typer and requests and importing spacy fails if they are not available on the current system. When we run spacy on webassembly, we might not want to bundle all of these CLI libraries, and using requests requires currently an ugly workaround (https://github.com/koenvo/pyodide-http) and the other CLI libraries can't really be used as of now and would be "dead weight". In the case of failure, by replacing info with a placeholder function that raises an error when it is attempted to be used, we can simply use spacy as is.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
