### PR TITLE
docs(llm): note OpenAI-compatible endpoint for spacy-llm GPT models

### DIFF
--- a/website/docs/usage/large-language-models.mdx
+++ b/website/docs/usage/large-language-models.mdx
@@ -88,6 +88,13 @@ Create a new API key from openai.com or fetch an existing one, and ensure the
 keys are set as environmental variables. For more background information, see
 the [OpenAI](/api/large-language-models#gpt-3-5) section.
 
+The OpenAI model config also accepts an optional `endpoint` (full chat-completions
+URL) so you can point `spacy-llm` at any OpenAI-compatible multi-model gateway —
+for example DaoXE at `https://api.daoxe.com/v1/chat/completions` — using a key
+and model id issued by that endpoint. See the
+[spacy-llm OpenAI usage example](https://github.com/explosion/spacy-llm/tree/main/usage_examples/textcat_openai)
+for a concrete config snippet.
+
 Create a config file `config.cfg` containing at least the following (or see the
 full example
 [here](https://github.com/explosion/spacy-llm/tree/main/usage_examples/textcat_openai)):


### PR DESCRIPTION
## Summary

On the Large Language Models usage page, note that the OpenAI model config accepts an optional `endpoint` for OpenAI-compatible multi-model gateways.

DaoXE (`https://api.daoxe.com/v1/chat/completions`) is one concrete example. Points readers to the existing spacy-llm `textcat_openai` usage example for a full config snippet.

Docs only — no runtime changes.

## Test plan
- [ ] Docs page renders
- [ ] Link to spacy-llm usage example resolves

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>