### PR TITLE
displacy: fix import path for ipython 9.0.1

### DIFF
--- a/spacy/displacy/__init__.py
+++ b/spacy/displacy/__init__.py
@@ -66,7 +66,12 @@ def render(
     if jupyter or (jupyter is None and is_in_jupyter()):
         # return HTML rendered by IPython display()
         # See #4840 for details on span wrapper to disable mathjax
-        from IPython.core.display import HTML, display
+        try:
+            # import path was changed in IPython 8.0.0 43a01a21101ea65dbd52cf760c1e4f149bfab588
+            # and the path shim was finally removed in 9.0.1 8a0533f31abcc4cb4341858bdeee86e2061c4fd9
+            from IPython.display import HTML, display
+        except ImportError:
+            from IPython.core.display import HTML, display
 
         return display(HTML('<span class="tex2jax_ignore">{}</span>'.format(html)))
     return html


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

With IPython 9.0.1, they [removed the `IPython.core.display` shim](https://github.com/ipython/ipython/commit/8a0533f31abcc4cb4341858bdeee86e2061c4fd9) that `displacy.render()` relied on. This was apparently deprecated in [IPython 8.0.0](https://github.com/ipython/ipython/commit/43a01a21101ea65dbd52cf760c1e4f149bfab588).

This fixes it by trying the newer import path if possible, falling back to the older one.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

I am unable to install the packages in requirements.txt due to `thinc<8.4.0,>=8.3.4` being unsatisfied since there's only nearby version 8 package is `8.3.2` and then it skips to `9.0.0.dev0`. However, editing this line locally fixed the import issue.