### PR TITLE
Fix docs for MorphAnalysis.__contains__

### DIFF
--- a/website/docs/api/morphology.mdx
+++ b/website/docs/api/morphology.mdx
@@ -147,9 +147,10 @@ Whether a feature/value pair is in the analysis.
 > assert "Feat1=Val1" in morph
 > ```
 
-| Name        | Description                                   |
-| ----------- | --------------------------------------------- |
-| **RETURNS** | A feature/value pair in the analysis. ~~str~~ |
+| Name         | Description                                                           |
+| ------------ | --------------------------------------------------------------------- |
+| `feature`    | A feature/value pair. ~~str~~                                         |
+| **RETURNS**  | Whether the feature/value pair is contained in the analysis. ~~bool~~ |
 
 ### MorphAnalysis.\_\_iter\_\_ {id="morphanalysis-iter",tag="method"}
 


### PR DESCRIPTION

## Description
Fix #13406: Fixing the documentation of `MorphAnalysis.__contains__`  

### Types of change
docs fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
