### PR TITLE
Fix: Update display import for compatibility with latest IPython

### DIFF
--- a/spacy/displacy/__init__.py
+++ b/spacy/displacy/__init__.py
@@ -66,7 +66,7 @@ def render(
     if jupyter or (jupyter is None and is_in_jupyter()):
         # return HTML rendered by IPython display()
         # See #4840 for details on span wrapper to disable mathjax
-        from IPython.core.display import HTML, display
+        from IPython.display import HTML, display
 
         return display(HTML('<span class="tex2jax_ignore">{}</span>'.format(html)))
     return html


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

**Fix: Update display import for compatibility with latest IPython**

---

## Description

This PR updates the import statement in `displacy.render()` to fix an `ImportError` caused by breaking changes in IPython 9+.

Replaced:

```python
from IPython.core.display import HTML, display
```

With:

```python
from IPython.display import HTML, display
```

The `display` function is no longer available in `IPython.core.display` in IPython 9 and above. This change ensures `displacy.render()` works correctly in Jupyter and notebook environments using newer versions of IPython.

**Tested in:**
- Python 3.12.9 (venv)
- IPython 9.0.2
- JupyterLab
- Confirmed `displacy.render()` now works without error.

---

### Types of change

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Documentation update

---

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

---

Let me know if you want to attach an issue number or want help creating tests for the fix!