### PR TITLE
Fix typo (#13657) [ci skip]

### DIFF
--- a/website/docs/api/large-language-models.mdx
+++ b/website/docs/api/large-language-models.mdx
@@ -1597,7 +1597,7 @@ The name of the model to be used has to be passed in via the `name` attribute.
 
 | Argument | Description                                                                                                                                                           |
 | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`   | The name of a mdodel supported by LangChain for this API. ~~str~~                                                                                                     |
+| `name`   | The name of a model supported by LangChain for this API. ~~str~~                                                                                                     |
 | `config` | Configuration passed on to the LangChain model. Defaults to `{}`. ~~Dict[Any, Any]~~                                                                                  |
 | `query`  | Function that executes the prompts. If `None`, defaults to `spacy.CallLangChain.v1`. ~~Optional[Callable[["langchain.llms.BaseLLM", Iterable[Any]], Iterable[Any]]]~~ |
 


### PR DESCRIPTION
Fixes "mdodel" to "model". 