### PR TITLE
Fix typing errors with set_extenion methods

### DIFF
--- a/spacy/tokens/doc.pyi
+++ b/spacy/tokens/doc.pyi
@@ -28,8 +28,12 @@ from .underscore import Underscore
 
 DOCBIN_ALL_ATTRS: Tuple[str, ...]
 
-class DocMethod(Protocol):
-    def __call__(self: Doc, *args: Any, **kwargs: Any) -> Any: ...  # type: ignore[misc]
+DocMethod = Union[
+ Callable[[Doc], Any],
+ Callable[[Doc, Any], Any],
+ Callable[[Doc, Any, Any], Any],
+ Callable[[Doc, Any, Any, Any], Any],
+]
 
 class Doc:
     vocab: Vocab

--- a/spacy/tokens/span.pyi
+++ b/spacy/tokens/span.pyi
@@ -8,8 +8,12 @@ from .doc import Doc
 from .token import Token
 from .underscore import Underscore
 
-class SpanMethod(Protocol):
-    def __call__(self: Span, *args: Any, **kwargs: Any) -> Any: ...  # type: ignore[misc]
+SpanMethod = Union[
+ Callable[[Span], Any],
+ Callable[[Span, Any], Any],
+ Callable[[Span, Any, Any], Any],
+ Callable[[Span, Any, Any, Any], Any],
+]
 
 class Span:
     @classmethod

--- a/spacy/tokens/token.pyi
+++ b/spacy/tokens/token.pyi
@@ -9,8 +9,12 @@ from .morphanalysis import MorphAnalysis
 from .span import Span
 from .underscore import Underscore
 
-class TokenMethod(Protocol):
-    def __call__(self: Token, *args: Any, **kwargs: Any) -> Any: ...  # type: ignore[misc]
+TokenMethod = Union[
+ Callable[[Token], Any],
+ Callable[[Token, Any], Any],
+ Callable[[Token, Any, Any], Any],
+ Callable[[Token, Any, Any, Any], Any],
+]
 
 class Token:
     i: int


### PR DESCRIPTION
## Description
eg:
```
Argument of type "(span: Span, tag: str) -> str" cannot be assigned to parameter "method" of type "SpanMethod | None" in function "set_extension"
  Type "(span: Span, tag: str) -> str" is incompatible with type "SpanMethod | None"
    "function" is incompatible with protocol "SpanMethod"
      "__call__" is not present
    "function" is incompatible with "None"PylancereportArgumentType
```

Rationale:
`Callable` only accepts a single parameter, optional parameters don't work ... isn't recognized as variadic arguments (... not valid here) SomeMethod(Protocol) __call__ approach doesn't support mapping non variadic arguments to variadic arguments. Therefore, to not break the currently documented interface, implement a union of Callable overloads.

### Types of change
Typing fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
