### PR TITLE
Fix bare except: use specific exception types

### DIFF
--- a/spacy/cli/_util.py
+++ b/spacy/cli/_util.py
@@ -206,7 +206,7 @@ def get_git_version(
     """
     try:
         ret = run_command("git --version", capture=True)
-    except:
+    except Exception:
         raise RuntimeError(error)
     stdout = ret.stdout.strip()
     if not stdout or not stdout.startswith("git version"):

--- a/spacy/ml/callbacks.py
+++ b/spacy/ml/callbacks.py
@@ -90,7 +90,7 @@ def pipes_with_nvtx_range(
             # the original parameters are passed to pydantic for validation downstream.
             try:
                 wrapped_func.__signature__ = inspect.signature(func)  # type: ignore
-            except:
+            except Exception:
                 # Can fail for Cython methods that do not have bindings.
                 warnings.warn(Warnings.W122.format(method=name, pipe=pipe.name))
                 continue


### PR DESCRIPTION
Replace bare `except:` clauses with specific exception types:

- `spacy/ml/callbacks.py`: `except Exception:` (guards `inspect.signature()` which can fail for Cython methods)
- `spacy/cli/_util.py`: `except Exception:` (guards `run_command("git --version")`)

Bare `except:` catches `BaseException` including `SystemExit` and `KeyboardInterrupt`.