### PR TITLE
[Enhancement]: add scores to Displacy entity markup

### DIFF
--- a/spacy/displacy/render.py
+++ b/spacy/displacy/render.py
@@ -14,6 +14,7 @@ from .templates import (
     TPL_FIGURE,
     TPL_KB_LINK,
     TPL_PAGE,
+    TPL_SCORE,
     TPL_SPAN,
     TPL_SPAN_RTL,
     TPL_SPAN_SLICE,
@@ -579,6 +580,7 @@ class EntityRenderer:
             label = span["label"]
             start = span["start"]
             end = span["end"]
+            score = TPL_SCORE.format(score=span["score"]) if "score" in span else ""
             kb_id = span.get("kb_id", "")
             kb_url = span.get("kb_url", "#")
             kb_link = TPL_KB_LINK.format(kb_id=kb_id, kb_url=kb_url) if kb_id else ""
@@ -596,6 +598,7 @@ class EntityRenderer:
                     "text": entity,
                     "bg": color,
                     "kb_link": kb_link,
+                    "score": score,
                 }
                 ent_settings.update(additional_params)
                 markup += self.ent_template.format(**ent_settings)

--- a/spacy/displacy/templates.py
+++ b/spacy/displacy/templates.py
@@ -51,14 +51,14 @@ TPL_ENTS = """
 TPL_ENT = """
 <mark class="entity" style="background: {bg}; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em;">
     {text}
-    <span style="font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; vertical-align: middle; margin-left: 0.5rem">{label}{kb_link}</span>
+    <span style="font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; vertical-align: middle; margin-left: 0.5rem">{label}{kb_link}{score}</span>
 </mark>
 """
 
 TPL_ENT_RTL = """
 <mark class="entity" style="background: {bg}; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em">
     {text}
-    <span style="font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; vertical-align: middle; margin-right: 0.5rem">{label}{kb_link}</span>
+    <span style="font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; vertical-align: middle; margin-right: 0.5rem">{label}{kb_link}{score}</span>
 </mark>
 """
 
@@ -127,3 +127,5 @@ TPL_PAGE = """
     <body style="font-size: 16px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; padding: 4rem 2rem; direction: {dir}">{content}</body>
 </html>
 """
+
+TPL_SCORE = "({score:.2f})"


### PR DESCRIPTION
## Description
This PR adds the ability to pass scores along with entities to displacy with the manual mode. If no score is passed there is no change.

It uses the template below: 
```
# Doing it with a template similar to TPL_KB_LINK so that we don't get empty '()' parenthesis if no score is present
TPL_SCORE = "({score:.2f})"
```
not sure if should allow modification of template|precision through options?

### Example
So far only tested with `manual=True` mode on jupyter, but if anyone else is willing to complete it feel free~

```
from spacy import displacy

text="Hello world with scores"
formatted_entities =[  {'start': 0,
                        'end': 5,
                        'label': 'greeting',
                        'score': 0.90},
                        {'start': 5,
                        'end': 11,
                        'label': 'planet',
                        'score': 0.86666},
                        {'start': 17,
                        'end': 23,
                        'label': 'yeay',
                        'score': 0.5},
                        ]
displacy.render([{"text": text, "ents": formatted_entities, "title": None}], style="ent", manual=True,jupyter=True)
```
<img width="439" alt="image" src="https://github.com/user-attachments/assets/c1f2b7b6-39d0-4cc6-bded-0bfa2156a260" />

If a 'score' doesn't exist it isn't shown:
<img width="393" alt="image" src="https://github.com/user-attachments/assets/93fa8936-4b00-4be5-9c3b-9c4e8024cb1e" />
 

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ ] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
