### PR TITLE
Fix LLM EntityLinker task factory typo

### DIFF
--- a/website/docs/api/large-language-models.mdx
+++ b/website/docs/api/large-language-models.mdx
@@ -21,7 +21,7 @@ through a generic `llm`
 [component factory](https://spacy.io/usage/processing-pipelines#custom-components-factories)
 as well as through task-specific component factories: `llm_ner`, `llm_spancat`,
 `llm_rel`, `llm_textcat`, `llm_sentiment`, `llm_summarization`,
-`llm_entity_linker`, `llm_raw` and `llm_translation`. For these factories, the
+`llm_entitylinker`, `llm_raw` and `llm_translation`. For these factories, the
 GPT-3-5 model from OpenAI is used by default, but this can be customized.
 
 > #### Example


### PR DESCRIPTION
## Description
Change the factory string for the EntityLinker to "llm_entitylinker" from "llm_entity_linker" so that it works, as per https://github.com/explosion/spacy-llm/blob/main/spacy_llm/tasks/__init__.py#L33.
This appears to be the only place it is documented.

### Types of change
Documentation change to reflect the API as currently implemented.

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
~~- [ ] I ran the tests, and all new and existing tests passed.~~
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
