### PR TITLE
Sanitize direct download

### DIFF
--- a/spacy/cli/__init__.py
+++ b/spacy/cli/__init__.py
@@ -2,7 +2,6 @@ from wasabi import msg
 
 # Needed for testing
 from . import download as download_module  # noqa: F401
-
 from ._util import app, setup_cli  # noqa: F401
 from .apply import apply  # noqa: F401
 from .assemble import assemble_cli  # noqa: F401

--- a/spacy/cli/__init__.py
+++ b/spacy/cli/__init__.py
@@ -1,5 +1,8 @@
 from wasabi import msg
 
+# Needed for testing
+from . import download as download_module  # noqa: F401
+
 from ._util import app, setup_cli  # noqa: F401
 from .apply import apply  # noqa: F401
 from .assemble import assemble_cli  # noqa: F401

--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -4,6 +4,7 @@ from typing import Optional, Sequence
 import requests
 import typer
 from wasabi import msg
+from urllib.parse import urljoin
 
 from .. import about
 from ..errors import OLD_MODEL_SHORTCUTS
@@ -63,6 +64,13 @@ def download(
         )
         pip_args = pip_args + ("--no-deps",)
     if direct:
+        # Reject model names with '/', in order to prevent shenanigans.
+        if "/" in model:
+            msg.fail(
+                title="Model download rejected",
+                text=f"Cannot download model '{model}'. Models are expected to be file names, not URLs or fragments",
+                exits=True,
+            )
         components = model.split("-")
         model_name = "".join(components[:-1])
         version = components[-1]
@@ -153,7 +161,16 @@ def get_latest_version(model: str) -> str:
 def download_model(
     filename: str, user_pip_args: Optional[Sequence[str]] = None
 ) -> None:
-    download_url = about.__download_url__ + "/" + filename
+    # Construct the download URL carefully. We need to make sure we don't
+    # allow relative paths or other shenanigans to trick us into download
+    # from outside our own repo.
+    base_url = about.__download_url__
+    if not base_url.endswith("/"):
+        base_url = about.__download_url__ + "/"
+    download_url = urljoin(base_url, filename)
+    print(base_url, filename, download_url)
+    if not download_url.startswith(about.__download_url__):
+        raise ValueError(f"Download from {filename} rejected. Was it a relative path?")
     pip_args = list(user_pip_args) if user_pip_args is not None else []
     cmd = [sys.executable, "-m", "pip", "install"] + pip_args + [download_url]
     run_command(cmd)

--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -165,10 +165,10 @@ def download_model(
     # allow relative paths or other shenanigans to trick us into download
     # from outside our own repo.
     base_url = about.__download_url__
+    # urljoin requires that the path ends with /, or the last path part will be dropped
     if not base_url.endswith("/"):
         base_url = about.__download_url__ + "/"
     download_url = urljoin(base_url, filename)
-    print(base_url, filename, download_url)
     if not download_url.startswith(about.__download_url__):
         raise ValueError(f"Download from {filename} rejected. Was it a relative path?")
     pip_args = list(user_pip_args) if user_pip_args is not None else []

--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -1,10 +1,10 @@
 import sys
 from typing import Optional, Sequence
+from urllib.parse import urljoin
 
 import requests
 import typer
 from wasabi import msg
-from urllib.parse import urljoin
 
 from .. import about
 from ..errors import OLD_MODEL_SHORTCUTS

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -25,6 +25,8 @@ from spacy.cli.debug_data import (
     _get_spans_length_freq_dist,
     _print_span_characteristics,
 )
+
+from spacy.cli import download_module
 from spacy.cli.download import get_compatibility, get_version
 from spacy.cli.evaluate import render_parses
 from spacy.cli.find_threshold import find_threshold
@@ -1066,3 +1068,15 @@ def test_debug_data_trainable_lemmatizer_not_annotated():
 def test_project_api_imports():
     from spacy.cli import project_run
     from spacy.cli.project.run import project_run  # noqa: F401, F811
+
+
+def test_download_rejects_relative_urls(monkeypatch):
+    """Test that we can't tell spacy download to get an arbitrary model by using a
+    relative path in the filename"""
+
+    monkeypatch.setattr(download_module, "run_command", lambda cmd: None)
+
+    # Check that normal download works
+    download_module.download("en_core_web_sm-3.7.1", direct=True)
+    with pytest.raises(SystemExit):
+        download_module.download("../en_core_web_sm-3.7.1", direct=True)

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -12,7 +12,7 @@ from thinc.api import Config
 
 import spacy
 from spacy import about
-from spacy.cli import info
+from spacy.cli import download_module, info
 from spacy.cli._util import parse_config_overrides, string_to_list, walk_directory
 from spacy.cli.apply import apply
 from spacy.cli.debug_data import (
@@ -25,8 +25,6 @@ from spacy.cli.debug_data import (
     _get_spans_length_freq_dist,
     _print_span_characteristics,
 )
-
-from spacy.cli import download_module
 from spacy.cli.download import get_compatibility, get_version
 from spacy.cli.evaluate import render_parses
 from spacy.cli.find_threshold import find_threshold


### PR DESCRIPTION
The 'direct' option in 'spacy download' is supposed to only download from our model releases repository. However, users were able to pass in a relative path, allowing download from arbitrary repositories. This meant that a service that sourced strings from user input and which used the direct option would allow users to install arbitrary packages.