### PR TITLE
Extension serialization attr tests: add teardown

### DIFF
--- a/spacy/tests/serialize/test_serialize_extension_attrs.py
+++ b/spacy/tests/serialize/test_serialize_extension_attrs.py
@@ -15,7 +15,12 @@ def doc_w_attrs(en_tokenizer):
     Token.set_extension("_test_token", default="t0")
     doc[1]._._test_token = "t1"
 
-    return doc
+    yield doc
+
+    Doc.remove_extension("_test_attr")
+    Doc.remove_extension("_test_prop")
+    Doc.remove_extension("_test_method")
+    Token.remove_extension("_test_token")
 
 
 def test_serialize_ext_attrs_from_bytes(doc_w_attrs):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

The doc/token extension serialization tests add extensions that are not
serializable with pickle. This didn't cause issues before due to the
implicit run order of tests. However, test ordering has changed with
pytest 8.0.0, leading to failed tests in test_language.

Update the fixtures in the extension serialization tests to do proper
teardown and remove the extensions.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bugfix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
