### PR TITLE
Fix quirk of enum values in Python

### DIFF
--- a/spacy/attrs.pyx
+++ b/spacy/attrs.pyx
@@ -91,6 +91,9 @@ IDS = {
     "MORPH": MORPH,
     "IDX": IDX,
 }
+# Make these ints in Python, so that we don't get this unexpected 'flag' type
+# This will match the behaviour before Cython 3
+IDS = {name: int(value) for name, value in IDS.items()}
 
 
 # ATTR IDs, in order of the symbol

--- a/spacy/parts_of_speech.pyx
+++ b/spacy/parts_of_speech.pyx
@@ -23,7 +23,9 @@ IDS = {
     "SPACE": SPACE
 }
 
-
+# Make these ints in Python, so that we don't get this unexpected 'flag' type
+# This will match the behaviour before Cython 3
+IDS = {name: int(value) for name, value in IDS.items()}
 NAMES = {value: key for key, value in IDS.items()}
 
 # As of Cython 3.1, the global Python namespace no longer has the enum


### PR DESCRIPTION
After the Cython 3 change, the types of enum members such as spacy.parts_of_speech.NOUN became 'flag', rather than simple 'int'. This change mostly doesn't matter because the flag type does duck-type like an int -- it compares, additions, prints etc the same. However, it doesn't repr the same and if you do an isinstance check it will fail. It's therefore better to just make them ints like they were before.

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ ] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
