### PR TITLE
Update llm docs to clarify task-specific factories

### DIFF
--- a/website/docs/api/large-language-models.mdx
+++ b/website/docs/api/large-language-models.mdx
@@ -32,7 +32,7 @@ as well as through task-specific component factories: `llm_ner`, `llm_spancat`,
 > llm = nlp.add_pipe("llm", config=config)
 >
 > # Construction via add_pipe with a task-specific factory and default GPT3.5 model
-> llm = nlp.add_pipe("llm-ner")
+> llm = nlp.add_pipe("llm_ner")
 >
 > # Construction from class
 > from spacy_llm.pipeline import LLMWrapper

--- a/website/docs/api/large-language-models.mdx
+++ b/website/docs/api/large-language-models.mdx
@@ -16,14 +16,6 @@ prototyping** and **prompting**, and turning unstructured responses into
 
 ## Config and implementation {id="config"}
 
-An LLM component is implemented through the `LLMWrapper` class. It is accessible
-through a generic `llm`
-[component factory](https://spacy.io/usage/processing-pipelines#custom-components-factories)
-as well as through task-specific component factories: `llm_ner`, `llm_spancat`,
-`llm_rel`, `llm_textcat`, `llm_sentiment` and `llm_summarization`.
-
-### LLMWrapper.\_\_init\_\_ {id="init",tag="method"}
-
 > #### Example
 >
 > ```python
@@ -34,10 +26,23 @@ as well as through task-specific component factories: `llm_ner`, `llm_spancat`,
 > # Construction via add_pipe with a task-specific factory and default GPT3.5 model
 > llm = nlp.add_pipe("llm_ner")
 >
+> # Construction via add_pipe with a task-specific factory and custom model
+> llm = nlp.add_pipe("llm_ner", config={"model": {"@llm_models": "spacy.Dolly.v1", "name": "dolly-v2-12b"}})
+>
 > # Construction from class
 > from spacy_llm.pipeline import LLMWrapper
 > llm = LLMWrapper(vocab=nlp.vocab, task=task, model=model, cache=cache, save_io=True)
 > ```
+
+An LLM component is implemented through the `LLMWrapper` class. It is accessible
+through a generic `llm`
+[component factory](https://spacy.io/usage/processing-pipelines#custom-components-factories)
+as well as through task-specific component factories: `llm_ner`, `llm_spancat`,
+`llm_rel`, `llm_textcat`, `llm_sentiment` and `llm_summarization`. For these
+factories, the GPT-3-5 model from OpenAI is used by default, but this can be
+customized.
+
+### LLMWrapper.\_\_init\_\_ {id="init",tag="method"}
 
 Create a new pipeline instance. In your application, you would normally use a
 shortcut for this and instantiate the component using its string name and


### PR DESCRIPTION
cf https://github.com/explosion/spaCy/discussions/13080

## Description
Explain that task-specific factories use GPT3.5 by default, but this can be changed by providing config settings.

### Types of change
docs update

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
