### PR TITLE
Fixed the import issue in displacy/__init__.py

### DIFF
--- a/spacy/displacy/__init__.py
+++ b/spacy/displacy/__init__.py
@@ -66,7 +66,8 @@ def render(
     if jupyter or (jupyter is None and is_in_jupyter()):
         # return HTML rendered by IPython display()
         # See #4840 for details on span wrapper to disable mathjax
-        from IPython.core.display import HTML, display
+        from IPython.core.display import HTML
+        from IPython.display import display
 
         return display(HTML('<span class="tex2jax_ignore">{}</span>'.format(html)))
     return html


### PR DESCRIPTION
IPython deprecated IPython.core.display.display. The new one became IPython.display.display. So, I just fixed the import issue based on the new changes in IPython

<!--- Provide a general summary of your changes in the title. -->

## Description
I changed line 69 in displacy/__init__.py to fix the import issue originating from a deprication from IPython itself, but SpaCy wasn't updated to take the new changes into consideration

### Types of change
Bug Fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [Done] I confirm that I have the right to submit this contribution under the project's MIT license.
- [Done] I ran the tests, and all new and existing tests passed.
- [Done] My changes don't require a change to the documentation, or if they do, I've added all required information.
