### PR TITLE
Remove typing-extensions from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ langcodes>=3.2.0,<4.0.0
 # Official Python utilities
 setuptools
 packaging>=20.0
-typing_extensions>=3.7.4.1,<4.5.0; python_version < "3.8"
 # Development dependencies
 pre-commit>=2.13.0
 cython>=0.25,<3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,6 @@ install_requires =
     # Official Python utilities
     setuptools
     packaging>=20.0
-    typing_extensions>=3.7.4.1,<4.5.0; python_version < "3.8"
     langcodes>=3.2.0,<4.0.0
 
 [options.entry_points]


### PR DESCRIPTION
## Description
Removing `typing-extensions` from spaCy's requirements, as this is dealt with by `confection`. In the latest release `v0.1.5` of `confection`, we've [bumped](https://github.com/explosion/confection/pull/63) the upper pin to allow up to 5.0.0 for Python < 3.8, hopefully dealing with an install issue that was preventing us to build the wheels for spaCy 3.7.5. 

### Types of change
Fix & update

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
