### PR TITLE
Update __all__ fields

### DIFF
--- a/spacy/kb/__init__.py
+++ b/spacy/kb/__init__.py
@@ -1,3 +1,11 @@
 from .candidate import Candidate, get_candidates, get_candidates_batch
 from .kb import KnowledgeBase
 from .kb_in_memory import InMemoryLookupKB
+
+__all__ = [
+    "Candidate",
+    "KnowledgeBase",
+    "InMemoryLookupKB",
+    "get_candidates",
+    "get_candidates_batch",
+]

--- a/spacy/matcher/__init__.py
+++ b/spacy/matcher/__init__.py
@@ -3,4 +3,4 @@ from .levenshtein import levenshtein
 from .matcher import Matcher
 from .phrasematcher import PhraseMatcher
 
-__all__ = ["Matcher", "PhraseMatcher", "DependencyMatcher", "levenshtein"]
+__all__ = ["DependencyMatcher", "Matcher", "PhraseMatcher", "levenshtein"]

--- a/spacy/pipeline/__init__.py
+++ b/spacy/pipeline/__init__.py
@@ -22,6 +22,7 @@ from .trainable_pipe import TrainablePipe
 __all__ = [
     "AttributeRuler",
     "DependencyParser",
+    "EditTreeLemmatizer",
     "EntityLinker",
     "EntityRecognizer",
     "EntityRuler",

--- a/spacy/tokens/__init__.py
+++ b/spacy/tokens/__init__.py
@@ -5,4 +5,4 @@ from .span import Span
 from .span_group import SpanGroup
 from .token import Token
 
-__all__ = ["Doc", "Token", "Span", "SpanGroup", "DocBin", "MorphAnalysis"]
+__all__ = ["Doc", "DocBin", "MorphAnalysis", "Span", "SpanGroup", "Token"]

--- a/spacy/training/__init__.py
+++ b/spacy/training/__init__.py
@@ -16,3 +16,28 @@ from .iob_utils import (  # noqa: F401
     tags_to_entities,
 )
 from .loggers import console_logger  # noqa: F401
+
+__all__ = [
+    "Alignment",
+    "Corpus",
+    "Example",
+    "JsonlCorpus",
+    "PlainTextCorpus",
+    "biluo_tags_to_offsets",
+    "biluo_tags_to_spans",
+    "biluo_to_iob",
+    "create_copy_from_base_model",
+    "docs_to_json",
+    "dont_augment",
+    "iob_to_biluo",
+    "minibatch_by_padded_size",
+    "minibatch_by_words",
+    "offsets_to_biluo_tags",
+    "orth_variants_augmenter",
+    "read_json_file",
+    "remove_bilu_prefix",
+    "split_bilu_label",
+    "tags_to_entities",
+    "validate_get_examples",
+    "validate_examples",
+]


### PR DESCRIPTION
Update `__all__` fields across the main modules 
 
## Description
Ensure that the imported classes/functions can be easily imported from the main module instead of a submodule (and doesn't get flagged by type checking). For easier maintenance, alphabetize the lists.

### Types of change
fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
