### PR TITLE
Fix #13882: Decrement vocab.length when memory_zone clears transient …

### DIFF
--- a/spacy/tests/vocab_vectors/test_memory_zone.py
+++ b/spacy/tests/vocab_vectors/test_memory_zone.py
@@ -1,4 +1,5 @@
 from spacy.vocab import Vocab
+import pytest
 
 
 def test_memory_zone_no_insertion():
@@ -57,3 +58,68 @@ def test_memory_zone_exception_cleanup():
     # Vocab should be fully usable for new operations
     lex = vocab["cat"]
     assert lex.text == "cat"
+
+
+@pytest.mark.issue(13882)
+def test_memory_zone_vocab_length_decremented():
+    """Test that vocab.length is correctly decremented when memory_zone
+    clears transient lexemes.
+
+    Bug: The length counter was incremented when adding lexemes but never
+    decremented when memory_zone cleared transient lexemes, causing
+    len(vocab) to grow continuously even though lexemes were properly removed.
+    """
+    vocab = Vocab()
+
+    # Add some permanent lexemes
+    vocab["hello"]
+    vocab["world"]
+    initial_len = len(vocab)
+    assert initial_len == 2
+
+    # Add transient lexemes inside memory_zone
+    with vocab.memory_zone():
+        vocab["transient1"]
+        vocab["transient2"]
+        vocab["transient3"]
+        inside_len = len(vocab)
+        assert inside_len == 5  # 2 permanent + 3 transient
+
+    # After exiting memory_zone, length should return to initial
+    after_zone_len = len(vocab)
+    assert after_zone_len == initial_len, (
+        f"vocab.length should be {initial_len} after memory_zone, "
+        f"but got {after_zone_len}"
+    )
+
+    # Verify by iteration that only permanent lexemes remain
+    actual_count = sum(1 for _ in vocab)
+    assert actual_count == initial_len
+    assert after_zone_len == actual_count
+
+
+@pytest.mark.issue(13882)
+def test_memory_zone_multiple_cycles():
+    """Test that vocab.length is correctly maintained across multiple
+    memory_zone cycles."""
+    vocab = Vocab()
+    vocab["permanent"]
+    base_len = len(vocab)
+    assert base_len == 1
+
+    # Multiple memory_zone cycles
+    for i in range(3):
+        with vocab.memory_zone():
+            for j in range(5):
+                vocab[f"temp_{i}_{j}"]
+
+        # Length should return to base after each cycle
+        assert len(vocab) == base_len, (
+            f"After cycle {i+1}, vocab.length should be {base_len}, "
+            f"but got {len(vocab)}"
+        )
+
+    # Final verification
+    final_len = len(vocab)
+    actual_count = sum(1 for _ in vocab)
+    assert final_len == actual_count == base_len

--- a/spacy/vocab.pyx
+++ b/spacy/vocab.pyx
@@ -251,9 +251,15 @@ cdef class Vocab:
 
     def _clear_transient_orths(self):
         """Remove transient lexemes from the index (generally at the end of the memory zone)"""
+        cdef hash_t orth
+        cdef int num_cleared = 0
+        
         for orth in self._transient_orths:
-            map_clear(self._by_orth.c_map, orth)
+            if self._by_orth.get(orth) is not NULL:
+                map_clear(self._by_orth.c_map, orth)
+                num_cleared += 1
         self._transient_orths.clear()
+        self.length -= num_cleared
 
     def __contains__(self, key):
         """Check whether the string or int key has an entry in the vocabulary.


### PR DESCRIPTION
Fix #13882: Decrement vocab.length when memory_zone clears transient lexemes

## Description

This PR fixes issue #13882 where the `Vocab.length` counter was incremented when adding lexemes but never decremented when `memory_zone` cleared transient lexemes. This caused `len(vocab)` to grow continuously even though the actual lexemes were properly removed from the internal hash map, making it unreliable for monitoring memory_zone effectiveness in production environments.

**Changes:**
- Modified `spacy/vocab.pyx`: Enhanced `_clear_transient_orths()` to track and decrement `self.length` by the number of cleared lexemes, with NULL check for edge cases
- Added comprehensive tests in `spacy/tests/vocab_vectors/test_memory_zone.py`:
  * `test_memory_zone_vocab_length_decremented`: Verifies single memory_zone cycle
  * `test_memory_zone_multiple_cycles`: Verifies multiple cycles
  * Both marked with `@pytest.mark.issue(13882)`

**Testing:**
All tests pass successfully:
- Existing memory_zone tests still pass
- New tests verify the fix works for both simple and complex usage patterns
- Tested with reproduction script confirming `len(vocab)` now correctly decrements
- Code formatted with `black` and passes `flake8` linting

The fix ensures `len(vocab)` correctly reflects actual lexeme count and matches iteration count over vocab.

### Types of change
Bug fix - fixes issue #13882 where vocab.length counter was not properly maintained when memory_zone cleared transient lexemes.

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
