### PR TITLE
Renamed main branch back to v4 for now

### DIFF
--- a/.github/workflows/gputests.yml
+++ b/.github/workflows/gputests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [master, main]
+        branch: [master, v4]
     if: github.repository_owner == 'explosion'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/slowtests.yml
+++ b/.github/workflows/slowtests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [master, main]
+        branch: [master, v4]
     if: github.repository_owner == 'explosion'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION

## Description
For clarity, renamed `main` back to `v4` to avoid confusion for users.

### Types of change
fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
