### PR TITLE
Remove spaCy Quickstart course due to spam domain

### DIFF
--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -2745,7 +2745,7 @@
             "title": "spaCy Quickstart",
             "slogan": "Learn spaCy basics quickly by visualizing various Doc objects",
             "description": "In this course, I use the itables Python library inside a Jupyter notebook so that you can visualize the different spaCy document objects. This will provide a solid foundation for people who wish to learn the spaCy NLP library.",
-            "url": "https://learnspacy.com/courses/spacy-quickstart/",
+            "url": "",
             "image": "https://learnspacy.com/wp-content/uploads/2024/09/custom_search_builder_spacy-2048x1202.png",
             "thumb": "https://learnspacy.com/wp-content/uploads/2024/09/learnspacy_logo.png",
             "author": "Aravind Mohanoor",


### PR DESCRIPTION
Problem
The "spaCy Quickstart" course links to learnspacy.com, which now redirects to spam/ads instead of educational content.
Solution
Changed the URL to blank in website/meta/universe.json to disable the problematic link.
Changes

Modified "url": "" (set to empty) for the "id": "spacy-quickstart" entry in universe.json

Result
Users won't be redirected to spam sites when browsing this course entry.