### PR TITLE
Fix missing cp314 wheels on PyPI (#13949)

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -23,9 +23,30 @@ jobs:
     # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
     # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05  # v1
-        with:
-          tag: ${{ github.event.release.tag_name }}
-          fileName: '*'
-          out-file-path: 'dist'
+      # Use `gh release download` rather than a third-party downloader action:
+      # GitHub paginates release assets at 30 per page, and a downloader that
+      # only reads the first page silently drops the tail. That's how the
+      # cp314 wheels + sdist went missing from PyPI for v3.8.14/v3.8.15 while
+      # being present on the GitHub release (#13949). `gh` paginates correctly.
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          mkdir -p dist
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir dist --pattern '*'
+      # Guard against a partial download ever reaching PyPI again: compare the
+      # number of files fetched to the asset count on the release.
+      - name: Verify all assets were downloaded
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          expected=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets | length')
+          actual=$(find dist -type f | wc -l | tr -d ' ')
+          echo "Release assets: $expected, downloaded files: $actual"
+          if [ "$expected" -ne "$actual" ]; then
+            echo "::error::Downloaded $actual files but release has $expected assets; aborting to avoid a partial PyPI upload."
+            exit 1
+          fi
       - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1


### PR DESCRIPTION
## Problem

Fixes #13949. The v3.8.14 and v3.8.15 GitHub releases each have **40 assets**, but PyPI received only **30**. The 10 missing files are exactly the last-uploaded batch:

- all 8 `cp314` wheels
- the `cp313 win_arm64` wheel
- the `sdist` (`.tar.gz`)

## Root cause

`publish_pypi.yml` downloaded release assets with `robinraju/release-downloader`, which reads only the **first page** of a release's assets. GitHub paginates the release-assets listing at **30 per page** (the endpoint returns a `Link: …page=2` header and only 30 items), so the tail was never fetched and never uploaded to PyPI — even though all 40 files are present on the GitHub release.

This regressed when the action was pinned from the floating `@v1` tag to a specific SHA (v1.12) for supply-chain hardening in 4216738. v3.8.13 was published *before* that pin and got all 40 files; v3.8.14 was the first release *after* it and lost the tail.

## Fix

- Replace the downloader action with `gh release download`, which paginates correctly (verified locally: it fetches all 40 assets, including every cp314 wheel and the sdist).
- Add a verification step that compares the number of downloaded files against the release's asset count and fails the job on mismatch, so a partial upload can never silently reach PyPI again.

## Note

This workflow only runs on new release publications, so the already-affected v3.8.14/v3.8.15 wheels won't appear on PyPI retroactively — those need a one-off manual `gh release download` + `twine upload` of the missing files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)