### PR TITLE
docs(website): remove spaCy Quickstart from Universe/Courses due to spam redirect (fixes #13853)

### DIFF
--- a/website/meta/universe.json
+++ b/website/meta/universe.json
@@ -2739,20 +2739,7 @@
                 "courses"
             ]
         },
-        {
-            "type": "education",
-            "id": "spacy-quickstart",
-            "title": "spaCy Quickstart",
-            "slogan": "Learn spaCy basics quickly by visualizing various Doc objects",
-            "description": "In this course, I use the itables Python library inside a Jupyter notebook so that you can visualize the different spaCy document objects. This will provide a solid foundation for people who wish to learn the spaCy NLP library.",
-            "url": "https://learnspacy.com/courses/spacy-quickstart/",
-            "image": "https://learnspacy.com/wp-content/uploads/2024/09/custom_search_builder_spacy-2048x1202.png",
-            "thumb": "https://learnspacy.com/wp-content/uploads/2024/09/learnspacy_logo.png",
-            "author": "Aravind Mohanoor",
-            "category": [
-                "courses"
-            ]
-        },
+        
         {
             "type": "education",
             "id": "video-spacys-ner-model",


### PR DESCRIPTION
## Description
This PR removes the "spaCy Quickstart" entry from the Universe/Courses section of the documentation because its external link (`learnspacy.com`) now redirects to spam/ads content.

Following issue #13853, the course item has been fully deleted from `website/meta/universe.json`. No replacements were added — this change simply removes the problematic entry while preserving valid JSON structure and overall formatting.

### Changes
- Deleted the `"spaCy Quickstart"` object from `website/meta/universe.json`
- Verified JSON structure remains valid
- No other content modified

### Type of Change
- [x] Documentation cleanup / broken link removal
- [ ] Bug fix  
- [ ] Enhancement  
- [ ] New feature  

### Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.  
- [x] I ran validation to ensure `website/meta/universe.json` is valid JSON.  
- [x] My changes do not require additional documentation updates.  

---

### Context
This PR improves the accuracy and professionalism of spaCy’s public learning resources by removing a broken external link that redirected users to spam. It aligns with spaCy’s documentation quality standards and helps protect users from misleading third-party sites.
