### PR TITLE
Bump weasel upper pin to allow v0.4.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ wasabi>=0.9.1,<1.2.0
 srsly>=2.4.3,<3.0.0
 catalogue>=2.0.6,<2.1.0
 typer>=0.3.0,<0.10.0
-weasel>=0.1.0,<0.4.0
+weasel>=0.1.0,<0.5.0
 # Third party dependencies
 numpy>=1.15.0; python_version < "3.9"
 numpy>=1.19.0; python_version >= "3.9"

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     wasabi>=0.9.1,<1.2.0
     srsly>=2.4.3,<3.0.0
     catalogue>=2.0.6,<2.1.0
-    weasel>=0.1.0,<0.4.0
+    weasel>=0.1.0,<0.5.0
     # Third-party dependencies
     typer>=0.3.0,<0.10.0
     tqdm>=4.38.0,<5.0.0


### PR DESCRIPTION
## Description
Bump weasel upper pin to allow v0.4.x.

Weasel 0.4.0 has no breaking changes other than dropping Python 3.6, which spaCy already did since 3.7.0.

### Types of change
Update

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
