### PR TITLE
Clarify data_path loading for apply CLI command

### DIFF
--- a/website/docs/api/cli.mdx
+++ b/website/docs/api/cli.mdx
@@ -1296,7 +1296,7 @@ input formats are:
 
 When a directory is provided it is traversed recursively to collect all files.
 
-When loading a .spacy file, any potential annotations stored on the `Doc` that are not overwritten by a pipe will be preserved.
+When loading a .spacy file, any potential annotations stored on the `Doc` that are not overwritten by the pipeline will be preserved.
 If you want to evaluate the pipeline on raw text only, make sure that the .spacy file does not contain any annotations.
 
 ```bash

--- a/website/docs/api/cli.mdx
+++ b/website/docs/api/cli.mdx
@@ -1296,6 +1296,9 @@ input formats are:
 
 When a directory is provided it is traversed recursively to collect all files.
 
+When loading a .spacy file, any potential annotations stored on the `Doc` will be preserved.
+If you want to evaluate the pipeline on raw text only, make sure that the .spacy file does not contain any annotations.
+
 ```bash
 $ python -m spacy apply [model] [data-path] [output-file] [--code] [--text-key] [--force-overwrite] [--gpu-id] [--batch-size] [--n-process]
 ```

--- a/website/docs/api/cli.mdx
+++ b/website/docs/api/cli.mdx
@@ -1296,7 +1296,7 @@ input formats are:
 
 When a directory is provided it is traversed recursively to collect all files.
 
-When loading a .spacy file, any potential annotations stored on the `Doc` will be preserved.
+When loading a .spacy file, any potential annotations stored on the `Doc` that are not overwritten by a pipe will be preserved.
 If you want to evaluate the pipeline on raw text only, make sure that the .spacy file does not contain any annotations.
 
 ```bash


### PR DESCRIPTION
Fixes https://github.com/explosion/spaCy/issues/13230

## Description
Attempt to clarify that if a specified .spacy file contains annotations, that these will be preserved by the `apply` CLI command, and run through the pipeline as is. There are valid cases to do for this, like e.g. evaluating an EL pipeline on files that have gold entities, but the behaviour may be surprising for users assuming that the pipeline will be applied to raw text only.

### Types of change
doc update

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
