### PR TITLE
Add Malayalam characters to char classes so periods tokenize correctly (#12898)

### DIFF
--- a/.github/contributors/vineethsaivs.md
+++ b/.github/contributors/vineethsaivs.md
@@ -1,0 +1,106 @@
+# spaCy contributor agreement
+
+This spaCy Contributor Agreement (**"SCA"**) is based on the
+[Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf).
+The SCA applies to any contribution that you make to any product or project
+managed by us (the **"project"**), and sets out the intellectual property rights
+you grant to us in the contributed materials. The term **"us"** shall mean
+[ExplosionAI GmbH](https://explosion.ai/legal). The term
+**"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested
+below and include the filled-in version with your first pull request, under the
+folder [`.github/contributors/`](/.github/contributors/). The name of the file
+should be your GitHub username, with the extension `.md`. For example, the user
+example_user would create the file `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions
+constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code,
+object code, patch, tool, sample, graphic, specification, manual,
+documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and
+registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such
+    assignment is or becomes invalid, ineffective or unenforceable, you hereby
+    grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+    royalty-free, unrestricted license to exercise all rights under those
+    copyrights. This includes, at our option, the right to sublicense these same
+    rights to third parties through multiple levels of sublicensees or other
+    licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your
+    contribution as if each of us were the sole owners, and if one of us makes
+    a derivative work of your contribution, the one who makes the derivative
+    work (or has it made will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution
+    against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and
+    exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the
+    consent of, pay or render an accounting to the other for any use or
+    distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment
+to any third party, you hereby grant to us a perpetual, irrevocable,
+non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer
+    your contribution in whole or in part, alone or in combination with or
+    included in any product, work or materials arising out of the project to
+    which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through
+    multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your
+contribution. The rights that you grant to us under these terms are effective
+on the date you first submitted a contribution to us, even if your submission
+took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of
+    authorship and you can legally grant the rights set out in this SCA;
+
+    * to the best of your knowledge, each contribution will not violate any
+    third party's copyrights, trademarks, patents, or other intellectual
+    property rights; and
+
+    * each contribution shall be in compliance with U.S. export control laws and
+    other applicable export and import laws. You agree to notify us if you
+    become aware of any circumstance which would make any of the foregoing
+    representations inaccurate in any respect. We may publicly disclose your
+    participation in the project, including the fact that you have signed the SCA.
+
+6. This SCA is governed by the laws of the State of California and applicable
+U.S. Federal law. Any choice of law rules will not apply.
+
+7. Please place an “x” on one of the applicable statement below. Please do NOT
+mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person
+    or entity, including my employer, has or will have rights with respect to my
+    contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the
+    actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           | Vineeth Sai          |
+| Company name (if applicable)   |                      |
+| Title or role (if applicable)  |                      |
+| Date                           | 18 - 06 - 2026       |
+| GitHub username                | vineethsaivs         |
+| Website (optional)             |                      |

--- a/spacy/lang/char_classes.py
+++ b/spacy/lang/char_classes.py
@@ -16,6 +16,8 @@ _tamil = r"\u0B80-\u0BFF"
 
 _telugu = r"\u0C00-\u0C7F"
 
+_malayalam = r"\u0D00-\u0D7F"
+
 # from the final table in: https://en.wikipedia.org/wiki/CJK_Unified_Ideographs
 _cjk = (
     r"\u4E00-\u62FF\u6300-\u77FF\u7800-\u8CFF\u8D00-\u9FFF\u3400-\u4DBF"
@@ -247,6 +249,7 @@ _uncased = (
     + _kannada
     + _tamil
     + _telugu
+    + _malayalam
     + _hangul
     + _kana
     + _cjk

--- a/spacy/tests/lang/ml/test_text.py
+++ b/spacy/tests/lang/ml/test_text.py
@@ -20,3 +20,10 @@ def test_ml_tokenizer_handles_long_text(ml_tokenizer):
 def test_ml_tokenizer_handles_cnts(ml_tokenizer, text, length):
     tokens = ml_tokenizer(text)
     assert len(tokens) == length
+
+
+def test_ml_tokenizer_splits_trailing_period(ml_tokenizer):
+    # Regression test for #12898: a sentence-terminal period must be split off the
+    # final Malayalam word instead of staying attached to it.
+    tokens = ml_tokenizer("ഭാഷയാണ് മലയാളം.")
+    assert [t.text for t in tokens] == ["ഭാഷയാണ്", "മലയാളം", "."]


### PR DESCRIPTION
## Description

Fixes #12898.

Malayalam sentence-terminal periods were not split off the final word:

```python
import spacy
nlp = spacy.blank("ml")
[t.text for t in nlp("ഭാഷയാണ് മലയാളം.")]
# before: ['ഭാഷയാണ്', 'മലയാളം.']
# after:  ['ഭാഷയാണ്', 'മലയാളം', '.']
```

Malayalam letters were not part of the `_uncased` character group in `spacy/lang/char_classes.py`, so the tokenizer did not treat them as alphabetic characters and the suffix rules never separated the trailing period.

Following @svlandeg's suggestion on the issue, this defines the Malayalam Unicode block (`U+0D00-U+0D7F`) and adds it to `_uncased`, mirroring the existing Indic scripts (Tamil, Telugu, Kannada). A tokenizer regression test is added under `spacy/tests/lang/ml/`. Tamil and the existing Malayalam tests are unaffected.

### Types of change
Bug fix (Malayalam tokenization).

## Checklist
- [x] I ran the tests, and all new and existing tests passed (`spacy/tests/lang/ml/`).
- [ ] **Contributor agreement**: I have not added `.github/contributors/` because the spaCy Contributor Agreement is a copyright-assignment that must be signed by me, the human contributor; I will add `.github/contributors/vineethsaivs.md` before merge.

---
*Disclosure: prepared with AI assistance; reviewed by me and I can explain every line.*