### PR TITLE
fix: update imports to the vendored-in ones

### DIFF
--- a/spacy/cli/_util.py
+++ b/spacy/cli/_util.py
@@ -15,10 +15,10 @@ from typing import (
 
 import srsly
 import typer
-from click import NoSuchOption
-from click.shell_completion import split_arg_string
 from thinc.api import ConfigValidationError, require_gpu
 from thinc.util import gpu_is_available
+from typer._click.exceptions import NoSuchOption
+from typer._click.shell_completion import split_arg_string
 from typer.main import get_command
 from wasabi import Printer, msg
 from weasel import app as project_cli

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -6,9 +6,9 @@ from typing import Any, Dict, List, Tuple
 
 import pytest
 import srsly
-from click import NoSuchOption
 from packaging.specifiers import SpecifierSet
 from thinc.api import Config
+from typer._click.exceptions import NoSuchOption
 
 import spacy
 from spacy import about


### PR DESCRIPTION
fixes: #13971

## Description
As of v0.26, `typer` started vendoring `click`, so it's no longer installed as a dependency. `spaCy` was importing a couple of things directly from `click`. This breaks importing `spaCy` in fresh venvs.

This PR updates the imports to get the vendored-in `NoSuchOption` exception class and `split_arg_string` function.

### Types of change
Bug fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
