### PR TITLE
Clarify vocab docs

### DIFF
--- a/website/docs/api/vocab.mdx
+++ b/website/docs/api/vocab.mdx
@@ -13,7 +13,7 @@ between `Doc` objects.
 <Infobox variant ="warning">
 
 Note that a `Vocab` instance is not static. It increases in size as texts with
-new tokens are processed.
+new tokens are processed. Some models may have an empty vocab at initialization.
 
 </Infobox>
 

--- a/website/docs/api/vocab.mdx
+++ b/website/docs/api/vocab.mdx
@@ -93,6 +93,7 @@ given string, you need to look it up in
 > #### Example
 >
 > ```python
+> nlp("I'm eating an apple")
 > apple = nlp.vocab.strings["apple"]
 > oov = nlp.vocab.strings["dskfodkfos"]
 > assert apple in nlp.vocab


### PR DESCRIPTION
Fixes https://github.com/explosion/spaCy/issues/13252

## Description
The example in the docs assumes that `"apple"` is in the vocab but this isn't necessarily the case. Expanding the example to ensure that it is, and to (hopefully) clarify that the vocab works as a cache.

### Types of change
docs update

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
