### PR TITLE
Fix regex of URL quadratic backtracking

### DIFF
--- a/spacy/lang/tokenizer_exceptions.py
+++ b/spacy/lang/tokenizer_exceptions.py
@@ -13,7 +13,7 @@ URL_PATTERN = (
     # (see: https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml)
     r"(?:(?:[\w\+\-\.]{2,})://)?"
     # mailto:user or user:pass authentication
-    r"(?:\S+(?::\S*)?@)?"
+    r"(?:\S+@)?"
     r"(?:"
     # IP address exclusion
     # private & local networks

--- a/spacy/tests/tokenizer/test_urls.py
+++ b/spacy/tests/tokenizer/test_urls.py
@@ -1,6 +1,8 @@
+import time
+
 import pytest
 
-from spacy.lang.tokenizer_exceptions import BASE_EXCEPTIONS
+from spacy.lang.tokenizer_exceptions import BASE_EXCEPTIONS, URL_MATCH
 
 URLS_BASIC = [
     "http://www.nytimes.com/2016/04/20/us/politics/new-york-primary-preview.html?hp&action=click&pgtype=Homepage&clickSource=story-heading&module=a-lede-package-region&region=top-news&WT.nav=top-news&_r=0",
@@ -203,3 +205,19 @@ def test_tokenizer_handles_two_suffix_url(tokenizer, suffix1, suffix2, url):
         assert tokens[0].text == url
         assert tokens[1].text == suffix1
         assert tokens[2].text == suffix2
+
+
+@pytest.mark.parametrize(
+    "pathological_url",
+    [
+        "a:" * 20000 + "!",
+        ("aa://" * 20000) + "!",
+    ],
+    ids=["colon-runs", "scheme-runs"],
+)
+def test_url_match_auth_group_is_linear(pathological_url):
+    # regression test to prevent O(n**2) regex matches
+    start = time.perf_counter()
+    assert URL_MATCH(pathological_url) is None
+    elapsed = time.perf_counter() - start
+    assert elapsed < 0.3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->
# URL regex quardratic backtracking

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
In `spacy/lang/tokenizer_exceptions.py:16` the regex for mailto:user or user:pass auth faces takes quardratic time to match crafted examples like `"a:"*16000`.

Code to reproduce the issue:
```python
import time
import spacy

nlp = spacy.blank("en")

for n in (1000, 2000, 4000, 8000, 16000):
    text = "a:" * n
    start = time.perf_counter()
    nlp(text)
    print(f"{len(text):>6} chars  {time.perf_counter() - start:7.2f}s")
 ```
On the current master would write:
```
  2000 chars     0.03s
  4000 chars     0.08s
  8000 chars     0.36s
 16000 chars     1.20s
 32000 chars     4.76s
```
On the PR it would produce:
```
  2000 chars     0.01s
  4000 chars     0.01s
  8000 chars     0.03s
 16000 chars     0.05s
 32000 chars     0.10s
```
For tests I have added two pathological cases and measure their time to prevent regression.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.