### PR TITLE
Update mock import to work with Python 3.13

### DIFF
--- a/spacy/tests/doc/test_underscore.py
+++ b/spacy/tests/doc/test_underscore.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 
 from spacy.tokens import Doc, Span, Token
 from spacy.tokens.underscore import Underscore

--- a/spacy/tests/matcher/test_dependency_matcher.py
+++ b/spacy/tests/matcher/test_dependency_matcher.py
@@ -3,7 +3,7 @@ import pickle
 import re
 
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 
 from spacy.matcher import DependencyMatcher
 from spacy.tokens import Doc, Token

--- a/spacy/tests/matcher/test_matcher_api.py
+++ b/spacy/tests/matcher/test_matcher_api.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 
 from spacy.matcher import Matcher
 from spacy.tokens import Doc, Span, Token

--- a/spacy/tests/matcher/test_phrase_matcher.py
+++ b/spacy/tests/matcher/test_phrase_matcher.py
@@ -2,7 +2,7 @@ import warnings
 
 import pytest
 import srsly
-from mock import Mock
+from unittest.mock import Mock
 
 from spacy.lang.en import English
 from spacy.matcher import Matcher, PhraseMatcher

--- a/spacy/tests/pipeline/test_analysis.py
+++ b/spacy/tests/pipeline/test_analysis.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 
 from spacy.language import Language
 from spacy.pipe_analysis import get_attr_info, validate_attrs


### PR DESCRIPTION

## Description

There's no `mock` import in Python 3.13 so need to update to `unittest`

### Types of change

Update `mock` import to `unittest.mock`

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
