### PR TITLE
`TextCatParametricAttention.v1`: set key transform dimensions

### DIFF
--- a/spacy/ml/models/textcat.py
+++ b/spacy/ml/models/textcat.py
@@ -264,6 +264,7 @@ def _build_parametric_attention_with_residual_nonlinear(
 
         parametric_attention.set_ref("tok2vec", tok2vec)
         parametric_attention.set_ref("attention_layer", attention_layer)
+        parametric_attention.set_ref("key_transform", key_transform)
         parametric_attention.set_ref("nonlinear_layer", nonlinear_layer)
         parametric_attention.set_ref("norm_layer", norm_layer)
 
@@ -273,8 +274,10 @@ def _build_parametric_attention_with_residual_nonlinear(
 def _init_parametric_attention_with_residual_nonlinear(model, X, Y) -> Model:
     tok2vec_width = get_tok2vec_width(model)
     model.get_ref("attention_layer").set_dim("nO", tok2vec_width)
-    model.get_ref("nonlinear_layer").set_dim("nO", tok2vec_width)
+    model.get_ref("key_transform").set_dim("nI", tok2vec_width)
+    model.get_ref("key_transform").set_dim("nO", tok2vec_width)
     model.get_ref("nonlinear_layer").set_dim("nI", tok2vec_width)
+    model.get_ref("nonlinear_layer").set_dim("nO", tok2vec_width)
     model.get_ref("norm_layer").set_dim("nI", tok2vec_width)
     model.get_ref("norm_layer").set_dim("nO", tok2vec_width)
     init_chain(model, X, Y)

--- a/spacy/ml/models/textcat.py
+++ b/spacy/ml/models/textcat.py
@@ -185,6 +185,11 @@ def build_text_classifier_v2(
 
 
 def init_ensemble_textcat(model, X, Y) -> Model:
+    # When tok2vec is lazily initialized, we need to initialize it before
+    # the rest of the chain to ensure that we can get its width.
+    tok2vec = model.get_ref("tok2vec")
+    tok2vec.initialize(X)
+
     tok2vec_width = get_tok2vec_width(model)
     model.get_ref("attention_layer").set_dim("nO", tok2vec_width)
     model.get_ref("maxout_layer").set_dim("nO", tok2vec_width)
@@ -272,6 +277,11 @@ def _build_parametric_attention_with_residual_nonlinear(
 
 
 def _init_parametric_attention_with_residual_nonlinear(model, X, Y) -> Model:
+    # When tok2vec is lazily initialized, we need to initialize it before
+    # the rest of the chain to ensure that we can get its width.
+    tok2vec = model.get_ref("tok2vec")
+    tok2vec.initialize(X)
+
     tok2vec_width = get_tok2vec_width(model)
     model.get_ref("attention_layer").set_dim("nO", tok2vec_width)
     model.get_ref("key_transform").set_dim("nI", tok2vec_width)

--- a/spacy/tests/pipeline/test_textcat.py
+++ b/spacy/tests/pipeline/test_textcat.py
@@ -30,6 +30,9 @@ from spacy.training.initialize import init_nlp
 
 from ..util import make_tempdir
 
+# Ensure that the architecture gets added to the registry.
+from ..tok2vec import build_lazy_init_tok2vec as _
+
 TRAIN_DATA_SINGLE_LABEL = [
     ("I'm so happy.", {"cats": {"POSITIVE": 1.0, "NEGATIVE": 0.0}}),
     ("I'm so angry", {"cats": {"POSITIVE": 0.0, "NEGATIVE": 1.0}}),
@@ -39,6 +42,13 @@ TRAIN_DATA_MULTI_LABEL = [
     ("I'm angry and confused", {"cats": {"ANGRY": 1.0, "CONFUSED": 1.0, "HAPPY": 0.0}}),
     ("I'm confused but happy", {"cats": {"ANGRY": 0.0, "CONFUSED": 1.0, "HAPPY": 1.0}}),
 ]
+
+lazy_init_model_config = """
+[model]
+@architectures = "LazyInitTok2Vec.v1"
+width = 96
+"""
+LAZY_INIT_TOK2VEC_MODEL = Config().from_str(lazy_init_model_config)["model"]
 
 
 def make_get_examples_single_label(nlp):
@@ -544,6 +554,34 @@ def test_error_with_multi_labels():
         train_examples.append(Example.from_dict(nlp.make_doc(text), annotations))
     with pytest.raises(ValueError):
         nlp.initialize(get_examples=lambda: train_examples)
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    "name,textcat_config",
+    [
+        # ENSEMBLE V2
+        ("textcat_multilabel", {"@architectures": "spacy.TextCatEnsemble.v2", "tok2vec": LAZY_INIT_TOK2VEC_MODEL, "linear_model": {"@architectures": "spacy.TextCatBOW.v3", "exclusive_classes": False, "ngram_size": 1, "no_output_layer": False}}),
+        ("textcat", {"@architectures": "spacy.TextCatEnsemble.v2", "tok2vec": LAZY_INIT_TOK2VEC_MODEL, "linear_model": {"@architectures": "spacy.TextCatBOW.v3", "exclusive_classes": True, "ngram_size": 5, "no_output_layer": False}}),
+        # PARAMETRIC ATTENTION V1
+        ("textcat", {"@architectures": "spacy.TextCatParametricAttention.v1", "tok2vec": LAZY_INIT_TOK2VEC_MODEL, "exclusive_classes": True}),
+        ("textcat_multilabel", {"@architectures": "spacy.TextCatParametricAttention.v1", "tok2vec": LAZY_INIT_TOK2VEC_MODEL, "exclusive_classes": False}),
+        # REDUCE
+        ("textcat", {"@architectures": "spacy.TextCatReduce.v1", "tok2vec": LAZY_INIT_TOK2VEC_MODEL, "exclusive_classes": True, "use_reduce_first": True, "use_reduce_last": True, "use_reduce_max": True, "use_reduce_mean": True}),
+        ("textcat_multilabel", {"@architectures": "spacy.TextCatReduce.v1", "tok2vec": LAZY_INIT_TOK2VEC_MODEL, "exclusive_classes": False, "use_reduce_first": True, "use_reduce_last": True, "use_reduce_max": True, "use_reduce_mean": True}),
+    ],
+)
+# fmt: on
+def test_tok2vec_lazy_init(name, textcat_config):
+    # Check that we can properly initialize and use a textcat model using
+    # a lazily-initialized tok2vec.
+    nlp = English()
+    pipe_config = {"model": textcat_config}
+    textcat = nlp.add_pipe(name, config=pipe_config)
+    textcat.add_label("POSITIVE")
+    textcat.add_label("NEGATIVE")
+    nlp.initialize()
+    nlp.pipe(["This is a test."])
 
 
 @pytest.mark.parametrize(

--- a/spacy/tests/pipeline/test_textcat.py
+++ b/spacy/tests/pipeline/test_textcat.py
@@ -28,10 +28,9 @@ from spacy.tokens import Doc, DocBin
 from spacy.training import Example
 from spacy.training.initialize import init_nlp
 
-from ..util import make_tempdir
-
 # Ensure that the architecture gets added to the registry.
 from ..tok2vec import build_lazy_init_tok2vec as _
+from ..util import make_tempdir
 
 TRAIN_DATA_SINGLE_LABEL = [
     ("I'm so happy.", {"cats": {"POSITIVE": 1.0, "NEGATIVE": 0.0}}),

--- a/spacy/tests/pipeline/test_textcat.py
+++ b/spacy/tests/pipeline/test_textcat.py
@@ -44,7 +44,7 @@ TRAIN_DATA_MULTI_LABEL = [
 
 lazy_init_model_config = """
 [model]
-@architectures = "LazyInitTok2Vec.v1"
+@architectures = "test.LazyInitTok2Vec.v1"
 width = 96
 """
 LAZY_INIT_TOK2VEC_MODEL = Config().from_str(lazy_init_model_config)["model"]

--- a/spacy/tests/tok2vec.py
+++ b/spacy/tests/tok2vec.py
@@ -1,9 +1,10 @@
 from typing import List
 
-from spacy.util import registry
-from thinc.types import Floats2d
-from spacy.tokens import Doc
 from thinc.api import Model
+from thinc.types import Floats2d
+
+from spacy.tokens import Doc
+from spacy.util import registry
 
 
 @registry.architectures("LazyInitTok2Vec.v1")

--- a/spacy/tests/tok2vec.py
+++ b/spacy/tests/tok2vec.py
@@ -1,0 +1,35 @@
+from typing import List
+
+from spacy.util import registry
+from thinc.types import Floats2d
+from spacy.tokens import Doc
+from thinc.api import Model
+
+
+@registry.architectures("LazyInitTok2Vec.v1")
+def build_lazy_init_tok2vec(*, width: int) -> Model[List[Doc], List[Floats2d]]:
+    """tok2vec model of which the output size is only known after
+    initialization. This implementation does not output meaningful
+    embeddings, it is strictly for testing."""
+    return Model(
+        "lazy_init_tok2vec",
+        lazy_init_tok2vec_forward,
+        init=lazy_init_tok2vec_init,
+        dims={"nO": None},
+        attrs={"width": width},
+    )
+
+
+def lazy_init_tok2vec_init(model: Model, X=None, Y=None):
+    width = model.attrs["width"]
+    model.set_dim("nO", width)
+
+
+def lazy_init_tok2vec_forward(model: Model, X: List[Doc], is_train: bool):
+    width = model.get_dim("nO")
+    Y = [model.ops.alloc2f(len(doc), width) for doc in X]
+
+    def backprop(dY):
+        return []
+
+    return Y, backprop

--- a/spacy/tests/tok2vec.py
+++ b/spacy/tests/tok2vec.py
@@ -7,7 +7,7 @@ from spacy.tokens import Doc
 from spacy.util import registry
 
 
-@registry.architectures("LazyInitTok2Vec.v1")
+@registry.architectures("test.LazyInitTok2Vec.v1")
 def build_lazy_init_tok2vec(*, width: int) -> Model[List[Doc], List[Floats2d]]:
     """tok2vec model of which the output size is only known after
     initialization. This implementation does not output meaningful


### PR DESCRIPTION
This is necessary for tok2vec implementations that initialize lazily (e.g. curated transformers).

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Set key transform dimensions in `TextCatParametricAttention.v1`, otherwise the key transformation dimensionality cannot be inferred for lazily-initialized tok2vecs listeners like transformers.

Not sure how we can test this without making a new tok2vec model in spaCy that is lazily initialized (does know its width until initialization). Maybe we should add a separate model to the tests?

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
