### PR TITLE
Fix floret vectors StringStore sharing after Vocab unpickling (E018 with nlp.pipe n_process>1)

### DIFF
--- a/spacy/tests/serialize/test_serialize_vocab_strings.py
+++ b/spacy/tests/serialize/test_serialize_vocab_strings.py
@@ -193,3 +193,9 @@ def test_pickle_vocab(strings, lex_attr):
     vocab_unpickled = pickle.loads(vocab_pickled)
     assert vocab.to_bytes() == vocab_unpickled.to_bytes()
     assert vocab_unpickled.vectors.mode == "floret"
+    # The unpickled vectors must share the vocab's StringStore, so that
+    # strings interned after unpickling (e.g. by the tokenizer in a
+    # multiprocessing worker) resolve in floret-mode string lookups (#13993)
+    assert vocab_unpickled.vectors.strings is vocab_unpickled.strings
+    key = vocab_unpickled.strings.add("post-unpickle-string")
+    assert vocab_unpickled.vectors.strings.as_string(key) == "post-unpickle-string"

--- a/spacy/vocab.pyx
+++ b/spacy/vocab.pyx
@@ -633,8 +633,14 @@ def pickle_vocab(vocab):
 def unpickle_vocab(sstore, vectors, morphology, _unused_object,
                    lex_attr_getters, lookups, get_noun_chunks):
     cdef Vocab vocab = Vocab()
-    vocab.vectors = vectors
+    # Set strings before vectors: the vectors setter shares the vocab's
+    # StringStore with the vectors table. In the reverse order, the vectors
+    # kept a reference to the fresh Vocab's empty StringStore, so hashes
+    # interned after unpickling (e.g. by the tokenizer in a multiprocessing
+    # worker) were missing when floret-mode vectors looked up token strings,
+    # raising E018.
     vocab.strings = sstore
+    vocab.vectors = vectors
     vocab.morphology = morphology
     vocab._unused_object = _unused_object
     vocab.lex_attr_getters = srsly.pickle_loads(lex_attr_getters)


### PR DESCRIPTION
## Description

Fixes #13993: `nlp.pipe(texts, n_process>1)` immediately and deterministically raises `[E018]` (wrapped in `[E871]`) for any pipeline whose `vocab.vectors.mode == "floret"` (e.g. the official `sv_core_news_lg`), under the `spawn` multiprocessing start method (the default on macOS and Windows).

**Cause:** floret-mode vectors resolve each token hash back to its literal text via `self.strings` in `Vectors.get_batch()`. Normally `vectors.strings` is the same `StringStore` object as `vocab.strings` — the `Vocab.vectors` setter explicitly shares it. But `unpickle_vocab` assigned `vocab.vectors = vectors` *before* `vocab.strings = sstore`, so the setter shared the fresh `Vocab()`'s empty StringStore, which the very next line replaced. After unpickling — which is exactly how a spawned `nlp.pipe` worker receives the pipeline — the vectors table holds a reference to a discarded, empty store. Every string the tokenizer interns in the worker goes into `vocab.strings`, the floret lookup consults the orphaned store, and the first lookup raises E018.

**Fix:** assign `vocab.strings` before `vocab.vectors` in `unpickle_vocab`, so the existing setter logic shares the correct store. No new mechanism, just an ordering fix.

**Testing** (macOS arm64, Python 3.10, source build of `master`):

- Verified the severed reference directly: after `pickle.loads(pickle.dumps(nlp.vocab))`, `vocab.strings is vocab.vectors.strings` is `False` before this fix and `True` after.
- A/B against the issue's repro (1000 Swedish docs, `sv_core_news_lg`, `batch_size=40`, `n_process=2`): unpatched build fails with the exact E018/hash from the issue; patched build processes all 1000 docs.
- `spacy/tests/vocab_vectors` and `spacy/tests/serialize` pass (222 passed).
- Extended the existing `test_pickle_vocab` (which already uses floret-mode vectors) to assert that the unpickled vectors share the vocab's StringStore and that a string interned *after* unpickling resolves through `vectors.strings`. The new assertions fail on unpatched spaCy 3.8.7 and pass with this fix.

(🤖 Claude Code was used to investigate the bug and prepare this fix.)

### Types of change

Bug fix.

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
