### PR TITLE
Fix #13950: tokenizer issue: special spans cause every subsequent span to not be cached

### DIFF
--- a/spacy/tests/tokenizer/test_tokenizer.py
+++ b/spacy/tests/tokenizer/test_tokenizer.py
@@ -5,6 +5,7 @@ import pytest
 
 from spacy.lang.de import German
 from spacy.lang.en import English
+from spacy.strings import hash_string
 from spacy.symbols import ORTH
 from spacy.tokenizer import Tokenizer
 from spacy.tokens import Doc
@@ -555,3 +556,14 @@ def test_tokenizer_initial_special_case_explain(en_vocab):
     tokens = [t.text for t in tokenizer("id")]
     explain_tokens = [t[1] for t in tokenizer.explain("id")]
     assert tokens == explain_tokens
+
+
+@pytest.mark.issue(13950)
+def test_issue13950(en_tokenizer):
+    # Special contraction occurs before regular words
+    en_tokenizer("I can't believe you have done this")
+
+    # "believe" and "this" appear after the special case "can't".
+    # They should still be cached.
+    assert hash_string("believe") in en_tokenizer._cache
+    assert hash_string("this") in en_tokenizer._cache

--- a/spacy/tokenizer.pxd
+++ b/spacy/tokenizer.pxd
@@ -12,7 +12,7 @@ from .vocab cimport LexemesOrTokens, Vocab, _Cached
 
 cdef class Tokenizer:
     cdef Pool mem
-    cdef PreshMap _cache
+    cdef readonly PreshMap _cache  # readonly so tests can check state
     cdef PreshMap _specials
     cdef readonly Vocab vocab
 

--- a/spacy/tokenizer.pyx
+++ b/spacy/tokenizer.pyx
@@ -192,6 +192,7 @@ cdef class Tokenizer:
                     # we don't have to create the slice when we hit the cache.
                     span = string[start:i]
                     key = hash_string(span)
+                    has_special = 0
                     if not self._try_specials_and_cache(key, doc, &has_special, with_special_cases):
                         self._tokenize(doc, span, key, &has_special, with_special_cases)
                 if uc == ' ':
@@ -204,6 +205,7 @@ cdef class Tokenizer:
         if start < i:
             span = string[start:]
             key = hash_string(span)
+            has_special = 0
             if not self._try_specials_and_cache(key, doc, &has_special, with_special_cases):
                 self._tokenize(doc, span, key, &has_special, with_special_cases)
             doc.c[doc.length - 1].spacy = string[-1] == " " and not in_ws


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Fixes https://github.com/explosion/spaCy/issues/13950

Basically once a span with special cases appeared (like "can't" or any nonstandard contraction), `has_special` would be set and remain set for any subsequent spans, even if they weren't special. These spans wouldn't get cached, and performance suffered as a result. Fortunately the fix is pretty straightforward, and we immediately see some decent tokenizer speedups.

To illustrate the worst case scenario: if you stick "can't" at the beginning of Huckleberry Finn, it takes 691ms to tokenize on my macbook pro. Reusing the same tokenizer on the same text is another 637ms. After the fix, the first pass takes 230ms, and reusing (everything cached now) takes 87ms. So a **3x speedup on the cold run, and a 7x speedup on the warm run**.

```python
text = open("/tmp/huck_finn.txt").read()
tok = spacy.blank("en").tokenizer
doc = tok(text)
```

Important note: in the average case of tokenizing a diverse, real-world corpora (like a bunch of tweets or something), the impact is more modest because eventually most words will get cached because they appear in a document where they don't follow a special span.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bug fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
