### PR TITLE
match confection bounds between requirements.txt and setup.cfg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Our libraries
 spacy-legacy>=3.0.11,<3.1.0
 spacy-loggers>=1.0.0,<2.0.0
+confection>=1.3.2,<2.0.0
 cymem>=2.0.2,<2.1.0
 preshed>=3.0.2,<3.1.0
 thinc>=8.3.12,<8.4.0
@@ -34,4 +35,3 @@ types-requests
 types-setuptools>=57.0.0
 ruff>=0.9.0
 cython-lint>=0.15.0
-confection>=1.1.0,<2.0.0


### PR DESCRIPTION
Tests for 8.3.13 in https://github.com/conda-forge/spacy-feedstock/pull/173 fail with
```
=========================== short test summary info ============================
FAILED tests/package/test_requirements.py::test_build_dependencies - AssertionError: confection has different version in setup.cfg and in requirements.txt: >=1.3.2,<2.0.0 and >=1.1.0,<2.0.0 respectively
assert 'confection>=1.3.2,<2.0.0' == 'confection>=1.1.0,<2.0.0'
  
  - confection>=1.1.0,<2.0.0
  ?               ^ ^
  + confection>=1.3.2,<2.0.0
  ?               ^ ^
= 1 failed, 3589 passed, 1233 skipped, 1 deselected, 25 xfailed, 6 xpassed in 223.47s (0:03:43) =
```
because https://github.com/explosion/spaCy/commit/0d94a9d66dd6a754fa958db2fd20ce60ff908c94 only changed `setup.cfg`, not `requirements.txt`. Fix that.

Also move the confection line under `# Our libraries`.