### PR TITLE
Update spaCy Universe entry for ChatterBot to use the correct name casing

### DIFF
--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -1307,7 +1307,7 @@
         },
         {
             "id": "Chatterbot",
-            "title": "Chatterbot",
+            "title": "ChatterBot",
             "slogan": "A machine-learning based conversational dialog engine for creating chat bots",
             "github": "gunthercox/ChatterBot",
             "pip": "chatterbot",


### PR DESCRIPTION
## Description

This is a very small change to update the `title` attribute of the [spaCy Universe entry for ChatterBot](https://spacy.io/universe/project/Chatterbot) to use the correct casing for the name so that it matches the logo and casing of the [ChatterBot GitHub repository](https://github.com/gunthercox/chatterbot) and [documentation](https://docs.chatterbot.us/).

Current:

![image](https://github.com/user-attachments/assets/97d55ff0-05c5-448e-a33b-49dcfaf2a2bc)

Expected:

![image](https://github.com/user-attachments/assets/13278baf-0d37-4ee3-9190-e46ab50692fa)

### Types of change

Documentation update

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

***

_P.S. The spaCy Universe collection is wonderful and I was quite happy and surprised when I recently stumbled upon the fact that ChatterBot had an entry there._