### PR TITLE
Fix click dependency issue (#13971)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ wasabi>=0.9.1,<1.2.0
 srsly>=2.5.3,<3.0.0
 catalogue>=2.0.6,<2.1.0
 typer>=0.3.0,<1.0.0
+click>=8.2.1,<9.0.0
 weasel>=1.0.0,<2.0.0
 # Third party dependencies
 numpy>=2.0.0,<3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ install_requires =
     confection>=1.3.2,<2.0.0
     # Third-party dependencies
     typer>=0.3.0,<1.0.0
+    click>=8.2.1,<9.0.0
     tqdm>=4.38.0,<5.0.0
     numpy>=1.15.0; python_version < "3.9"
     numpy>=1.19.0; python_version >= "3.9"


### PR DESCRIPTION
This fixes issue #13971 that causes a `spacy` import to fail after a fresh install if/when `click` isn't available.

## Description

This PR just adds a `click` dependency to `requirements.txt` as well as `setup.cfg`.
I added it to next to `typer` in both since that's what previously pulled it in.

Again, this is to fix #13971 


### Types of change
Fix of a dependency issue

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
