### PR TITLE
Fix Typos in Documentation and Vietnamese Lexical Attributes

### DIFF
--- a/spacy/cli/info.py
+++ b/spacy/cli/info.py
@@ -84,7 +84,7 @@ def info(
 
 
 def info_spacy() -> Dict[str, Any]:
-    """Generate info about the current spaCy intallation.
+    """Generate info about the current spaCy installation.
 
     RETURNS (dict): The spaCy info.
     """

--- a/spacy/lang/vi/lex_attrs.py
+++ b/spacy/lang/vi/lex_attrs.py
@@ -3,13 +3,13 @@ from ...attrs import LIKE_NUM
 _num_words = [
     "không",  # Zero
     "một",  # One
-    "mốt",  # Also one, irreplacable in niché cases for unit digit such as "51"="năm mươi mốt"
+    "mốt",  # Also one, irreplaceable in niché cases for unit digit such as "51"="năm mươi mốt"
     "hai",  # Two
     "ba",  # Three
     "bốn",  # Four
     "tư",  # Also four, used in certain cases for unit digit such as "54"="năm mươi tư"
     "năm",  # Five
-    "lăm",  # Also five, irreplacable in niché cases for unit digit such as "55"="năm mươi lăm"
+    "lăm",  # Also five, irreplaceable in niché cases for unit digit such as "55"="năm mươi lăm"
     "sáu",  # Six
     "bảy",  # Seven
     "bẩy",  # Also seven, old fashioned


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in the codebase:
- Fixes the word "intallation" to "installation" in the docstring of the info_spacy function in spacy/cli/info.py.
- Fixes the typo "irreplacable" to "irreplaceable" in the comments for Vietnamese number words in spacy/lang/vi/lex_attrs.py.

These changes improve the clarity and accuracy of the documentation and comments. No functional code changes were made.