### PR TITLE
fix: add is_base_form to FrenchLemmatizer to prevent over-lemmatizing infinitives

### DIFF
--- a/spacy/lang/fr/lemmatizer.py
+++ b/spacy/lang/fr/lemmatizer.py
@@ -14,6 +14,14 @@ class FrenchLemmatizer(Lemmatizer):
     the lookup table.
     """
 
+    def is_base_form(self, token: Token) -> bool:
+        """Check whether the token is already in base form so that suffix
+        rules are skipped. French infinitives (VerbForm=Inf) are already in
+        base form; applying further suffix rules to them produces incorrect
+        results (e.g. "descendre" → "descendrer").
+        """
+        return token.morph.to_dict().get("VerbForm") == "Inf"
+
     @classmethod
     def get_lookups_config(cls, mode: str) -> Tuple[List[str], List[str]]:
         if mode == "rule":
@@ -29,6 +37,8 @@ class FrenchLemmatizer(Lemmatizer):
         string = token.text
         univ_pos = token.pos_.lower()
         if univ_pos in ("", "eol", "space"):
+            return [string.lower()]
+        if self.is_base_form(token):
             return [string.lower()]
         elif "lemma_rules" not in self.lookups or univ_pos not in (
             "noun",


### PR DESCRIPTION
## Description

Fixes #7320

French infinitives ending in `-dre`, `-re` etc. (e.g. `descendre`, `prendre`) were incorrectly lemmatized to `descendrer`, `prendrer` because suffix rules like `e → er` were applied to them after no match was found in the lookup tables.

**Root cause:** `FrenchLemmatizer.rule_lemmatize` fully overrides the parent class method and does not call `is_base_form` before applying suffix rules. The parent `Lemmatizer.rule_lemmatize` checks `is_base_form` before the rules loop (line 190), but the French override skips that.

**Fix:**
1. Added `is_base_form()` to `FrenchLemmatizer` — returns `True` when `VerbForm=Inf` in the token's morphology (same pattern as `EnglishLemmatizer`)
2. Added a call to `self.is_base_form(token)` at the top of `FrenchLemmatizer.rule_lemmatize` (after the space/eol early return), mirroring the parent class pattern

French infinitives are now returned as-is (lowercased) without suffix rule application.

## Types of change

- Bug fix

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's open-source license
- [x] I ran the tests, and all new and existing tests passed
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information