### PR TITLE
docs: list cs_core_news_sm under Czech language models

### DIFF
--- a/website/meta/languages.json
+++ b/website/meta/languages.json
@@ -47,7 +47,8 @@
         {
             "code": "cs",
             "name": "Czech",
-            "has_examples": true
+            "has_examples": true,
+            "models": ["cs_core_news_sm"]
         },
         {
             "code": "da",


### PR DESCRIPTION
## Summary

Adds the community Czech package `cs_core_news_sm` to the language models list on the models usage page (`website/meta/languages.json`), so Czech shows an available pipeline like other languages.

Fixes #13969

## Testing

- JSON valid; single-entry change only.