### PR TITLE
Fix memory_zone cleanup on exception

### DIFF
--- a/spacy/strings.pyx
+++ b/spacy/strings.pyx
@@ -205,11 +205,13 @@ cdef class StringStore:
         if mem is None:
             mem = Pool()
         self.mem = mem
-        yield mem
-        for key in self._transient_keys:
-            map_clear(self._map.c_map, key)
-        self._transient_keys.clear()
-        self.mem = self._non_temp_mem
+        try:
+            yield mem
+        finally:
+            for key in self._transient_keys:
+                map_clear(self._map.c_map, key)
+            self._transient_keys.clear()
+            self.mem = self._non_temp_mem
 
     def add(self, string: str, allow_transient: Optional[bool] = None) -> int:
         """Add a string to the StringStore.

--- a/spacy/tests/vocab_vectors/test_memory_zone.py
+++ b/spacy/tests/vocab_vectors/test_memory_zone.py
@@ -34,3 +34,26 @@ def test_memory_zone_redundant_insertion():
         _ = vocab["dog"]
     assert "dog" in vocab
     assert "horse" not in vocab
+
+
+def test_memory_zone_exception_cleanup():
+    """Test that if an exception occurs inside a memory zone, the vocab
+    is properly cleaned up and remains usable afterward."""
+    vocab = Vocab()
+    _ = vocab["dog"]
+    assert "dog" in vocab
+    try:
+        with vocab.memory_zone():
+            _ = vocab["horse"]
+            raise ValueError("simulated error")
+    except ValueError:
+        pass
+    # Vocab should not be stuck in memory zone state
+    assert not vocab.in_memory_zone
+    # Pre-existing words should still work
+    assert "dog" in vocab
+    # Transient word from failed zone should be cleaned up
+    assert "horse" not in vocab
+    # Vocab should be fully usable for new operations
+    lex = vocab["cat"]
+    assert lex.text == "cat"

--- a/spacy/vocab.pyx
+++ b/spacy/vocab.pyx
@@ -150,9 +150,11 @@ cdef class Vocab:
             if hasattr(self._vectors, "memory_zone"):
                 contexts.append(stack.enter_context(self._vectors.memory_zone(mem)))
             self.mem = mem
-            yield mem
-        self._clear_transient_orths()
-        self.mem = self._non_temp_mem
+            try:
+                yield mem
+            finally:
+                self._clear_transient_orths()
+                self.mem = self._non_temp_mem
 
     def add_flag(self, flag_getter, int flag_id=-1):
         """Set a new boolean flag to words in the vocabulary.


### PR DESCRIPTION
## Summary

When an exception propagates out of `nlp.memory_zone()`, the cleanup code in `StringStore.memory_zone()` and `Vocab.memory_zone()` never runs. This leaves the vocab in a broken state (transient strings/lexemes not cleared, `self.mem` still pointing to a temporary pool), causing an `AssertionError` in `Vocab.get()` on the next call to `nlp()`.

Fixes #13924

## Root cause

Both `StringStore.memory_zone()` and `Vocab.memory_zone()` use `@contextmanager` with cleanup code placed after `yield` but without a `try/finally` wrapper. In a `@contextmanager`, code after `yield` only runs on normal exit. If an exception is thrown at the `yield` point, it propagates without executing the cleanup.

## Changes

- **`spacy/strings.pyx`**: Wrap `yield` and cleanup (clearing transient keys, restoring `self.mem`) in `try/finally`
- **`spacy/vocab.pyx`**: Same pattern for `_clear_transient_orths()` and `self.mem` restore
- **`spacy/tests/vocab_vectors/test_memory_zone.py`**: Add regression test that raises inside a memory zone and verifies the vocab is usable afterward

## Testing

- All existing `test_memory_zone` tests pass (no change to happy-path behavior)
- New `test_memory_zone_exception_cleanup` verifies:
  - `vocab.in_memory_zone` is `False` after exception
  - Pre-existing words still accessible
  - Transient words from the failed zone are cleaned up
  - Vocab accepts new words without errors