### PR TITLE
SKETCH: Drop build constraints for python 3.9+

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Configure Python version
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.9"
           architecture: x64
 
       - name: black
@@ -60,10 +60,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python_version: ["3.12"]
         include:
-          - os: windows-latest
-            python_version: "3.7"
-          - os: macos-latest
-            python_version: "3.8"
           - os: ubuntu-latest
             python_version: "3.9"
           - os: windows-latest

--- a/build-constraints.txt
+++ b/build-constraints.txt
@@ -1,6 +1,0 @@
-# build version constraints for use with wheelwright
-numpy==1.15.0; python_version=='3.7' and platform_machine!='aarch64'
-numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64'
-numpy==1.17.3; python_version=='3.8' and platform_machine!='aarch64'
-numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64'
-numpy>=1.25.0; python_version>='3.9'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,7 @@ requires = [
     "preshed>=3.0.2,<3.1.0",
     "murmurhash>=0.28.0,<1.1.0",
     "thinc>=8.1.8,<8.3.0",
-    "numpy>=1.15.0; python_version < '3.9'",
-    "numpy>=1.25.0; python_version >= '3.9'",
+    "numpy>=1.25.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,7 @@ typer>=0.3.0,<0.10.0
 smart-open>=5.2.1,<7.0.0
 weasel>=0.1.0,<0.4.0
 # Third party dependencies
-numpy>=1.15.0; python_version < "3.9"
-numpy>=1.19.0; python_version >= "3.9"
+numpy>=1.19.0
 requests>=2.13.0,<3.0.0
 tqdm>=4.38.0,<5.0.0
 pydantic>=1.7.4,!=1.8,!=1.8.1,<3.0.0
@@ -23,7 +22,6 @@ langcodes>=3.2.0,<4.0.0
 # Official Python utilities
 setuptools
 packaging>=20.0
-typing_extensions>=3.7.4.1,<4.5.0; python_version < "3.8"
 # Development dependencies
 pre-commit>=2.13.0
 cython>=0.25,<3.0
@@ -32,7 +30,7 @@ pytest-timeout>=1.3.0,<2.0.0
 mock>=2.0.0,<3.0.0
 flake8>=3.8.0,<6.0.0
 hypothesis>=3.27.0,<7.0.0
-mypy>=1.5.0,<1.6.0; platform_machine != "aarch64" and python_version >= "3.8"
+mypy>=1.5.0,<1.6.0; platform_machine != "aarch64"
 types-mock>=0.1.1
 types-setuptools>=57.0.0
 types-requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,18 +30,7 @@ project_urls =
 [options]
 zip_safe = false
 include_package_data = true
-python_requires = >=3.7
-# NOTE: This section is superseded by pyproject.toml and will be removed in
-# spaCy v4
-setup_requires =
-    cython>=0.25,<3.0
-    numpy>=1.15.0; python_version < "3.9"
-    numpy>=1.19.0; python_version >= "3.9"
-    # We also need our Cython packages here to compile against
-    cymem>=2.0.2,<2.1.0
-    preshed>=3.0.2,<3.1.0
-    murmurhash>=0.28.0,<1.1.0
-    thinc>=8.1.8,<8.3.0
+python_requires = >=3.9
 install_requires =
     # Our libraries
     spacy-legacy>=3.0.11,<3.1.0
@@ -58,15 +47,13 @@ install_requires =
     typer>=0.3.0,<0.10.0
     smart-open>=5.2.1,<7.0.0
     tqdm>=4.38.0,<5.0.0
-    numpy>=1.15.0; python_version < "3.9"
-    numpy>=1.19.0; python_version >= "3.9"
+    numpy>=1.19.0
     requests>=2.13.0,<3.0.0
     pydantic>=1.7.4,!=1.8,!=1.8.1,<3.0.0
     jinja2
     # Official Python utilities
     setuptools
     packaging>=20.0
-    typing_extensions>=3.7.4.1,<4.5.0; python_version < "3.8"
     langcodes>=3.2.0,<4.0.0
 
 [options.entry_points]

--- a/spacy/tests/package/test_requirements.py
+++ b/spacy/tests/package/test_requirements.py
@@ -5,6 +5,7 @@ from pathlib import Path
 def test_build_dependencies():
     # Check that library requirements are pinned exactly the same across different setup files.
     libs_ignore_requirements = [
+        "cython",
         "numpy",
         "pytest",
         "pytest-timeout",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

The use of `build-constraints.txt` is an explosion-internal design intertwined with `wheelwright`. After dropping python 3.8, the `oldest-supported-numpy`-ish build constraints are no longer necessary, which greatly simplifies the `cibuildwheel` setup, making it much more feasible/sensible to move wheel building into a repo-internal workflow rather than using `wheelwright`.

All of the complicated settings related to `PIP_CONSTRAINT` can be removed from the `cibuildwheel` settings and you can switch to the `build` frontend to have more isolated builds. (I thought this would eliminate the need for the `clean` step for profiling-free python 3.12 builds, but it didn't seem to work in my initial tests.)

`wheelwright` sketch: 

https://github.com/explosion/wheelwright/tree/branch-for-spacy-3899e82e6

`ec2buildwheel` sketch:

https://github.com/explosion/ec2buildwheel/tree/drop-build-constraints

Resulting `wheelwright` build:

https://dev.azure.com/explosion-ai/Public/_build/results?buildId=26889&view=results


### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

?

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ ] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
