### PR TITLE
fix(cli): make `spacy download --url` actually use the custom URL

### DIFF
--- a/.github/contributors/shaun0927.md
+++ b/.github/contributors/shaun0927.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI UG (haftungsbeschränkt)](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           | Junghwan Na          |
+| Company name (if applicable)   |                      |
+| Title or role (if applicable)  |                      |
+| Date                           | 17 April 2026        |
+| GitHub username                | shaun0927            |
+| Website (optional)             |                      |

--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -180,9 +180,11 @@ def download_model(
     base_url = custom_url if custom_url else about.__download_url__
     # urljoin requires that the path ends with /, or the last path part will be dropped
     if not base_url.endswith("/"):
-        base_url = about.__download_url__ + "/"
+        base_url = base_url + "/"
     download_url = urljoin(base_url, filename)
-    if not download_url.startswith(about.__download_url__):
+    # Only enforce the GitHub-origin guard when the user did not opt into a
+    # custom URL. When --url is passed the user has explicitly chosen a source.
+    if custom_url is None and not download_url.startswith(about.__download_url__):
         raise ValueError(f"Download from {filename} rejected. Was it a relative path?")
     pip_args = list(user_pip_args) if user_pip_args is not None else []
     cmd = _get_pip_install_cmd() + pip_args + [download_url]

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -1237,3 +1237,34 @@ def test_download_rejects_relative_urls(monkeypatch):
     download_module.download("en_core_web_sm-3.7.1", direct=True)
     with pytest.raises(SystemExit):
         download_module.download("../en_core_web_sm-3.7.1", direct=True)
+
+
+def test_download_uses_custom_url(monkeypatch):
+    """`download_model(custom_url=...)` must actually use the user-supplied URL,
+    both with and without a trailing slash, instead of falling back to the
+    default GitHub URL or being rejected by the origin guard."""
+
+    captured = {}
+
+    def fake_run(cmd):
+        captured["url"] = next(arg for arg in cmd if arg.startswith("http"))
+
+    monkeypatch.setattr(download_module, "run_command", fake_run)
+    monkeypatch.setattr(
+        download_module, "_get_pip_install_cmd", lambda: ["pip", "install"]
+    )
+
+    for base in ("https://my-mirror.example.com/models", "https://my-mirror.example.com/models/"):
+        captured.clear()
+        download_module.download_model("foo-1.0.tar.gz", custom_url=base)
+        assert captured["url"].startswith("https://my-mirror.example.com/models/"), (
+            f"custom_url={base!r} produced {captured['url']!r}"
+        )
+
+    # Without --url, the default GitHub URL is still used and the relative-path
+    # guard remains in effect.
+    captured.clear()
+    download_module.download_model("foo-1.0.tar.gz")
+    assert captured["url"].startswith(about.__download_url__)
+    with pytest.raises(ValueError):
+        download_module.download_model("../foo-1.0.tar.gz")

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -1254,7 +1254,10 @@ def test_download_uses_custom_url(monkeypatch):
         download_module, "_get_pip_install_cmd", lambda: ["pip", "install"]
     )
 
-    for base in ("https://my-mirror.example.com/models", "https://my-mirror.example.com/models/"):
+    for base in (
+        "https://my-mirror.example.com/models",
+        "https://my-mirror.example.com/models/",
+    ):
         captured.clear()
         download_module.download_model("foo-1.0.tar.gz", custom_url=base)
         assert captured["url"].startswith("https://my-mirror.example.com/models/"), (


### PR DESCRIPTION
Fixes #13963.

<!--- Provide a general summary of your changes in the title. -->

## Description

The `--url` flag added in #13848 is broken: any value passed via `--url` is either silently dropped (no trailing slash) or rejected by the post-construction guard (with trailing slash), so the flag cannot succeed under any input. See #13963 for the full reproduction.

`spacy/cli/download.py:180-186` had two interlocking defects:

1. When `base_url` (= the user's custom URL) lacked a trailing slash, line 183 reassigned it to `about.__download_url__ + "/"`, discarding the user's choice.
2. The line-185 `startswith(about.__download_url__)` guard then rejected any URL that *was* preserved, because a custom mirror by definition does not start with the GitHub URL.

This change:

- Appends `/` to the actual `base_url` instead of swapping it for the default.
- Skips the GitHub-origin guard when `custom_url` is provided. The user has explicitly opted into a custom source via `--url`; the relative-path guard is still in force when no `--url` is passed (the `test_download_rejects_relative_urls` case continues to pass).

Adds a regression test (`test_download_uses_custom_url`) exercising both trailing-slash variants of `--url` plus the default-URL path so the relative-path rejection from #13848's review thread is preserved.

No new dependencies. No behavior change for users who do not pass `--url`.

### Types of change

Bug fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.