### PR TITLE
fix: DeprecationWarning: Importing 'parser.split_arg_string' is deprecated, it will only be available in 'shell_completion' in Click 9.0.

### DIFF
--- a/spacy/cli/_util.py
+++ b/spacy/cli/_util.py
@@ -20,7 +20,7 @@ from typing import (
 import srsly
 import typer
 from click import NoSuchOption
-from click.parser import split_arg_string
+from click.shell_completion import split_arg_string
 from thinc.api import Config, ConfigValidationError, require_gpu
 from thinc.util import gpu_is_available
 from typer.main import get_command


### PR DESCRIPTION
This appears as Click release 8.2.0: https://click.palletsprojects.com/en/stable/changes

But I also noticed that `requirements.txt` does not include `click`. Any idea?