### PR TITLE
[Documentation] Replace broken URL in  _serialization.mdx

### DIFF
--- a/website/docs/usage/101/_serialization.mdx
+++ b/website/docs/usage/101/_serialization.mdx
@@ -4,7 +4,7 @@ progress** – for example, everything that's in your `nlp` object. This means
 you'll have to translate its contents and structure into a format that can be
 saved, like a file or a byte string. This process is called serialization. spaCy
 comes with **built-in serialization methods** and supports the
-[Pickle protocol](https://www.diveinto.org/python3/serializing.html#dump).
+[Pickle protocol](https://docs.python.org/3/library/pickle.html).
 
 > #### What's pickle?
 >


### PR DESCRIPTION
## Description

"Pickle protocol" text previously linked to https://www.diveinto.org/python3/serializing.html#dump, however diveinto is not currently a valid domain. Updating hyperlink to the Python documentation for pickle.

### Types of change
Documentation.

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
