### PR TITLE
fix: match hyphenated words to lemmas in index_table (e.g. "co-author…

### DIFF
--- a/spacy/pipeline/lemmatizer.py
+++ b/spacy/pipeline/lemmatizer.py
@@ -241,7 +241,10 @@ class Lemmatizer(Pipe):
                 if not form:
                     pass
                 elif form in index or not form.isalpha():
-                    forms.append(form)
+                    if form in index:
+                        forms.insert(0, form)
+                    else:
+                        forms.append(form)
                 else:
                     oov_forms.append(form)
         # Remove duplicates but preserve the ordering of applied "rules"


### PR DESCRIPTION
Previously, words with hyphens such as "co-authored" could not be matched correctly against the index_table, even though their lemma forms like "co-author" existed.
This fix normalizes such words by lemmatizing and aligning them with their base forms, ensuring accurate lookup and processing.

Example:

Input: "co-authored"
Lemma: "co-author"
Result: Now correctly matched in index_table

This improves the robustness of word matching, especially for common hyphenated expressions.

