### PR TITLE
docs: fix README.md for compatible Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ For detailed installation instructions, see the
 
 - **Operating system**: macOS / OS X · Linux · Windows (Cygwin, MinGW, Visual
   Studio)
-- **Python version**: Python 3.7+ (only 64 bit)
+- **Python version**: Python >=3.7, <=3.12 (only 64 bit)
 - **Package managers**: [pip] · [conda] (via `conda-forge`)
 
 [pip]: https://pypi.org/project/spacy/


### PR DESCRIPTION
## Description
SpaCy 3.8 is not compatible with Python 3.13 yet but the doc says otherwise, which can lead for users to loose time on that if they are ill-informed.
See https://github.com/explosion/spaCy/issues/13658

### Types of change
Update README.md to fix compatible Python versions.
