### PR TITLE
Add custom download URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 22.3.0
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3.10
       additional_dependencies: ['click==8.0.4']
 -   repo: https://github.com/pycqa/flake8
     rev: 5.0.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 22.3.0
     hooks:
     - id: black
-      language_version: python3.10
+      language_version: python3.7
       additional_dependencies: ['click==8.0.4']
 -   repo: https://github.com/pycqa/flake8
     rev: 5.0.4

--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -29,6 +29,7 @@ def download_cli(
     model: str = Arg(..., help="Name of pipeline package to download"),
     direct: bool = Opt(False, "--direct", "-d", "-D", help="Force direct download of name + version"),
     sdist: bool = Opt(False, "--sdist", "-S", help="Download sdist (.tar.gz) archive instead of pre-built binary wheel"),
+    url: str = Opt(None, "--url", "-U", help="Download from given url")
     # fmt: on
 ):
     """
@@ -41,13 +42,14 @@ def download_cli(
     DOCS: https://spacy.io/api/cli#download
     AVAILABLE PACKAGES: https://spacy.io/models
     """
-    download(model, direct, sdist, *ctx.args)
+    download(model, direct, sdist, custom_url=url, *ctx.args)
 
 
 def download(
     model: str,
     direct: bool = False,
     sdist: bool = False,
+    custom_url: Optional[str] = None,
     *pip_args,
 ) -> None:
     if (
@@ -87,7 +89,7 @@ def download(
 
     filename = get_model_filename(model_name, version, sdist)
 
-    download_model(filename, pip_args)
+    download_model(filename, pip_args, custom_url)
     msg.good(
         "Download and installation successful",
         f"You can now load the package via spacy.load('{model_name}')",
@@ -159,12 +161,14 @@ def get_latest_version(model: str) -> str:
 
 
 def download_model(
-    filename: str, user_pip_args: Optional[Sequence[str]] = None
+    filename: str,
+    user_pip_args: Optional[Sequence[str]] = None,
+    custom_url: Optional[str] = None,
 ) -> None:
     # Construct the download URL carefully. We need to make sure we don't
     # allow relative paths or other shenanigans to trick us into download
     # from outside our own repo.
-    base_url = about.__download_url__
+    base_url = custom_url if custom_url else about.__download_url__
     # urljoin requires that the path ends with /, or the last path part will be dropped
     if not base_url.endswith("/"):
         base_url = about.__download_url__ + "/"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
I add a cli option in the download command to specify a custom url. This is usefuls for people in air gapped environment that should download models from mirror.

### Types of change
It is a small enhancement

## Checklist
- [X ] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
