### PR TITLE
fix: check pip module availability instead of PATH binary in download

### DIFF
--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -1,3 +1,4 @@
+import importlib.util
 import shutil
 import sys
 from typing import Optional, Sequence
@@ -189,7 +190,7 @@ def download_model(
 
 
 def _get_pip_install_cmd() -> list:
-    if shutil.which("pip"):
+    if importlib.util.find_spec("pip") is not None:
         return [sys.executable, "-m", "pip", "install"]
     elif shutil.which("uv"):
         return ["uv", "pip", "install"]


### PR DESCRIPTION
Fixes #13946.

`_get_pip_install_cmd()` checks `shutil.which("pip")` then returns `[sys.executable, "-m", "pip", "install"]`. The binary check and the module invocation test different things. In venvs where `ensurepip` creates `pip3` but not bare `pip` (standard on Debian/Ubuntu), the binary check fails even though `python -m pip` works.

Replaces `shutil.which("pip")` with `importlib.util.find_spec("pip")` — the actual precondition for `sys.executable -m pip`. The `uv` branch is unchanged since `uv` is a standalone binary where `shutil.which` is the right check.

No new dependencies (stdlib). No change in behavior for environments where both `pip` and `pip3` exist.