### PR TITLE
Add Redfield NLP Nodes to the Spacy Universe

### DIFF
--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -4500,6 +4500,23 @@
                 "website": "https://nlp.unibuc.ro/people/snisioi.html"
             },
             "category": ["pipeline", "training", "models"]
+        },
+        {
+            "id": "redfield-spacy-nodes",
+            "title": "Redfield NLP Nodes for KNIME",
+            "slogan": "Makes the functionality of the spaCy library available in KNIME Analytics Platform.",
+            "description": "This extension provides nodes that make the functionality of the spaCy library available in the [KNIME Analytics Platform](https://www.knime.com/).",
+            "github": "Redfield-AB/Spacy-Nodes",
+            "url": "https://redfield.ai/spacy-redfield/",
+            "thumb": "https://raw.githubusercontent.com/Redfield-AB/Spacy-Nodes/master/resource/redfield_logo_100x100.png",
+            "image": "https://raw.githubusercontent.com/Redfield-AB/Spacy-Nodes/master/resource/screen1.png",
+            "author": "Redfield AB",
+            "author_links": {
+                "twitter": "Redfield_AB",
+                "github": "Redfield-AB",
+                "website": "https://redfield.ai"
+            },
+            "category": ["standalone"]
         }
     ],
 


### PR DESCRIPTION
Add Redfiled NLP Nodes to the Spacy Universe page

## Description
Add an entry in the universe.json file for the Redfiled NLP Nodes - KNIME extension that makes the functionality of the spaCy library available in KNIME Analytics Platform. 

### Types of change
Extending the Spacy Universe page

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
