### PR TITLE
remove reference to python 3.13 in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
     Topic :: Scientific/Engineering
 project_urls =
     Release notes = https://github.com/explosion/spaCy/releases


### PR DESCRIPTION
## Description
https://github.com/explosion/spaCy/commit/85cc763006c6cbe69c31d41ac53fa20699551801 changed the supported python range to exclude 3.13 but left this entry in `classifiers` after it had been previously added.

related:
https://github.com/explosion/spaCy/commit/a6317b3836966f1298bfc95a604662d4fdb9ce60 https://github.com/explosion/spaCy/commit/343f4f21d706971be93757b430bad39e9ed49ed3

I'm not familiar with the reasons for the back and forth on this but it confused me that its mentioned in setup.cfg but not actually pip installable in python 3.13.

### Types of change
Should be a noop, just tidying.

tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
