### PR TITLE
Fix displacy.render usage for Jupyter Notebooks

### DIFF
--- a/spacy/displacy/__init__.py
+++ b/spacy/displacy/__init__.py
@@ -66,7 +66,7 @@ def render(
     if jupyter or (jupyter is None and is_in_jupyter()):
         # return HTML rendered by IPython display()
         # See #4840 for details on span wrapper to disable mathjax
-        from IPython.core.display import HTML, display
+        from IPython.display import display, HTML
 
         return display(HTML('<span class="tex2jax_ignore">{}</span>'.format(html)))
     return html


### PR DESCRIPTION
## Summary

This PR fixes incorrect usage of `displacy.render` with `IPython.display.HTML`, which caused rendering issues in Jupyter Notebooks.

## Fix

Replaces:
```python
display(HTML(displacy.render(doc, style="ent")))