### PR TITLE
Fix quadratic backtracking regex in NER format autodetection

### DIFF
--- a/spacy/cli/convert.py
+++ b/spacy/cli/convert.py
@@ -210,8 +210,8 @@ def autodetect_ner_format(input_data: str) -> Optional[str]:
     # guess format from the first 20 lines
     lines = input_data.split("\n")[:20]
     format_guesses = {"ner": 0, "iob": 0}
-    iob_re = re.compile(r"\S+\|(O|[IB]-\S+)")
-    ner_re = re.compile(r"\S+\s+(O|[IB]-\S+)$")
+    iob_re = re.compile(r"\S\|(O|[IB]-\S+)")
+    ner_re = re.compile(r"\S\s+(O|[IB]-\S+)$")
     for line in lines:
         line = line.strip()
         if iob_re.search(line):

--- a/spacy/tests/test_cli.py
+++ b/spacy/tests/test_cli.py
@@ -15,6 +15,7 @@ from spacy import about
 from spacy.cli import download_module, info
 from spacy.cli._util import parse_config_overrides, string_to_list, walk_directory
 from spacy.cli.apply import apply
+from spacy.cli.convert import autodetect_ner_format
 from spacy.cli.debug_data import (
     _compile_gold,
     _get_distribution,
@@ -1237,3 +1238,40 @@ def test_download_rejects_relative_urls(monkeypatch):
     download_module.download("en_core_web_sm-3.7.1", direct=True)
     with pytest.raises(SystemExit):
         download_module.download("../en_core_web_sm-3.7.1", direct=True)
+
+
+@pytest.mark.parametrize(
+    "input_data,expected",
+    [
+        ("I-PER|O word|B-LOC", "iob"),
+        ("word\tB-PER", "ner"),
+        ("word B-PER", "ner"),
+        ("nothing to detect here", None),
+        # A pipe with nothing before it is not an IOB token
+        ("|O", None),
+        # `ner_re` is anchored at the end of the line, a trailing token disqualifies.
+        ("word B-PER extra", None),
+        # Both formats detected -> ambiguous, no guess.
+        ("word|B-PER\nword B-PER", None),
+    ],
+)
+def test_autodetect_ner_format(input_data, expected):
+    assert autodetect_ner_format(input_data) == expected
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        # long whitespace-free run: worst case for the `\S+\s+` (ner) regex
+        "a" * 200000,
+        # pipe-rich but never followed by a valid tag: worst case for the
+        # `\S+\|` (iob) regex
+        "x|" * 100000,
+    ],
+    ids=["whitespace-free-run", "pipe-runs"],
+)
+def test_autodetect_ner_format_no_catastrophic_backtracking(line):
+    # If this test hangs, check the regexes in autodetect_ner_format for a
+    # repeated prefix in front of the delimiter. The 20-line cap in that
+    # function does not bound line length.
+    assert autodetect_ner_format(line) is None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->
# Fix quardratic backtracking regex in NER format autodetection
## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
In `spacy/cli/convert.py:213-214` `r"\S+\|(O|[IB]-\S+)"` and  `r"\S+\s+(O|[IB]-\S+)$"` can lead to quadratic backtracking on crafted input.
```python
import re
import time

line = "x|" * 10000

for name, pattern in [
    ("old", r"\S+\|(O|[IB]-\S+)"),
    ("new", r"\S\|(O|[IB]-\S+)"),
]:
    start = time.perf_counter()
    re.search(pattern, line)
    print(f"{name}: {time.perf_counter() - start:.3f}s")
 ```
 Output:                                                                                                                                                                                       

 ```
old: 3.523s
new: 0.001s
 ```
For the other regex
 ```python
import re
import time

line = "a" * 20000

for name, pattern in [
    ("old", r"\S+\s+(O|[IB]-\S+)$"),
    ("new", r"\S\s+(O|[IB]-\S+)$"),
]:
    start = time.perf_counter()
    re.search(pattern, line)
    print(f"{name}: {time.perf_counter() - start:.3f}s")
 ```

 Output:

 ```
old: 4.900s
new: 0.001s
 ```
## Reasoning:
First regex faces the issue if there is pipes but no ensuing NER tag thus it tests every position in backtracking fashion, and the 20 line cap wouldn't help because it doesn't limit line length.

Second regex if the string contains no whitespace at all it backtracks on every position.
## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
