### PR TITLE
fix typo

### DIFF
--- a/website/docs/api/large-language-models.mdx
+++ b/website/docs/api/large-language-models.mdx
@@ -1507,7 +1507,7 @@ These models all take the same parameters:
 > ```ini
 > [components.llm.model]
 > @llm_models = "spacy.Llama2.v1"
-> name = "llama2-7b-hf"
+> name = "Llama-2-7b-hf"
 > ```
 
 Currently, these models are provided as part of the core library:


### PR DESCRIPTION
Should be cherry-picked to `spacy.io` after merging.

## Description
Fix typo in model name for example `Llama` code snippet

### Types of change
doc fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
