### PR TITLE
universe-pipeline-solipCysme-french

### DIFF
--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -277,6 +277,47 @@
             ]
         },
         {
+            "id": "solipcysme",
+            "title": "solipCysme",
+            "slogan": "spaCy pipeline for french fictions and first person point of view texts.",
+            "description": "__solipCysme__ is a pipeline for french language, designed for the analysis of fictions and first person point of view texts, with a focus on personal pronouns.",
+            "github": "thjbdvlt/solipCysme",
+            "code_example": [
+                "pip install https://huggingface.co/thjbdvlt/fr_solipcysme/resolve/main/fr_solipcysme-any-py3-none-any.whl",
+                "",
+                "import spacy",
+                "",
+                "nlp = spacy.load('fr_solipcysme')",
+                "for i in nlp(",
+                "'la MACHINE à (b)rouiller le temps s'est peut-être déraillée..?'",
+                "):",
+                "    print(",
+                "        i, ",
+                "        i.norm_, ",
+                "        i.pos_, ",
+                "        i.morph, ",
+                "        i.lemma_, ",
+                "        i.dep_, ",
+                "        i._.tokentype,",
+                "        i._.vv_pos,",
+                "        i._.vv_morph",
+                "    )"
+            ],
+            "code_language": "python",
+            "author": "thjbdvlt",
+            "author_links": {
+                "github": "thjbdvlt"
+            },
+            "category": [
+                "pipeline",
+                "research",
+                "models"
+            ],
+            "tags": [
+                "french"
+            ]
+        },
+        {
             "id": "spacy-cleaner",
             "title": "spacy-cleaner",
             "slogan": "Easily clean text with spaCy!",


### PR DESCRIPTION
Add a pipeline ([solipcysme](https://github.com/thjbdvlt/solipCysme)) for french language, designed for the analysis of fictions and first person point of view texts, primarly focused on personal pronouns. It aims to fill a gap in french models: the currently available pipelines for french are trained on 'news' data, a special kind of data that lack of personal pronouns (as an example: 'tu', which means 'you', is not in the data), and of some verb modes (e.g. imperative) very usual in fictions.

PS: The pipeline integrates two small projects that are already in the spaCy universe (_presque_, a normalizer for french, and _quelquhui_, a tokenizer for french). Maybe i should remove these projects, so i only have one there?