### PR TITLE
Preserve whitespace in the Korean tokenizer

### DIFF
--- a/.github/contributors/Incheonkirin.md
+++ b/.github/contributors/Incheonkirin.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI GmbH](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           | Mingi Jeong          |
+| Company name (if applicable)   |                      |
+| Title or role (if applicable)  |                      |
+| Date                           | 2026-06-06           |
+| GitHub username                | Incheonkirin         |
+| Website (optional)             |                      |

--- a/spacy/lang/ko/__init__.py
+++ b/spacy/lang/ko/__init__.py
@@ -50,9 +50,51 @@ class KoreanTokenizer(DummyTokenizer):
 
     def __call__(self, text: str) -> Doc:
         dtokens = list(self.detailed_tokens(text))
-        surfaces = [dt["surface"] for dt in dtokens]
-        doc = Doc(self.vocab, words=surfaces, spaces=list(check_spaces(text, surfaces)))
-        for token, dtoken in zip(doc, dtokens):
+        # Reconstruct the document while preserving the original whitespace
+        # (runs of spaces, newlines, tabs and leading/trailing whitespace).
+        # mecab only returns morpheme surfaces, so any whitespace between them
+        # is re-attached here instead of being collapsed to a single space.
+        words: list = []
+        spaces: list = []
+        full_tags: list = []
+        token_dtokens: list = []
+        offset = 0
+        for dtoken in dtokens:
+            surface = dtoken["surface"]
+            idx = text.find(surface, offset)
+            if idx < 0:
+                idx = offset
+            if idx > offset:
+                gap = text[offset:idx]
+                if gap == " " and words:
+                    # a single space is represented with the space flag
+                    spaces[-1] = True
+                else:
+                    # any other whitespace is kept as its own token so that
+                    # doc.text == text and character offsets stay aligned
+                    words.append(gap)
+                    spaces.append(False)
+                    full_tags.append("")
+                    token_dtokens.append(None)
+            words.append(surface)
+            spaces.append(False)
+            full_tags.append(dtoken["tag"])
+            token_dtokens.append(dtoken)
+            offset = idx + len(surface)
+        if offset < len(text):
+            tail = text[offset:]
+            if tail == " " and words:
+                spaces[-1] = True
+            else:
+                words.append(tail)
+                spaces.append(False)
+                full_tags.append("")
+                token_dtokens.append(None)
+
+        doc = Doc(self.vocab, words=words, spaces=spaces)
+        for token, dtoken in zip(doc, token_dtokens):
+            if dtoken is None:
+                continue  # whitespace token: keep the default tag/pos/lemma
             first_tag, sep, eomi_tags = dtoken["tag"].partition("+")
             token.tag_ = first_tag  # stem(어간) or pre-final(선어말 어미)
             if token.tag_ in TAG_MAP:
@@ -60,7 +102,7 @@ class KoreanTokenizer(DummyTokenizer):
             else:
                 token.pos = X
             token.lemma_ = dtoken["lemma"]
-        doc.user_data["full_tags"] = [dt["tag"] for dt in dtokens]
+        doc.user_data["full_tags"] = full_tags
         return doc
 
     def detailed_tokens(self, text: str) -> Iterator[Dict[str, Any]]:
@@ -107,19 +149,6 @@ def try_mecab_import() -> None:
             "[mecab-ko-dic](https://bitbucket.org/eunjeon/mecab-ko-dic), "
             "and [natto-py](https://github.com/buruzaemon/natto-py)"
         ) from None
-
-
-def check_spaces(text, tokens):
-    prev_end = -1
-    start = 0
-    for token in tokens:
-        idx = text.find(token, start)
-        if prev_end > 0:
-            yield prev_end != idx
-        prev_end = idx + len(token)
-        start = prev_end
-    if start > 0:
-        yield False
 
 
 __all__ = ["Korean"]

--- a/spacy/tests/lang/ko/test_tokenizer.py
+++ b/spacy/tests/lang/ko/test_tokenizer.py
@@ -26,6 +26,19 @@ def test_ko_tokenizer(ko_tokenizer, text, expected_tokens):
     assert tokens == expected_tokens.split()
 
 
+@pytest.mark.parametrize(
+    "text",
+    [
+        "보험금을  지급한다.\n\n면책기간\t특약",  # runs of spaces, newlines, a tab
+        "  앞뒤 공백 있음  ",                       # leading / trailing whitespace
+        "서울 타워 근처에 살고 있습니다.",            # single spaces (unchanged)
+        "보험약관",                                 # no whitespace
+    ],
+)
+def test_ko_tokenizer_preserves_whitespace(ko_tokenizer, text):
+    assert ko_tokenizer(text).text == text
+
+
 @pytest.mark.parametrize("text,expected_tags", TAG_TESTS)
 def test_ko_tokenizer_tags(ko_tokenizer, text, expected_tags):
     tags = [token.tag_ for token in ko_tokenizer(text)]


### PR DESCRIPTION
Fixes #13401.

The Korean tokenizer doesn't preserve whitespace — runs of spaces, newlines and tabs all come back as a single space, so `doc.text` stops matching the input and the offsets drift:

```python
import spacy

nlp = spacy.blank("ko")
text = "보험금을  지급한다.\n\n면책기간\t특약"
nlp(text).text == text   # False — you get "보험금을 지급한다. 면책기간 특약"
```

The `xx` tokenizer round-trips the same string fine, so it's specific to the Korean path. The reason is in `KoreanTokenizer.__call__`: mecab only returns the morpheme surfaces, and the `Doc` is rebuilt with `spaces=check_spaces(...)`, which is one boolean per token. A boolean can only encode "one space or none", so anything more than a single space gets dropped (and leading/trailing whitespace too).

I kept the existing behaviour where I could — a single space between morphemes still rides on the space flag, and only the rest (multiple spaces, newlines, tabs, leading/trailing) is kept as a whitespace token, the way the default tokenizer already represents whitespace. With that `doc.text == text` holds again, the morpheme tags and lemmas are unchanged, and single-space tokenization stays exactly the same. I also dropped the now-unused `check_spaces` helper and added a round-trip test.
